### PR TITLE
Fix send code for newlines on Windows #114

### DIFF
--- a/src/selection.ts
+++ b/src/selection.ts
@@ -44,7 +44,7 @@ export function checkForBlankOrComment(line: string): boolean {
     let index = 0;
     let isWhitespaceOnly = true;
     while (index < line.length) {
-        if (!((line[index] === " ") || (line[index] === "\t"))) {
+        if (!((line[index] === " ") || (line[index] === "\t") || (line[index] === "\r"))) {
             isWhitespaceOnly = false;
             break;
         }


### PR DESCRIPTION
Fixes #114 

**What problem did you solve?**

Currently, blank lines that end in '\r\n' (common on Windows) are treated as not being blank, and are sent to the console by `R: Run Selection/Line`. This PR treats '\r' as whitespace, and so these lines are not sent to the console.

**How can I check this pull request (on any OS)?**

Create a file `temp.R` containing:

    # Some blank lines
    
    
    x <- 1

If 'LR' is displayed at the bottom right of the VSCode window, click on it and change the end of line sequence to 'CRLF'.

Use `R: Run Selection/Line`. Only `x <- 1` is sent to the console.