### PR TITLE
Add auto-completion of roxygen tags #128

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import { isNull } from "util";
-import { commands, ExtensionContext, languages, Terminal, window, IndentAction } from "vscode";
+import { commands, ExtensionContext, languages, Terminal, window, IndentAction, Position, TextDocument, CompletionItem } from "vscode";
 import { buildPkg, documentPkg, installPkg, loadAllPkg, testPkg } from "./package";
 import { previewDataframe, previewEnvironment } from "./preview";
 import { createGitignore } from "./rGitignore";
@@ -11,6 +11,18 @@ import { checkForBlankOrComment, getSelection } from "./selection";
 import { config, delay } from "./util";
 
 const wordPattern = /(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\<\>\/\s]+)/g;
+
+// Get with names(roxygen2:::default_tags())
+const roxygenTagCompletionItems = [
+    "export", "exportClass", "exportMethod", "exportPattern", "import", "importClassesFrom",
+    "importFrom", "importMethodsFrom", "rawNamespace", "S3method", "useDynLib", "aliases",
+    "author", "backref", "concept", "describeIn", "description", "details",
+    "docType", "encoding", "evalRd", "example", "examples", "family",
+    "field", "format", "inherit", "inheritParams", "inheritDotParams", "inheritSection",
+    "keywords", "method", "name", "md", "noMd", "noRd",
+    "note", "param", "rdname", "rawRd", "references", "return",
+    "section", "seealso", "slot", "source", "template", "templateVar",
+    "title", "usage"].map((x) => new CompletionItem(x + " "));
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -148,6 +160,16 @@ export function activate(context: ExtensionContext) {
         const focus = config.get("source.focus") as string;
         term.show(focus !== "terminal");
     }
+
+    languages.registerCompletionItemProvider("r", {
+        provideCompletionItems(document: TextDocument, position: Position) {
+            if (document.lineAt(position).text.substr(0, 2) === "#'") {
+                return roxygenTagCompletionItems;
+            } else {
+                return undefined;
+            };
+        }
+    }, '@'); // Trigger on '@'
 
     languages.setLanguageConfiguration("r", {
         wordPattern,


### PR DESCRIPTION
Closes #128 

Auto-completes roxygen tags such as `@param` in roxygen comments (starting with `#'`).

![roxygen-tag](https://user-images.githubusercontent.com/23294156/65688991-0506c200-e0a7-11e9-908c-3a93735f037e.gif)