### PR TITLE
Automatically comment new lines in roxygen sections #124

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import { isNull } from "util";
-import { commands, ExtensionContext, languages, Terminal, window } from "vscode";
+import { commands, ExtensionContext, languages, Terminal, window, IndentAction } from "vscode";
 import { buildPkg, documentPkg, installPkg, loadAllPkg, testPkg } from "./package";
 import { previewDataframe, previewEnvironment } from "./preview";
 import { createGitignore } from "./rGitignore";
@@ -151,6 +151,10 @@ export function activate(context: ExtensionContext) {
 
     languages.setLanguageConfiguration("r", {
         wordPattern,
+        onEnterRules: [{ // Automatically continue roxygen comments: #'
+                beforeText: /^#'.*/,
+                action: { indentAction: IndentAction.None, appendText: '#\' ' }
+        }]
     });
 
     context.subscriptions.push(


### PR DESCRIPTION
Closes #124 

This PR makes it so that hitting <kbd>enter</kbd> on an roxygen comment line (starting with `#'`) starts the new line with `#'` as well.

It only applies if there is no indentation before `#'`.

![roxygen-newline](https://user-images.githubusercontent.com/23294156/65599910-e5ee2e80-dfd9-11e9-9232-af5ee6b09535.gif)
