### PR TITLE
Issue 26: Added detection of bracket and pipe blocks.

### DIFF
--- a/src/extendSelection.ts
+++ b/src/extendSelection.ts
@@ -1,0 +1,204 @@
+/**
+ * Like vscode's Position class, but allows negative values.
+ */
+class PositionNeg {
+    line: number;
+    character: number;
+    constructor(_line: number, _character: number) {
+        this.line = _line;
+        this.character = _character;
+    }
+}
+
+/**
+ * Class to hold lines that have been fetched from the document after they have been preprocessed.
+ */
+class LineCache {
+    lineCache: Map<number, string>;
+    endsInOperatorCache: Map<number, boolean>;
+    getLine: (number) => string;
+    lineCount: number;
+    constructor(_getLine: (number) => string, _lineCount: number) {
+        this.getLine = _getLine;
+        this.lineCount = _lineCount;
+        this.lineCache = new Map<number, string>();
+        this.endsInOperatorCache = new Map<number, boolean>();
+    }
+    getLineFromCache(line: number) {
+        const lineInCache = this.lineCache.has(line);
+        if (!lineInCache) {
+            this.addLineToCache(line);
+        }
+        const s = this.lineCache.get(line);
+        return (s);
+    }
+    getEndsInOperatorFromCache(line: number) {
+        const lineInCache = this.lineCache.has(line);
+        if (!lineInCache) {
+            this.addLineToCache(line);
+        }
+        const s = this.endsInOperatorCache.get(line);
+        return (s);
+    }
+    addLineToCache(line: number) {
+        const cleaned = cleanLine(this.getLine(line));
+        const endsInOperator = doesLineEndInOperator(cleaned);
+        this.lineCache.set(line, cleaned);
+        this.endsInOperatorCache.set(line, endsInOperator);
+    }
+}
+
+function doBracketsMatch(a: string, b: string): boolean {
+    const matches = { "(":")", "[":"]", "{":"}", ")":"(", "]":"[", "}":"{" };
+    return matches[a] === b;
+}
+
+function isBracket(c: string, lookingForward: boolean) {
+    if (lookingForward) {
+        return ((c === "(") || (c === "[") || (c === "{"));
+    } else {
+        return ((c === ")") || (c === "]") || (c === "}"));
+    }
+}
+
+function cleanLine(text: string) {
+    const cleaned = text.replace(/\s*\#.*/, ""); // Remove comments and preceeding spaces
+    return (cleaned);
+}
+
+function doesLineEndInOperator(text: string) {
+    const endingOperatorIndex = text.search(/(,|\+|!|\$|\^|&|\*|-|=|:|\'|~|\||\/|\?|%.*%)(\s*|\s*\#.*)$/);
+    const spacesOnlyIndex = text.search(/^\s*$/); // Space-only lines also counted.
+    return ((0 <= endingOperatorIndex) || (0 <= spacesOnlyIndex));
+}
+
+/**
+ * From a given position, return the 'next' character, its position in the document,
+ * whether it is start/end of a code line (possibly broken over multiple text lines), and whether it is the 
+ * start/end of the file. Considers the start and end of each line to be special distinct characters.
+ * @param p The starting position.
+ * @param lookingForward true if the 'next' character is toward the end of the document, false if toward the start of the document.
+ * @param getLine A function that returns the string at the given line of the document.
+ * @param getEndsInOperator A function that returns whether the given line ends in an operator.
+ * @param lineCount The number of lines in the document.
+ */
+function getNextChar(p: PositionNeg, lookingForward: boolean, getLine: (number) => string, getEndsInOperator: (number) => boolean, lineCount) {
+    const s = getLine(p.line);
+    let nextPos: PositionNeg = null;
+    let isEndOfCodeLine = false;
+    let isEndOfFile = false;
+    if (lookingForward) {
+        if (p.character != s.length) {
+            nextPos = new PositionNeg(p.line, p.character + 1);
+        } else if (p.line < (lineCount - 1)) {
+            nextPos = new PositionNeg(p.line + 1, -1);
+        } else {
+            // At end of document. Return same character.
+            isEndOfFile = true;
+            nextPos = new PositionNeg(p.line, p.character);
+        }
+        const nextLine: string = getLine(nextPos.line);
+        if (nextPos.character === nextLine.length) {
+            if ((nextPos.line === (lineCount - 1)) || !getEndsInOperator(nextPos.line)) {
+                isEndOfCodeLine = true;
+            }
+        }
+    } else {
+        if (p.character != -1) {
+            nextPos = new PositionNeg(p.line, p.character - 1);
+        } else if (p.line > 0) { 
+            nextPos = new PositionNeg(p.line - 1, getLine(p.line - 1).length - 1);
+        } else {
+            // At start of document. Return same character.
+            isEndOfFile = true;
+            nextPos = new PositionNeg(p.line, p.character);
+        }
+        if (nextPos.character === -1) {
+            if ((nextPos.line <= 0) || !getEndsInOperator(nextPos.line - 1)) {
+                isEndOfCodeLine = true;
+            }
+        }
+    }
+    const nextChar = getLine(nextPos.line)[nextPos.character];
+    return ({ nextChar: nextChar, nextPos: nextPos, isEndOfCodeLine: isEndOfCodeLine, isEndOfFile: isEndOfFile });
+}
+
+/**
+ * Given a line number, gets the text of that line and determines the first and last lines of the 
+ * file required to make a complete line of code, by matching brackets and extending over
+ * broken lines (single lines of code split into multiple text lines, joined by operators).
+ * 
+ * The algorithm:
+ * From the start of the given line, proceed forward looking for the end of the code line. 
+ * If a bracket is encountered, look for the match of that bracket (possibly changing direction to do so),
+ * from the farthest point reached in that direction. 
+ * Once the bracket is found, proceed in the same direction looking for the completion of the code line.
+ * Once the end of the code line has been matched, proceed in the other direction. 
+ * Repeat until all encountered brackets are matched, and the completions of the code lines have been reached in 
+ * both directions. The lines of the completions are the lines returned.
+ * 
+ * Example:
+ * Let's say we have the following R code file:
+ * 
+ *     library(magrittr) # For %>%    Line 1
+ *     list(x = 1,       #            Line 2
+ *          y = 2) %>%   #            Line 3
+ *         print()       #            Line 4
+ * 
+ * Let's say the cursor is on Line 3. We proceed forward until we hit the ')'. We look for the match, which 
+ * means looking backwards from the end of Line 2. We find the match, '(', on Line 2. We continue along 
+ * Line 2 until we reach the start of the line. The previous line, Line 1, does not end in an operator,
+ * so we have reached the completion of the code line. Now, we proceed forward again from the farthest point reached
+ * in the other direction: the ')' on Line 3. We encounter the end of the TEXT line, but it ends in an operator '%>%', 
+ * so it is not the end of the CODE line. Therefore, we continue onto Line 4. We encounter a '(' on Line 4, and continue 
+ * forward to find its match, which is the next character. Then we're at the end of Line 4, which doesn't
+ * end in an operator. Now we've found the completions in both directions, so we're finished. The farthest lines
+ * reached were Line 2 and Line 4, so those are the values returned.
+ * @param line The line of the document at which to start.
+ * @param getLine A function that returns the string at the given line of the document.
+ * @param lineCount The number of lines in the document.
+ */
+export function extendSelection(line: number, getLine: (number) => string, lineCount: number) {
+    const lc = new LineCache(getLine, lineCount);
+    const getLineFromCache = function(x) { return (lc.getLineFromCache(x)); }
+    const getEndsInOperatorFromCache = function(x) { return (lc.getEndsInOperatorFromCache(x)); }
+    let lookingForward = true;
+    // poss[1] is the farthest point reached looking forward from line,
+    // and poss[0] is the farthest point reached looking backward from line.
+    let poss = { 0: new PositionNeg(line, 0), 1: new PositionNeg(line, -1) };
+    let flagsFinish = { 0: false, 1: false }; // 1 represents looking forward, 0 represents looking back.
+    let flagAbort = false;
+    let unmatched = { 0: <string[]>[], 1: <string[]>[]};
+    while (!flagAbort && !(flagsFinish[0] && flagsFinish[1])) {
+        let { nextChar, nextPos, isEndOfCodeLine, isEndOfFile } = getNextChar(poss[lookingForward ? 1 : 0], lookingForward, getLineFromCache, getEndsInOperatorFromCache, lineCount);
+        poss[lookingForward ? 1 : 0] = nextPos;
+        if (isBracket(nextChar, lookingForward)) {
+            unmatched[lookingForward ? 1 : 0].push(nextChar);
+        } else if (isBracket(nextChar, !lookingForward)) {
+            if (unmatched[lookingForward ? 1 : 0].length === 0) {
+                lookingForward = !lookingForward;
+                unmatched[lookingForward ? 1 : 0].push(nextChar);
+                flagsFinish[lookingForward ? 1 : 0] = false; 
+            } else {
+                let needsToMatch = unmatched[lookingForward ? 1 : 0].pop();
+                if (!doBracketsMatch(nextChar, needsToMatch)) {
+                    flagAbort = true;
+                }
+            }
+        } else if (isEndOfCodeLine) { 
+            if (unmatched[lookingForward ? 1 : 0].length === 0) {
+                // We have found everything we need to in this direction. Continue looking in the other direction.
+                flagsFinish[lookingForward ? 1 : 0] = true;
+                lookingForward = !lookingForward; 
+            } else if (isEndOfFile) {
+                // Have hit the start or end of the file without finding the matching bracket.
+                flagAbort = true;
+            }
+        }
+    }
+    if (flagAbort) {
+        return ({ startLine: line, endLine: line });
+    } else {
+        return ({ startLine: poss[0].line, endLine: poss[1].line });
+    }
+}

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -10,13 +10,447 @@ import * as assert from 'assert';
 // as well as import your extension to test it
 import * as vscode from 'vscode';
 import * as myExtension from '../src/extension';
+import { extendSelection } from "../src/extendSelection";
 
 // Defines a Mocha test suite to group tests of similar kind together
 suite("Extension Tests", () => {
 
-    // Defines a Mocha unit test
-    test("Something 1", () => {
-        assert.equal(-1, [1, 2, 3].indexOf(5));
-        assert.equal(-1, [1, 2, 3].indexOf(0));
+    test("Selecting multi-line {} bracketed expression", () => {
+        let doc = `
+        function (x) {
+            y = x
+            y
+        }
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 2);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(4, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(4, f, doc.length).endLine, 4);
+    })
+
+    test("Selecting two-line () bracketed expression", () => {
+        let doc = `
+        a = list(x = 1,
+            y = 2)
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 2);
+    })
+
+    test("Selecting three-line () bracketed expression", () => {
+        let doc = `
+        a = list(x = 1,
+            y = 2,
+            z = 3)
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
+    })
+
+    test("Selecting two-line piped expression", () => {
+        let doc = `
+        1 + 1 %>%
+            print()
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 2);
+    })
+
+    test("Selecting two-line piped expression with gap", () => {
+        let doc = `
+        1 + 1 %>%
+
+            print()
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
+    })
+
+    test("Selecting three-line piped expression", () => {
+        let doc = `
+        1 + 1 %>%
+            sum() %>%
+            print()
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
+    })
+
+
+    test("Selecting nested bracketed expression with brackets on different lines", () => {
+        let doc = `
+        (
+            c(
+                2
+            )
+        )
+        `.split("\n");
+        function f(i) {return (doc[i])};
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 5);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(4, f, doc.length).startLine, 2);
+        assert.equal(extendSelection(4, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(5, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(5, f, doc.length).endLine, 5);
+    })
+
+    test("Selecting nested bracketed expression with brackets on same line", () => {
+        let doc = `
+        {
+            c(
+                2
+            )}
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(4, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(4, f, doc.length).endLine, 4);
+    })
+
+    test("Selecting brackets and pipes", () => {
+        let doc = `
+        {
+            1
+        } %>%
+            c(
+                2
+            )
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 6);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 2);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 6);
+        assert.equal(extendSelection(4, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(4, f, doc.length).endLine, 6);
+        assert.equal(extendSelection(5, f, doc.length).startLine, 5);
+        assert.equal(extendSelection(5, f, doc.length).endLine, 5);
+        assert.equal(extendSelection(6, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(6, f, doc.length).endLine, 6);
+        
+        let doc2 = `
+        {
+            1
+        } %>%
+
+            c(
+                2
+            )
+        `.split("\n");
+        function f2(i) {return (doc2[i])}
+        assert.equal(extendSelection(1, f2, doc2.length).startLine, 0);
+        assert.equal(extendSelection(1, f2, doc2.length).endLine, 7);
+        assert.equal(extendSelection(2, f2, doc2.length).startLine, 2);
+        assert.equal(extendSelection(2, f2, doc2.length).endLine, 2);
+        assert.equal(extendSelection(3, f2, doc2.length).startLine, 0);
+        assert.equal(extendSelection(3, f2, doc2.length).endLine, 7);
+        assert.equal(extendSelection(4, f2, doc2.length).startLine, 0);
+        assert.equal(extendSelection(4, f2, doc2.length).endLine, 7);
+        assert.equal(extendSelection(5, f2, doc2.length).startLine, 0);
+        assert.equal(extendSelection(5, f2, doc2.length).endLine, 7);
+        assert.equal(extendSelection(6, f2, doc2.length).startLine, 6);
+        assert.equal(extendSelection(6, f2, doc2.length).endLine, 6);
+        assert.equal(extendSelection(7, f2, doc2.length).startLine, 0);
+        assert.equal(extendSelection(7, f2, doc2.length).endLine, 7);
+    })
+
+    test("Selecting large RStudio comparison", () => {
+        let doc = `
+        if (TRUE) {              #  1. RStudio sends lines 1-17; vscode-R sends 1-17
+                                 #  2. RStudio sends lines 2-4; vscode-R sends 2-4
+          a = data.frame(x = 2,  #  3. RStudio sends lines 2-4; vscode-R sends 3-4
+            y = 3)               #  4. RStudio sends lines 2-4; vscode-R sends 3-4
+          print(                 #  5. RStudio sends lines 5-15; vscode-R sends 5-15
+            a[                   #  6. RStudio sends lines 5-15; vscode-R sends 6-14
+              if (TRUE) {        #  7. RStudio sends lines 7-13; vscode-R sends 7-13
+                {                #  8. RStudio sends lines 8-12; vscode-R sends 8-12
+                  (              #  9. RStudio sends lines 9-11; vscode-R sends 9-11
+                    1            # 10. RStudio sends lines 9-11; vscode-R sends 10
+                  )              # 11. RStudio sends lines 9-11; vscode-R sends 9-11
+                }                # 12. RStudio sends lines 8-12; vscode-R sends 8-12
+              }                  # 13. RStudio sends lines 5-15; vscode-R sends 7-13
+              ]                  # 14. RStudio sends lines 5-15; vscode-R sends 6-14
+          )                      # 15. RStudio sends lines 5-15; vscode-R sends 5-15
+                                 # 16. RStudio sends lines 16-17; vscode-R sends 1-17
+        }                        # 17. RStudio sends lines 1-17; vscode-R sends 1-17
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 17);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 2);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(4, f, doc.length).startLine, 2);
+        assert.equal(extendSelection(4, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(5, f, doc.length).startLine, 5);
+        assert.equal(extendSelection(5, f, doc.length).endLine, 15);
+        assert.equal(extendSelection(6, f, doc.length).startLine, 6);
+        assert.equal(extendSelection(6, f, doc.length).endLine, 14);
+        assert.equal(extendSelection(7, f, doc.length).startLine, 7);
+        assert.equal(extendSelection(7, f, doc.length).endLine, 13);
+        assert.equal(extendSelection(8, f, doc.length).startLine, 8);
+        assert.equal(extendSelection(8, f, doc.length).endLine, 12);
+        assert.equal(extendSelection(9, f, doc.length).startLine, 9);
+        assert.equal(extendSelection(9, f, doc.length).endLine, 11);
+        assert.equal(extendSelection(10, f, doc.length).startLine, 10);
+        assert.equal(extendSelection(10, f, doc.length).endLine, 10);
+        assert.equal(extendSelection(11, f, doc.length).startLine, 9);
+        assert.equal(extendSelection(11, f, doc.length).endLine, 11);
+        assert.equal(extendSelection(12, f, doc.length).startLine, 8);
+        assert.equal(extendSelection(12, f, doc.length).endLine, 12);
+        assert.equal(extendSelection(13, f, doc.length).startLine, 7);
+        assert.equal(extendSelection(13, f, doc.length).endLine, 13);
+        assert.equal(extendSelection(14, f, doc.length).startLine, 6);
+        assert.equal(extendSelection(14, f, doc.length).endLine, 14);
+        assert.equal(extendSelection(15, f, doc.length).startLine, 5);
+        assert.equal(extendSelection(15, f, doc.length).endLine, 15);
+        assert.equal(extendSelection(16, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(16, f, doc.length).endLine, 17);
+        assert.equal(extendSelection(17, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(17, f, doc.length).endLine, 17);
     });
+
+    test("Selecting block with missing opening bracket", () => {
+        let doc = `
+            1
+        } %>%
+            c(
+                2
+            )
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 1);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 2);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(4, f, doc.length).startLine, 4);
+        assert.equal(extendSelection(4, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(5, f, doc.length).startLine, 5);
+        assert.equal(extendSelection(5, f, doc.length).endLine, 5);
+    });
+
+    test("Selecting block with missing closing bracket", () => {
+        let doc = `
+            c(
+                2
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 1);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 1);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 2);
+    })
+
+    test("Selecting block with missing closing bracket and gap", () => {
+        let doc = `
+            c(
+                2
+
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 1);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 1);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 2);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 4);
+    })
+
+    test("Selecting block with missing opening bracket 2", () => {
+        let doc = `
+                2
+            )
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 1);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 2);
+    });
+
+    test("Selecting block with missing opening bracket and gap", () => {
+        let doc = `
+
+                2
+            )
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 2);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
+    });
+
+    test("Selecting block with missing opening bracket and gap after", () => {
+        let doc = `
+
+                2
+            )
+
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 2);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(4, f, doc.length).startLine, 4);
+        assert.equal(extendSelection(4, f, doc.length).endLine, 5);
+    });
+
+    test("Selecting longer badly-formed block", () => {
+        let doc = `
+        polys = SpatialPolygonsDataFrame(
+            SpatialPolygons(list(
+                Polygons(list(
+                    Polygon(coords = rbind(c(0, 0)))
+                ), ID = "1")),
+                SpatialPolygons(list(
+                    Polygons(list(
+                        Polygon(coords = rbind(c(1,1)))
+                    ), ID = "2"))
+                )), data = data.frame(id = c(1,2))
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 1);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 1);
+    });
+
+    test("Selecting with comments", () => {
+        let doc = `
+            {
+                1
+                # }
+            }
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 2);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(4, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(4, f, doc.length).endLine, 4);
+    });
+
+
+    test("Selecting multi-line square bracket", () => {
+        let doc = `
+        a[1
+            ]
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 2);
+    });
+
+    test("Selecting ggplot plot", () => {
+        let doc = `
+        ggplot(aes(speed, dist), data = cars) +
+            geom_point()
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 2);
+    });
+
+    test("Selecting multi-line bracket with pipe", () => {
+        let doc = `
+        list(x = 1,
+            y = 2,
+            z = 3) %>%
+            print()
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(4, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(4, f, doc.length).endLine, 4);
+    });
+    
+    test("Selecting shorter RStudio comparison", () => {
+        let doc = `
+        (                     # 1. RStudio and vscode-R send lines 1-9
+            {                 # 2. RStudio and vscode-R send lines 2-8
+                (             # 3. RStudio and vscode-R send lines 3-7
+                    (         # 4. RStudio sends lines 3-7; vscode-R sends lines 4-6 
+                        1     # 5. RStudio sends lines 3-7; vscode-R sends line 5
+                    )         # 6. RStudio sends lines 3-7; vscode-R sends lines 4-6
+                )             # 7. RStudio and vscode-R send lines 3-7
+            }                 # 8. RStudio sends lines 1-9; vscode-R sends lines 2-8
+        )                     # 9. RStudio and vscode-R send lines 1-9
+        `.split("\n");
+        function f(i) {return (doc[i])}
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 9);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 8);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 7);
+        assert.equal(extendSelection(4, f, doc.length).startLine, 4);
+        assert.equal(extendSelection(4, f, doc.length).endLine, 6);
+        assert.equal(extendSelection(5, f, doc.length).startLine, 5);
+        assert.equal(extendSelection(5, f, doc.length).endLine, 5);
+        assert.equal(extendSelection(6, f, doc.length).startLine, 4);
+        assert.equal(extendSelection(6, f, doc.length).endLine, 6);
+        assert.equal(extendSelection(7, f, doc.length).startLine, 3);
+        assert.equal(extendSelection(7, f, doc.length).endLine, 7);
+        assert.equal(extendSelection(8, f, doc.length).startLine, 2);
+        assert.equal(extendSelection(8, f, doc.length).endLine, 8);
+        assert.equal(extendSelection(9, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(9, f, doc.length).endLine, 9);
+    });
+
 });


