### PR TITLE
Fix function call closing bracket highlight

### DIFF
--- a/syntax/r.json
+++ b/syntax/r.json
@@ -423,7 +423,7 @@
             "end": "(\\))",
             "endCaptures": {
                 "1": {
-                    "name": "punctuation.definition.parameters.r"
+                    "name": "punctuation.section.parens.end.r"
                 }
             },
             "name": "meta.function-call.r",


### PR DESCRIPTION
**What problem did you solve?**
Fix function call closing bracket highlight

**(If you have)Screenshot**
Before
<img width="372" alt="Screen Shot 2019-12-11 at 4 49 42 PM" src="https://user-images.githubusercontent.com/6521018/70606320-26ebfb80-1c37-11ea-84b0-9fe75866c89d.png">
After
<img width="372" alt="Screen Shot 2019-12-11 at 4 50 16 PM" src="https://user-images.githubusercontent.com/6521018/70606308-218eb100-1c37-11ea-8c50-a5c70ebde84c.png">

I saw this
```
"This file has been converted from https://github.com/randy3k/R-Box/blob/master/syntax/R%20Extended.sublime-syntax",
"If you want to provide a fix or improvement, please create a pull request against the original repository.",
"Once accepted there, we are happy to receive an update request."
```
but the file is not maintained there anymore (merged to sublime per randy3k/R-Box@ef660fa242e412c9c8d973c4d0d540c521f9d201) so I hope opening a PR here is appropriate. Let me know if I'm wrong.