### PR TITLE
Fix Preview Dataframe command #67

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -35,9 +35,10 @@ export async function previewDataframe() {
         return;
     }
 
-    const dataframeName = getSelection();
+    const selectedTextArray = getSelection().selectedTextArray;
+    const dataframeName = selectedTextArray[0];
 
-    if (!checkForSpecialCharacters(dataframeName)) {
+    if (selectedTextArray.length !== 1 || !checkForSpecialCharacters(dataframeName)) {
         window.showInformationMessage("This does not appear to be a dataframe.");
         return false;
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -37,7 +37,7 @@ export function delay(ms: number) {
 }
 
 export function checkForSpecialCharacters(text) {
-    return !/[~`!#$%\^&*+=\-\[\]\\';,/{}|\\":<>\?]/g.test(text);
+    return !/[~`!#$%\^&*+=\-\[\]\\';,/{}|\\":<>\?\s]/g.test(text);
 }
 
 export function checkIfFileExists(filePath) {


### PR DESCRIPTION
Fixes #67

**What problem did you solve?**

Command `R: Preview Dataframe` had become broken and was always producing the error 'This does not appear to be a dataframe.', even if the selected text was a valid dataframe. Now, the dataframe is previewed as expected (restoring the command's original behaviour).

I also added whitespace into the list of special characters that can't appear in a dataframe name.

**Screenshot**

![result](https://user-images.githubusercontent.com/23294156/52172393-6b5e6d80-27c2-11e9-8b9a-400759f635d5.png)

**How can I check this pull request?**

Create an R document (e.g., `temp.R`) with the following content:

```
cars mtcars
iris
```

Select just the word 'cars' and run `R: Preview Dataframe`. Preview window 'cars.csv' appears as expected. (Before this PR: Error 'This does not appear to be a dataframe.')

Verify that a space in selection is handled appropriately by selecting the words 'cars mtcars' and running `R: Preview Dataframe`. Produces error 'This does not appear to be a dataframe.' as expected.

Verify that a newline in selection is handled appropriately by selecting the words 'mtcars iris' and running `R: Preview Dataframe`. Produces error 'This does not appear to be a dataframe.' as expected.
