### PR TITLE
Adapt runSelection to use RCommands as Shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # R support for Visual Studio Code
 
-**Sorry, supporting this extension is ended. Please looking forward to coming new one (<https://github.com/Microsoft/RTVS/issues/1295>).**
-
 Requires [R](https://www.r-project.org/).
 
 ## Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "r",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4512,9 +4512,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
-      "integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.13.1.tgz",
+      "integrity": "sha512-fplQqb2miLbcPhyHoMV4FU9PtNRbgmm/zI5d3SZwwmJQM6V0eodju+hplpyfhLWpmwrDNfNYU57uYRb8s0zZoQ==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
@@ -4525,6 +4525,7 @@
         "glob": "^7.1.1",
         "js-yaml": "^3.7.0",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
         "tslib": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -321,7 +321,7 @@
     "@types/node": "^10.12.12",
     "mocha": "^6.0.0",
     "node-atomizr": "^0.6.1",
-    "tslint": "^5.12.1",
+    "tslint": "^5.13.1",
     "typescript": "^3.3.3",
     "vscode": "^1.1.26",
     "yamljs": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -134,6 +134,31 @@
         "command": "r.runSelection"
       },
       {
+        "title": "Show number of rows for selected object",
+        "category": "R",
+        "command": "r.nrow"
+      },
+      {
+        "title": "Show length for a selected object",
+        "category": "R",
+        "command": "r.length"
+      },
+      {
+        "title": "Show first part of a selected object",
+        "category": "R",
+        "command": "r.head"
+      },
+      {
+        "title": "Show first part of a selected object (transposed)",
+        "category": "R",
+        "command": "r.thead"
+      },
+      {
+        "title": "Show names for a selected object",
+        "category": "R",
+        "command": "r.names"
+      },
+      {
         "title": "Create gitignore",
         "category": "R",
         "command": "r.createGitignore"
@@ -186,6 +211,36 @@
         "key": "Ctrl+enter",
         "mac": "cmd+enter",
         "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
+        "command": "r.nrow",
+        "key": "Ctrl+1",
+        "mac": "cmd+1",
+        "when": "editorTextFocus && editorLangId == 'r'"
+      },
+      {
+        "command": "r.length",
+        "key": "Ctrl+2",
+        "mac": "cmd+2",
+        "when": "editorTextFocus && editorLangId == 'r'"
+      },
+      {
+        "command": "r.head",
+        "key": "Ctrl+3",
+        "mac": "cmd+3",
+        "when": "editorTextFocus && editorLangId == 'r'"
+      },
+      {
+        "command": "r.thead",
+        "key": "Ctrl+4",
+        "mac": "cmd+4",
+        "when": "editorTextFocus && editorLangId == 'r'"
+      },
+      {
+        "command": "r.names",
+        "key": "Ctrl+5",
+        "mac": "cmd+5",
+        "when": "editorTextFocus && editorLangId == 'r'"
       },
       {
         "command": "r.runSource",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,8 +41,8 @@ export function activate(context: ExtensionContext) {
         setFocus();
     }
 
-    async function runSelection(rFunctionName) {
-		const selection = getSelection();
+    async function runSelection(rFunctionName: string[]) {
+        const selection = getSelection();
         if (!rTerm) {
             const success = createRTerm(true);
             if (!success) {
@@ -61,16 +61,16 @@ export function activate(context: ExtensionContext) {
             }
             await delay(8); // Increase delay if RTerm can't handle speed.
 
-            if (rFunctionName) {
-                let rFunctionCall = ""
+            if (rFunctionName && rFunctionName.length) {
+                let rFunctionCall = "";
                 for (const feature of rFunctionName) {
-                    rFunctionCall += feature + "("  
+                    rFunctionCall += feature + "(";
                 }
                 line = rFunctionCall + line.trim() + ")".repeat(rFunctionName.length);
             }
             rTerm.sendText(line);
         }
-        setFocus(); 	
+        setFocus();
     }
 
     function setFocus() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,24 +41,36 @@ export function activate(context: ExtensionContext) {
         setFocus();
     }
 
-    async function runSelection() {
-        const selection = getSelection();
-
+    async function runSelection(rFunctionName) {
+		const selection = getSelection();
         if (!rTerm) {
             const success = createRTerm(true);
-            if (!success) { return; }
-            await delay (200); // Let RTerm warm up
+            if (!success) {
+                return;
+            }
+            await delay(200); // Let RTerm warm up
         }
         if (selection.linesDownToMoveCursor > 0) {
             commands.executeCommand("cursorMove", { to: "down", value: selection.linesDownToMoveCursor });
             commands.executeCommand("cursorMove", { to: "wrappedLineEnd" });
         }
-        for (const line of selection.selectedTextArray) {
-            if (checkForComment(line)) { continue; }
+
+        for (let line of selection.selectedTextArray) {
+            if (checkForComment(line)) {
+                continue;
+            }
             await delay(8); // Increase delay if RTerm can't handle speed.
+
+            if (rFunctionName) {
+                let rFunctionCall = ""
+                for (const feature of rFunctionName) {
+                    rFunctionCall += feature + "("  
+                }
+                line = rFunctionCall + line.trim() + ")".repeat(rFunctionName.length);
+            }
             rTerm.sendText(line);
         }
-        setFocus();
+        setFocus(); 	
     }
 
     function setFocus() {
@@ -73,10 +85,15 @@ export function activate(context: ExtensionContext) {
     });
 
     context.subscriptions.push(
+        commands.registerCommand("r.nrow", () => runSelection(["nrow"])),
+        commands.registerCommand("r.length", () => runSelection(["length"])),
+        commands.registerCommand("r.head", () => runSelection(["head"])),
+        commands.registerCommand("r.thead", () => runSelection(["t", "head"])),
+        commands.registerCommand("r.names", () => runSelection(["names"])),
         commands.registerCommand("r.runSource", () => runSource(false)),
         commands.registerCommand("r.createRTerm", createRTerm),
         commands.registerCommand("r.runSourcewithEcho", () => runSource(true)),
-        commands.registerCommand("r.runSelection", runSelection),
+        commands.registerCommand("r.runSelection", () => runSelection([])),
         commands.registerCommand("r.createGitignore", createGitignore),
         commands.registerCommand("r.previewDataframe", previewDataframe),
         commands.registerCommand("r.previewEnvironment", previewEnvironment),


### PR DESCRIPTION
The function runSelection could just send selected Code to the console. To ensure a intuitive workflow it would be nice to run internal R-functions by VS Code shortcuts for the selected code. 

Best way to check the pull request ist to start a R-console and run selected code like before (ctrl+enter). Then load a dataframe and check if the predefined shortcuts are running:
 ctrl+1 = nrow
ctrl+2 = length
ctrl+3 = head
ctrl+4 = transposed head (multiple functions)
ctrl+5 = names 