### PR TITLE
Custom encoding support

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,11 @@
           "default": "/usr/bin/R",
           "description": "R terms path for Linux."
         },
+        "r.rterm.encoding": {
+          "type": "string",
+          "default": "UTF-8",
+          "description": "An optional encoding to pass to R when executing the file, i.e. 'source(FILE, encoding=ENCODING)'"
+        },
         "r.lintr.linters": {
           "type": "string",
           "default": "default_linters",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,12 +64,15 @@ export function activate(context: ExtensionContext) {
 
     function runSource()  {
         const Rpath = ToRStringLiteral(window.activeTextEditor.document.fileName, '"');
-        
+        var encodingParam = config.get('rterm.encoding');
+        if (encodingParam) {
+            encodingParam = `, encoding="${encodingParam}"`
+        }
         if (!Rterm){
             commands.executeCommand('r.createRterm');  
         }
         Rterm.show();
-        Rterm.sendText(`source(${Rpath})`);
+        Rterm.sendText(`source(${Rpath}${encodingParam})`);
     }
 
     function createGitignore() {


### PR DESCRIPTION
Adds a configuration setting that allows for custom encoding to be passed in the Run Source command.

In the future this could be taken directly off the editor as it knows the encoding of the file being edited, this property is however not exposed to the JS API yet.

One questionable thing about this PR is that it provides UTF-8 as a default and therefore changes the default Run Source call `source(FILE)` to `source(FILE, encoding="UTF-8")`, which might be a breaking change. UTF-8 is a default file encoding in VS Code so for people predominantly working in this IDE it is the preffered setting.