### PR TITLE
Proposed fix for Load Chunk problems #27

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,6 @@ export function activate(context: ExtensionContext) {
         const selectedTextArray = selectedLineText.split("\n");
 
         return selectedTextArray;
-
     }
 
     async function runSelection() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,28 +38,34 @@ export function activate(context: ExtensionContext) {
         setFocus();
     }
 
-    function getSelection(): string {
+    function getSelection(): string[] {
         const { start, end } = window.activeTextEditor.selection;
         const currentDocument = window.activeTextEditor.document;
         const range = new Range(start, end);
         const selectedLineText = !range.isEmpty
                                  ? currentDocument.getText(new Range(start, end))
                                  : currentDocument.lineAt(start.line).text;
-        return selectedLineText;
+
+        const selectedTextArray = selectedLineText.split("\n");
+
+        return selectedTextArray;
+
     }
 
-    function runSelection() {
+    async function runSelection() {
         const selectedLineText = getSelection();
+
         if (!rTerm) {
             createRTerm(true);
+            await delay (200); // Let RTerm warm up
         }
 
-        commands.executeCommand("cursorMove", {to: "down"});
-
-        // Skip comments
-        if (checkForComment(selectedLineText)) { return; }
-
-        rTerm.sendText(selectedLineText);
+        for (const line of selectedLineText) {
+            commands.executeCommand("cursorMove", { to: "down" });
+            if (checkForComment(line)) { continue; }
+            await delay(5); // Increase delay if RTerm can't handle speed.
+            rTerm.sendText(line);
+        }
         setFocus();
     }
 


### PR DESCRIPTION
UPDATE: I realize this didn't address #27. Instead, it address RTerm choking when Run.Selection is given too much text _and_ sets us up to fix #27, which I'll handle if this PR passes review.

After some testing, it seems when you send too much text to be processed by RTerm a buffer is overrun somewhere.  Luckily, R executes line-by-line.  

I've split the selected text into a string[] and then loop over the array, sending a line at a time to the RTerm, with a small delay in between.  

*Adding a delay is not the best way to do this.* I realize it.  But without having access to output from the RTerm, I'm not sure how else to hack it.  I'm open to suggestions.