### PR TITLE
Added block detection and execute whole block

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,8 @@ export function activate(context: ExtensionContext) {
             rPath = [rPath, "echo = TRUE"].join(", ");
         }
         if (!rTerm) {
-            createRTerm(true);
+            const success = createRTerm(true);
+            if(!success){ return; }
         }
         rTerm.sendText(`source(${rPath})`);
         setFocus();
@@ -99,7 +100,8 @@ export function activate(context: ExtensionContext) {
         const selection = getSelection();
 
         if (!rTerm) {
-            createRTerm(true);
+            const success = createRTerm(true);
+            if(!success){ return; }
             await delay (200); // Let RTerm warm up
         }
         commands.executeCommand("cursorMove", { to: "down", value: selection.linesDownToMoveCursor });
@@ -143,7 +145,8 @@ export function activate(context: ExtensionContext) {
 
     async function previewEnvironment() {
         if (!rTerm) {
-            createRTerm(true);
+            const success = createRTerm(true);
+            if(!success){ return; }
         }
         const tmpDir = makeTmpDir();
         const pathToTmpCsv = tmpDir + "/environment.csv";
@@ -161,7 +164,8 @@ export function activate(context: ExtensionContext) {
 
     async function previewDataframe() {
         if (!rTerm) {
-            createRTerm(true);
+            const success = createRTerm(true);
+            if(!success){ return; }
         }
 
         const dataframeName = getSelection();

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -2,17 +2,26 @@
 
 import { Terminal, window } from "vscode";
 import { config, getRpath } from "./util";
+import fs = require("fs-extra");
 export let rTerm: Terminal;
 
-export function createRTerm(preserveshow?: boolean) {
+export function createRTerm(preserveshow?: boolean): boolean {
         const termName = "R";
         const termPath = getRpath();
         if (!termPath) {
             return;
         }
         const termOpt =  config.get("rterm.option") as string[];
-        rTerm = window.createTerminal(termName, termPath, termOpt);
-        rTerm.show(preserveshow);
+        fs.pathExists(termPath, (err, exists) => {
+            if(exists){
+                rTerm = window.createTerminal(termName, termPath, termOpt);
+                rTerm.show(preserveshow);
+                return true;
+            } else {
+                window.showErrorMessage("Cannot find R client.  Please check R path in preferences and reload.");
+                return false;
+            }
+        })
     }
 
 export function deleteTerminal(term: Terminal) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,7 +10,7 @@ export function getRpath() {
     } else if ( process.platform === "linux") {
         return config.get("rterm.linux") as string;
     }else {
-        window.showErrorMessage(process.platform + "can't use R");
+        window.showErrorMessage(process.platform + " can't use R");
         return "";
     }
 }
@@ -42,4 +42,13 @@ export function checkForSpecialCharacters(text) {
 
 export function checkIfFileExists(filePath) {
     return fs.existsSync(filePath);
+}
+
+export function assertRTerminalCreation(rTerm): boolean {
+    if(!rTerm) { 
+        window.showErrorMessage("Could not create R terminal.")
+        return false; 
+    } else {
+        return true;
+    }
 }


### PR DESCRIPTION
This PR provides functionality which should truly close #27.

If a partial block is selected, for example, 

```
myFunction <- function() {
   foo$Bar <- "FooBar"
...
```
It should parse one line at a time until it finds the termination of the block.  

It should also handle whole and half blocks.

```
myFunction <- function() {
   foo$Bar <- "FooBar"
}

myFunctionTwo <- function() {
   foo$Bar <- "FooBar"
```

And bidirectional block checking:

```
foo$Bar <- "FooBar"
}

myFunctionTwo <- function() {
   foo$Bar <- "FooBar"
}
```

Once I've received some feed back, I'll expand this to include looking at multiline functions.  For example,

```
myFunction(x = 2,
                     y = 3)
```