### PR TITLE
Fix check for Excel Viewer extension #96

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -125,7 +125,7 @@ function makeTmpDir() {
 
 function checkcsv() {
     const iscsv = extensions.getExtension("GrapeCity.gc-excelviewer");
-    if (iscsv.isActive) {
+    if (iscsv && iscsv.isActive) {
         return true;
     } else {
         window.showInformationMessage("This function need to install `GrapeCity.gc-excelviewer`");


### PR DESCRIPTION
Fix #96 

**What problem did you solve?**

Currently, if `Preview Dataframe` command is used and the Excel Viewer extension is not installed, the message displayed to the user is "Cannot read property 'isActive' of undefined". With this PR, a message instructing the user to install Excel Viewer is displayed.

**Screenshot**

![issue-96](https://user-images.githubusercontent.com/23294156/56847331-52261280-6914-11e9-8d9a-f62c6a8a6d93.png)
