### PR TITLE
Fix bracketed paste on Windows

### DIFF
--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -93,11 +93,12 @@ export async function runTextInTerm(term: Terminal, textArray: string[]) {
         // Surround with ANSI control characters for bracketed paste mode
         textArray[0] = `\x1b[200~${textArray[0]}`;
         textArray[textArray.length - 1] += "\x1b[201~";
-    }
-
-    for (const line of textArray) {
-        await delay(8); // Increase delay if RTerm can't handle speed.
-        term.sendText(line);
+        term.sendText(textArray.join("\n"));
+    } else {
+        for (const line of textArray) {
+            await delay(8); // Increase delay if RTerm can't handle speed.
+            term.sendText(line);
+        }
     }
     setFocus(term);
 }

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -90,9 +90,11 @@ export function runSelectionInTerm(term: Terminal) {
 
 export async function runTextInTerm(term: Terminal, textArray: string[]) {
     if (textArray.length > 1 && config.get<boolean>("bracketedPaste")) {
-        // Surround with ANSI control characters for bracketed paste mode
-        textArray[0] = `\x1b[200~${textArray[0]}`;
-        textArray[textArray.length - 1] += "\x1b[201~";
+        if (process.platform !== "win32") {
+            // Surround with ANSI control characters for bracketed paste mode
+            textArray[0] = `\x1b[200~${textArray[0]}`;
+            textArray[textArray.length - 1] += "\x1b[201~";
+        }
         term.sendText(textArray.join("\n"));
     } else {
         for (const line of textArray) {


### PR DESCRIPTION
Fixes #117

**What problem did you solve?**

Quoting @Hong-Revo from https://github.com/Ikuyadeu/vscode-R/issues/117#issuecomment-536391701

> I think the only indentation issue I'm having is that sometimes, Radian will treat a single multi-line block of submitted text as a group of lines. For example:
> 
> ```
> f <- function(x)
> {
>     if(x)
>         return(42)
>     else
>     {
>         if(TRUE)
>             23
>         else 69
>     }
> }
> ```
> 
> When I submit this, it shows up as:
> 
> ![image](https://user-images.githubusercontent.com/11328890/65848712-ac774380-e38a-11e9-8b82-f3a2f2d0d2e6.png)
> 
> Note the "+" in the middle. Also, sometimes radian thinks there is more text coming and I have to press Enter in the terminal to get it to process the submitted code. This is with bracketed paste on.

This PR makes two changes:

1. When bracketed paste mode is set, sends code text all at once instead of line by line
1. When bracketed paste mode is set and OS is Windows, does not attach ANSI control characters, as Windows does not seem to support these in general

**How can I check this pull request?**

1. Use Windows
1. If `r.bracketedPaste` setting not enabled, enable it and restart VSCode
1. Paste this code into a file `temp-R/temp.R`:

```
f <- function(x) {
    if(x)
        return(42)
    else
    {
        if(TRUE)
            23
        else 69
    }
}
```
4. 'Open Folder...' and choose 'temp-R'
5. Start radian console
6. Position cursor on line 1 of file
7. `R: Run Selection/Line in Active Terminal`
8. Observe no `+` in the text sent to the console, and no need to hit <kbd>Enter</kbd> in the console for it to make it process the code

For full testing, this should also be tried in the following configurations:
1. Windows, with `r.bracketedPaste` not enabled, in normal R
1. Mac/Linux, with `r.bracketedPaste` enabled, in radian
1. Mac/Linux, with `r.bracketedPaste` not enabled, in normal R

I've tried these on Linux but I don't have access to a Mac.

**Notes**

This PR means that setting `r.bracketedPaste` on Windows doesn't actually use bracketed paste ANSI control characters. I think it's probably easier to just leave the setting name and description as-is, but open to discussion if anyone thinks it will make things too confusing.

I think this PR is probably fine as is but I would like to do a bit more testing. I will remove 'WIP' after that.