### PR TITLE
Add package dev commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,31 @@
         "title": "Preview Environment",
         "category": "R",
         "command": "r.previewEnvironment"
+      },
+      {
+        "title": "Load All",
+        "category": "R",
+        "command": "r.loadAll"
+      },
+      {
+        "title": "Test Package",
+        "category": "R",
+        "command": "r.test"
+      },
+      {
+        "title": "Install Package",
+        "category": "R",
+        "command": "r.install"
+      },
+      {
+        "title": "Build Package",
+        "category": "R",
+        "command": "r.build"
+      },
+      {
+        "title": "Document",
+        "category": "R",
+        "command": "r.document"
       }
     ],
     "keybindings": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -239,6 +239,56 @@ export function activate(context: ExtensionContext) {
         }
     }
 
+    async function loadAllPkg() {
+        if (!rTerm) {
+            const success = createRTerm(true);
+            if (!success) { return; }
+        }
+
+        const rLoadAllCommand = "devtools::load_all('.')";
+        rTerm.sendText(rLoadAllCommand);
+    }
+
+    async function testPkg() {
+        if (!rTerm) {
+            const success = createRTerm(true);
+            if (!success) { return; }
+        }
+
+        const rTestCommand = "devtools::test()";
+        rTerm.sendText(rTestCommand);
+    }
+
+    async function installPkg() {
+        if (!rTerm) {
+            const success = createRTerm(true);
+            if (!success) { return; }
+        }
+
+        const rInstallCommand = "devtools::install()";
+        rTerm.sendText(rInstallCommand);
+    }
+
+    async function buildPkg() {
+        if (!rTerm) {
+            const success = createRTerm(true);
+            if (!success) { return; }
+        }
+
+        const rBuildCommand = "devtools::build()";
+        rTerm.sendText(rBuildCommand);
+    }
+
+    async function documentPkg() {
+        if (!rTerm) {
+            const success = createRTerm(true);
+            if (!success) { return; }
+        }
+
+        const rDocumentCommand = "devtools::document()";
+        rTerm.sendText(rDocumentCommand);
+    }
+
     context.subscriptions.push(
         commands.registerCommand("r.runSource", () => runSource(false)),
         commands.registerCommand("r.createRTerm", createRTerm),
@@ -249,6 +299,11 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand("r.previewDataframe", previewDataframe),
         commands.registerCommand("r.previewEnvironment", previewEnvironment),
         commands.registerCommand("r.installLintr", installLintr),
+        commands.registerCommand("r.loadAll", loadAllPkg),
+        commands.registerCommand("r.test", testPkg),
+        commands.registerCommand("r.install", installPkg),
+        commands.registerCommand("r.build", buildPkg),
+        commands.registerCommand("r.document", documentPkg),
         workspace.onDidSaveTextDocument(lintr),
         window.onDidCloseTerminal(deleteTerminal),
     );


### PR DESCRIPTION
I have no experience with VS Code extension development, so my apologies if I'm making any mistakes. This seems to work on my machine though.

The main thing I'd been missing compared to RStudio was shortcuts for package development. I think I'd like to add keyboard shortcuts, but I think I can do that in my user keymapping and just put these things in the command palette for everyone else.