### PR TITLE
Fix send code for newlines and Radian #114 #117

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -43,6 +43,9 @@ Yes / No
 
 // Keeping focus when running
 "r.source.focus": "editor",
+
+// Use bracketed paste mode
+"r.bracketedPaste": false,
 ```
 
 **Expected behavior**

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Requires [R](https://www.r-project.org/).
 ## Usage
 
 * For Windows, set config `r.rterm.windows` to your `R.exe` Path like `"C:\\Program Files\\R\\R-3.3.4\\bin\\x64\\R.exe"`;
+* For Radian console, enable config `r.bracketedPaste`
 * Open your folder that has R source file (**Can't work if you open only file**)
 * Use `F1` key and `R:` command or `Ctrl+Enter`(Mac: `⌘+Enter`)
 
@@ -52,7 +53,8 @@ This extension contributes the following settings:
 * `r.rpath.lsp`: set to R.exe path for Language Server Protocol
 * `r.rterm.option`: R command line options (i.e: --vanilla)
 * `r.source.encoding`: An optional encoding to pass to R when executing the file
-* `r.source.focus` : Keeping focus when running(editor or terminal)
+* `r.source.focus`: Keeping focus when running (editor or terminal)
+* `r.bracketedPaste`: For consoles supporting bracketed paste mode (such as Radian)
 
 * Language server(developing [here](https://github.com/REditorSupport/languageserver))
 

--- a/package.json
+++ b/package.json
@@ -312,6 +312,11 @@
             "terminal"
           ],
           "description": "Keeping focus when running"
+        },
+        "r.bracketedPaste": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use bracketed paste mode when sending code to console. Enable for Radian console"
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,6 +101,12 @@ export function activate(context: ExtensionContext) {
             commands.executeCommand("cursorMove", { to: "wrappedLineEnd" });
         }
 
+        if (selection.selectedTextArray.length > 1 && config.get("bracketedPaste")) {
+            // Surround with ANSI control characters for bracketed paste mode
+            selection.selectedTextArray[0] = "\x1b[200~" + selection.selectedTextArray[0];
+            selection.selectedTextArray[selection.selectedTextArray.length - 1] += "\x1b[201~";
+        }
+
         for (let line of selection.selectedTextArray) {
             if (checkForComment(line)) {
                 continue;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { buildPkg, documentPkg, installPkg, loadAllPkg, testPkg } from "./packag
 import { previewDataframe, previewEnvironment } from "./preview";
 import { createGitignore } from "./rGitignore";
 import { createRTerm, deleteTerminal, rTerm } from "./rTerminal";
-import { checkForComment, getSelection } from "./selection";
+import { checkForBlankOrComment, getSelection } from "./selection";
 import { config, delay } from "./util";
 
 const wordPattern = /(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\<\>\/\s]+)/g;
@@ -108,9 +108,6 @@ export function activate(context: ExtensionContext) {
         }
 
         for (let line of selection.selectedTextArray) {
-            if (checkForComment(line)) {
-                continue;
-            }
             await delay(8); // Increase delay if RTerm can't handle speed.
 
             if (rFunctionName && rFunctionName.length) {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -35,18 +35,22 @@ export function getSelection(): any {
 function removeCommentedLines(selection: string[]): string[] {
     const selectionWithoutComments = [];
     selection.forEach((line) => {
-        if (!checkForComment(line)) { selectionWithoutComments.push(line); }
+        if (!checkForBlankOrComment(line)) { selectionWithoutComments.push(line); }
     });
     return selectionWithoutComments;
 }
 
-export function checkForComment(line: string): boolean {
+export function checkForBlankOrComment(line: string): boolean {
     let index = 0;
+    let isWhitespaceOnly = true;
     while (index < line.length) {
-        if (!(line[index] === " ")) { break; }
+        if (!((line[index] === " ") || (line[index] === "\t"))) {
+            isWhitespaceOnly = false;
+            break;
+        }
         index++;
     }
-    return line[index] === "#";
+    return isWhitespaceOnly || line[index] === "#";
 }
 
 /**


### PR DESCRIPTION
Fixes #114
Fixes #117

**What problem did you solve?**

1. When sending code to console (R or Radian), blank lines before the code chunk are also sent (#114).

2. When sending code to Radian console, identation is odd (#117).

This PR adds a new setting, `r.bracketedPaste`, which enables bracketed paste mode to fix the indentation problems with Radian. This also works with the R console but not with readline 6 or before, so I have set it to `false` by default.

**(If you have)Screenshot**

R with `bracketedPaste` set to `false`, using the command `R: Run Selection/Line` with the cursor on line 3 - note that there is no blank prompt in the console BEFORE

    > f <- function(x) {

which shows that no blank lines have been sent:

![r_new](https://user-images.githubusercontent.com/23294156/62847288-6699e980-bd10-11e9-8018-927c0b3dec39.png)

Radian with `bracketedPaste` set to `true`, using the command `R: Run Selection/Line in Active Terminal` with the cursor on line 3 - note lack of blank prompt, and correct indentation:

![radian_good](https://user-images.githubusercontent.com/23294156/62847293-6bf73400-bd10-11e9-9433-fbd5926c87b3.png)

@randy3k Could you look at my bracketed paste mode code (lines 106-107 of `src/extension.ts`)? I think it is fine but you have a lot more experience with bracketed paste mode than I do. Thank you!
