### PR TITLE
Fix Preview Environment for variable x #111

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -17,8 +17,8 @@ export async function previewEnvironment() {
     const tmpDir = makeTmpDir();
     const pathToTmpCsv = tmpDir + "/environment.csv";
     const envName = "name=ls()";
-    const envClass = "class=sapply(ls(), function(x) {class(get(x))[1]})";
-    const envOut = "out=sapply(ls(), function(x) {capture.output(str(get(x)), silent = T)[1]})";
+    const envClass = "class=sapply(ls(), function(x) {class(get(x, envir = parent.env(environment())))[1]})";
+    const envOut = "out=sapply(ls(), function(x) {capture.output(str(get(x, envir = parent.env(environment()))), silent = T)[1]})";
     const rWriteCsvCommand = "write.csv(data.frame("
                              + envName + ","
                              + envClass + ","


### PR DESCRIPTION
Fixes #111 

Thanks @krzysztofarendt for noticing this problem!

**What problem did you solve?**

`R: Preview Environment` always reports `x` as `character`, because of variable shadowing.

Example (before PR) - note that `x` is a `data.frame` but preview shows it as `character`:

![env3](https://user-images.githubusercontent.com/23294156/62125164-4f69fd80-b307-11e9-9a9b-ae1f59c12beb.png)

**(If you have)Screenshot**

Example (after PR):

![env4](https://user-images.githubusercontent.com/23294156/62125200-71fc1680-b307-11e9-8a71-37058eb3c49f.png)

