### PR TITLE
Use empty order when creating DataTables in getTableHtml

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -223,7 +223,8 @@ async function getTableHtml(webview: Webview, file: string) {
         data: data.data,
         columns: data.columns,
         paging: false,
-        autoWidth: false
+        autoWidth: false,
+        order: []
       });
     });
   </script>


### PR DESCRIPTION
Closes #156.

According to https://datatables.net/examples/basic_init/table_sorting.html, explicitly use `order: []` to disable any initial ordering behavior.