### PR TITLE
Show r.term.option value in settings UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -336,7 +336,10 @@
             "--no-restore",
             "--no-site-file"
           ],
-          "description": "R command line options (i.e: --vanilla)"
+          "description": "R command line options",
+          "items": {
+            "type": "string"
+          }
         },
         "r.source.encoding": {
           "type": "string",


### PR DESCRIPTION
**What problem did you solve?**

It is not clear what the current value, expected format or default of the `r.term.option` setting are. This PR fixes that.

**Screenshot**

Before:

![options](https://user-images.githubusercontent.com/23294156/67137223-adeeaa00-f26c-11e9-8fff-492f0e0405ba.JPG)

After:

![options-new](https://user-images.githubusercontent.com/23294156/67137224-b21ac780-f26c-11e9-8686-4f57b02a3e19.JPG)

Items can be deleted/edited using buttons that appear when the items are hovered over.