### PR TITLE
Fix Preview Environment for multi-class objects #111

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -17,7 +17,7 @@ export async function previewEnvironment() {
     const tmpDir = makeTmpDir();
     const pathToTmpCsv = tmpDir + "/environment.csv";
     const envName = "name=ls()";
-    const envClass = "class=sapply(ls(), function(x) {class(get(x))})";
+    const envClass = "class=sapply(ls(), function(x) {class(get(x))[1]})";
     const envOut = "out=sapply(ls(), function(x) {capture.output(str(get(x)), silent = T)[1]})";
     const rWriteCsvCommand = "write.csv(data.frame("
                              + envName + ","


### PR DESCRIPTION
Fixes #111

Solution as suggested by @JimmyZJX - thank you! (I've applied it to `preview.ts` rather than `dist.js`.)

**What problem did you solve?**

`R: Preview Environment` produces strange results when objects have more than one class.

Example (before PR) - note that `time` appears more than once in preview:

![env1](https://user-images.githubusercontent.com/23294156/61373433-c9948e00-a8d4-11e9-986d-51cc424b73c2.png)


**(If you have)Screenshot**

Example (after PR):

![env2](https://user-images.githubusercontent.com/23294156/61373446-cef1d880-a8d4-11e9-9ce0-452febc068c5.png)

@Ikuyadeu I can build vscode-R successfully on commit 6411a58 but not on commits after that. I get build errors and can't run the unit tests with this version too, but it seems to run and it's only a one-line change so I'm going ahead with the PR.