### PR DESCRIPTION
Closes #26

If no editor text is selected, `r.runSelection` will check around the line on which the cursor lies and send to the R console the chunk of code necessary to make a complete code line (by matching brackets and following pipes and other operators).

Some examples of code chunks it will send to the console:

1. Multi-lined bracketed expressions:

```
a = list(x = 1,
         y = 2,
         z = 3)

a[1
    ]
```

2. Lines joined by pipes and other operators:

```
library(magrittr) # For %>%
library(ggplot2)

1 + 1 %>%
    print()

ggplot(aes(speed, dist), data = cars) +
    geom_point()
```

3. Combinations thereof:

```
library(magrittr) # For %>%

list(x = 1,
        y = 2,
        z = 3) %>%
    print()
```

If the algorithm encounters unmatched brackets, it just sends the current line.

Behaviour differs from that of RStudio in some cases. Roughly, vscode-R will send the smallest valid block of code, whereas RStudio sends the largest () or [] expression within the smallest {}. Here is an example:

```
(                     # 1. RStudio and vscode-R send lines 1-9
    {                 # 2. RStudio and vscode-R send lines 2-8
        (             # 3. RStudio and vscode-R send lines 3-7
            (         # 4. RStudio sends lines 3-7; vscode-R sends lines 4-6 
                1     # 5. RStudio sends lines 3-7; vscode-R sends line 5
            )         # 6. RStudio sends lines 3-7; vscode-R sends lines 4-6
        )             # 7. RStudio and vscode-R send lines 3-7
    }                 # 8. RStudio sends lines 1-9; vscode-R sends lines 2-8
)                     # 9. RStudio and vscode-R send lines 1-9
```

The algorithm would ideally ignore brackets in strings, but I haven't implemented that feature. If it proves to be a problem in practice then it could be dealt with in a separate issue/PR.  