### PR TITLE
Change cursorMove to wrappedLineFirstNonWhitespaceCharacter

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,7 +121,7 @@ export function activate(context: ExtensionContext) {
         const selection = getSelection();
         if (selection.linesDownToMoveCursor > 0) {
             commands.executeCommand("cursorMove", { to: "down", value: selection.linesDownToMoveCursor });
-            commands.executeCommand("cursorMove", { to: "wrappedLineEnd" });
+            commands.executeCommand("cursorMove", { to: "wrappedLineFirstNonWhitespaceCharacter" });
         }
 
         if (selection.selectedTextArray.length > 1 && config.get("bracketedPaste")) {


### PR DESCRIPTION
**What problem did you solve?**

This is a PR for #126. Moving cursor to next line and the first non-whitespace character avoids left-and-right scrolling of the editor view, especially when the lines of code are mixed with long and short lines.

This behavior is also consistent with RStudio editor.