### PR TITLE
fix behaviour when workplacefolders is Undefiend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3158,13 +3158,24 @@
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.3.tgz",
+      "integrity": "sha512-Ytgnz23gm2DVftnzqRRz2dOXZbGd2uiajSw/95bPp6v53zPRspQjLm/AfBgqbJ2qfeRXWIOMVLpp86+/5yX39Q==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "dev": true,
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        }
       }
     },
     "ieee754": {

--- a/src/rGitignore.ts
+++ b/src/rGitignore.ts
@@ -3,7 +3,6 @@
 import fs = require("fs-extra");
 import path = require("path");
 import {  window, workspace } from "vscode";
-const ignorePath =  path.join(workspace.workspaceFolders[0].uri.path, ".gitignore");
 // From "https://github.com/github/gitignore/raw/master/R.gitignore"
 const ignoreFiles = [".Rhistory",
                     ".Rapp.history",
@@ -26,6 +25,7 @@ export function createGitignore() {
         window.showWarningMessage("Please open workspace to create .gitignore");
         return;
     }
+    const ignorePath =  path.join(workspace.workspaceFolders[0].uri.path, ".gitignore");
     fs.writeFile(ignorePath, ignoreFiles, (err) => {
         try {
             if (err) {


### PR DESCRIPTION
**What problem did you solve?**
VScode cannot load this extention when we open a single file "hogehoge.R"

Origina code have no error handling while ignorePath is defined.

**(If you have)Screenshot**
No

**(If you do not have screenshot) How can I check this pull request?**
You'll open a file