### PR TITLE
RMarkdown knit support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "r",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -141,29 +141,17 @@
       {
         "title": "Knit Rmd To PDF",
         "category": "R",
-        "command": "r.knitRmdToPdf",
-        "icon": {
-          "light": "./images/DownloadFile.ico",
-          "dark": "./images/DownloadFile_inverse.ico"
-        }
+        "command": "r.knitRmdToPdf"
       },
       {
         "title": "Knit Rmd To HTML",
         "category": "R",
-        "command": "r.knitRmdToHtml",
-        "icon": {
-          "light": "./images/DownloadFile.ico",
-          "dark": "./images/DownloadFile_inverse.ico"
-        }
+        "command": "r.knitRmdToHtml"
       },
       {
         "title": "Knit Rmd To All Formats",
         "category": "R",
-        "command": "r.knitRmdToAll",
-        "icon": {
-          "light": "./images/DownloadFile.ico",
-          "dark": "./images/DownloadFile_inverse.ico"
-        }
+        "command": "r.knitRmdToAll"
       },
       {
         "title": "Run Source with Echo",
@@ -318,11 +306,6 @@
         {
           "when": "editorLangId == rmd",
           "command": "r.knitRmd",
-          "group": "navigation"
-        },
-        {
-          "when": "editorLangId == rmd",
-          "command": "r.knitRmdToPdf",
           "group": "navigation"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "workspaceContains:*.r|.rd|.rmd",
     "onCommand:r.createRTerm",
     "onCommand:r.runSource",
-    "onCommand:r.runRmdSource",
+    "onCommand:r.knitRmd",
+    "onCommand:r.knitRmdToPdf",
     "onCommand:r.runSourcewithEcho",
     "onCommand:r.runSelection",
     "onCommand:r.runSelectionInActiveTerm",
@@ -127,9 +128,18 @@
         }
       },
       {
-        "title": "Run Rmd Source",
+        "title": "Knit Rmd",
         "category": "R",
-        "command": "r.runRmdSource",
+        "command": "r.knitRmd",
+        "icon": {
+          "light": "./images/DownloadFile.ico",
+          "dark": "./images/DownloadFile_inverse.ico"
+        }
+      },
+      {
+        "title": "Knit Rmd To PDF",
+        "category": "R",
+        "command": "r.knitRmdToPdf",
         "icon": {
           "light": "./images/DownloadFile.ico",
           "dark": "./images/DownloadFile_inverse.ico"
@@ -266,9 +276,9 @@
         "when": "editorTextFocus && editorLangId == 'r'"
       },
       {
-        "command": "r.runRmdSource",
-        "key": "shift+Ctrl+s",
-        "mac": "shift+cmd+s",
+        "command": "r.knitRmd",
+        "key": "shift+Ctrl+k",
+        "mac": "shift+cmd+k",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {
@@ -287,7 +297,12 @@
         },
         {
           "when": "editorLangId == rmd",
-          "command": "r.runRmdSource",
+          "command": "r.knitRmd",
+          "group": "navigation"
+        },
+        {
+          "when": "editorLangId == rmd",
+          "command": "r.knitRmdToPdf",
           "group": "navigation"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "onCommand:r.runSource",
     "onCommand:r.knitRmd",
     "onCommand:r.knitRmdToPdf",
+    "onCommand:r.knitRmdToHtml",
+    "onCommand:r.knitRmdToAll",
     "onCommand:r.runSourcewithEcho",
     "onCommand:r.runSelection",
     "onCommand:r.runSelectionInActiveTerm",
@@ -140,6 +142,24 @@
         "title": "Knit Rmd To PDF",
         "category": "R",
         "command": "r.knitRmdToPdf",
+        "icon": {
+          "light": "./images/DownloadFile.ico",
+          "dark": "./images/DownloadFile_inverse.ico"
+        }
+      },
+      {
+        "title": "Knit Rmd To HTML",
+        "category": "R",
+        "command": "r.knitRmdToHtml",
+        "icon": {
+          "light": "./images/DownloadFile.ico",
+          "dark": "./images/DownloadFile_inverse.ico"
+        }
+      },
+      {
+        "title": "Knit Rmd To All Formats",
+        "category": "R",
+        "command": "r.knitRmdToAll",
         "icon": {
           "light": "./images/DownloadFile.ico",
           "dark": "./images/DownloadFile_inverse.ico"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "workspaceContains:*.r|.rd|.rmd",
     "onCommand:r.createRTerm",
     "onCommand:r.runSource",
+    "onCommand:r.runRmdSource",
     "onCommand:r.runSourcewithEcho",
     "onCommand:r.runSelection",
     "onCommand:r.runSelectionInActiveTerm",
@@ -120,6 +121,15 @@
         "title": "Run Source",
         "category": "R",
         "command": "r.runSource",
+        "icon": {
+          "light": "./images/DownloadFile.ico",
+          "dark": "./images/DownloadFile_inverse.ico"
+        }
+      },
+      {
+        "title": "Run Rmd Source",
+        "category": "R",
+        "command": "r.runRmdSource",
         "icon": {
           "light": "./images/DownloadFile.ico",
           "dark": "./images/DownloadFile_inverse.ico"
@@ -256,6 +266,12 @@
         "when": "editorTextFocus && editorLangId == 'r'"
       },
       {
+        "command": "r.runRmdSource",
+        "key": "shift+Ctrl+s",
+        "mac": "shift+cmd+s",
+        "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
         "command": "r.runSourcewithEcho",
         "key": "shift+Ctrl+enter",
         "mac": "shift+cmd+enter",
@@ -267,6 +283,11 @@
         {
           "when": "editorLangId == r",
           "command": "r.runSource",
+          "group": "navigation"
+        },
+        {
+          "when": "editorLangId == rmd",
+          "command": "r.runRmdSource",
           "group": "navigation"
         }
       ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,11 @@ export function activate(context: ExtensionContext) {
             const success = createRTerm(true);
             if (!success) { return; }
         }
-        rTerm.sendText(`rmarkdown::render(${rPath}, "${outputFormat}")`);
+        if (isNull(outputFormat)) {
+            rTerm.sendText(`rmarkdown::render(${rPath})`);
+        } else {
+            rTerm.sendText(`rmarkdown::render(${rPath}, "${outputFormat}")`);
+        }
     }
 
     async function runSelection(rFunctionName: string[]) {
@@ -156,8 +160,10 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand("r.thead", () => runSelection(["t", "head"])),
         commands.registerCommand("r.names", () => runSelection(["names"])),
         commands.registerCommand("r.runSource", () => runSource(false)),
-        commands.registerCommand("r.knitRmd", () => knitRmd(false, '')),
+        commands.registerCommand("r.knitRmd", () => knitRmd(false, null)),
         commands.registerCommand("r.knitRmdToPdf", () => knitRmd(false, "pdf_document")),
+        commands.registerCommand("r.knitRmdToHtml", () => knitRmd(false, "html_document")),
+        commands.registerCommand("r.knitRmdToAll", () => knitRmd(false, "all")),
         commands.registerCommand("r.createRTerm", createRTerm),
         commands.registerCommand("r.runSourcewithEcho", () => runSource(true)),
         commands.registerCommand("r.runSelection", () => runSelection([])),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,7 @@ export function activate(context: ExtensionContext) {
         setFocus(rTerm);
     }
 
-    function runRmdSource(echo: boolean)  {
+    function knitRmd(echo: boolean, outputFormat: string)  {
         const wad = window.activeTextEditor.document;
         wad.save();
         let rPath = ToRStringLiteral(wad.fileName, '"');
@@ -58,7 +58,7 @@ export function activate(context: ExtensionContext) {
             const success = createRTerm(true);
             if (!success) { return; }
         }
-        rTerm.sendText(`rmarkdown::render(${rPath})`);
+        rTerm.sendText(`rmarkdown::render(${rPath}, "${outputFormat}")`);
     }
 
     async function runSelection(rFunctionName: string[]) {
@@ -156,7 +156,8 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand("r.thead", () => runSelection(["t", "head"])),
         commands.registerCommand("r.names", () => runSelection(["names"])),
         commands.registerCommand("r.runSource", () => runSource(false)),
-        commands.registerCommand("r.runRmdSource", () => runRmdSource(false)),
+        commands.registerCommand("r.knitRmd", () => knitRmd(false, '')),
+        commands.registerCommand("r.knitRmdToPdf", () => knitRmd(false, "pdf_document")),
         commands.registerCommand("r.createRTerm", createRTerm),
         commands.registerCommand("r.runSourcewithEcho", () => runSource(true)),
         commands.registerCommand("r.runSelection", () => runSelection([])),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,25 @@ export function activate(context: ExtensionContext) {
         setFocus(rTerm);
     }
 
+    function runRmdSource(echo: boolean)  {
+        const wad = window.activeTextEditor.document;
+        wad.save();
+        let rPath = ToRStringLiteral(wad.fileName, '"');
+        let encodingParam = config.get("source.encoding") as string;
+        if (encodingParam) {
+            encodingParam = `encoding = "${encodingParam}"`;
+            rPath = [rPath, encodingParam].join(", ");
+        }
+        if (echo) {
+            rPath = [rPath, "echo = TRUE"].join(", ");
+        }
+        if (!rTerm) {
+            const success = createRTerm(true);
+            if (!success) { return; }
+        }
+        rTerm.sendText(`rmarkdown::render(${rPath})`);
+    }
+
     async function runSelection(rFunctionName: string[]) {
         const callableTerminal = await chooseTerminal();
         if (isNull(callableTerminal)) {
@@ -137,6 +156,7 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand("r.thead", () => runSelection(["t", "head"])),
         commands.registerCommand("r.names", () => runSelection(["names"])),
         commands.registerCommand("r.runSource", () => runSource(false)),
+        commands.registerCommand("r.runRmdSource", () => runRmdSource(false)),
         commands.registerCommand("r.createRTerm", createRTerm),
         commands.registerCommand("r.runSourcewithEcho", () => runSource(true)),
         commands.registerCommand("r.runSelection", () => runSelection([])),


### PR DESCRIPTION
**What problem did you solve?**

Fixes #121 

I'd independently had a the same issue as @a-torgovitsky in Issue #121  - needing a shortcut to knit RMarkdown files.

@mattva01 and I added commands to knit based on @a-torgovitsky's code snippet in his issue. Specifically:

* One command that Knits to the default document type (i.e. the first type specified in the Rmd header section). Shortcut Ctrl + Shft + K is the same as RStudio.
* One command that Knits specifically to PDF.

**Screenshot**

An open Rmd file now looks like:

![Screenshot_20190911_211904](https://user-images.githubusercontent.com/6020835/64746646-760c7e00-d4da-11e9-904a-636064fc3e2e.png)

However, we are currently reusing the "Run Source" icon for both Knit options (default and PDF):

![Screenshot_20190911_211950](https://user-images.githubusercontent.com/6020835/64746657-7ad13200-d4da-11e9-9f4c-870e4efd9465.png)

I tried creating a custom icon, but the text was far to small to be functionally useful, so I'm not sure what the best solution to this is (perhaps just a single Run Source icon, which runs the default Knit command? Or is reusing the Run Source icon too confusing).

**Additional commands (that I would like, at least)**

* Add a Knit to HTML command (which would be useful for my students).
* Add a Knit to All command.