### PR TITLE
Provide completion for session symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ This extension contributes the following settings:
 An opt-in experimental R session watcher is implemented to support the following features:
 
 * Watch any R session
-* Show symbol value in hover
+* Show value of session symbol on hover
+* Provide completion for session symbol
 * `View()` data frames and list objects
 * Show plot output on update
 * Show htmlwidgets and shiny apps

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import { commands, CompletionItem, ExtensionContext, Hover, IndentAction,
-         languages, Position, StatusBarAlignment, TextDocument, window } from "vscode";
+         languages, Position, StatusBarAlignment, TextDocument, window, CompletionItemKind, MarkdownString } from "vscode";
 
 import { previewDataframe, previewEnvironment } from "./preview";
 import { createGitignore } from "./rGitignore";
@@ -146,6 +146,22 @@ export function activate(context: ExtensionContext) {
                 return new Hover("```\n" + globalenv[text].str + "\n```");
             },
         });
+
+        languages.registerCompletionItemProvider("r", {
+            provideCompletionItems(document: TextDocument, position: Position) {
+                return Object.keys(globalenv).map((key) => {
+                    const obj = globalenv[key];
+                    const item = new CompletionItem(key,
+                        obj.class === "function" ?
+                            CompletionItemKind.Function :
+                            CompletionItemKind.Field);
+                    item.detail = "[session]";
+                    item.documentation = new MarkdownString("```r\n" + obj.str + "\n```");
+                    return item;
+                });
+            },
+        });
+
         const sessionStatusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 1000);
         sessionStatusBarItem.command = "r.attachActive";
         sessionStatusBarItem.text = "R: (not attached)";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -178,12 +178,11 @@ export function activate(context: ExtensionContext) {
                 }
             }
 
-            if (symbol != undefined) {
+            if (!token.isCancellationRequested && symbol != undefined) {
                 const obj = globalenv[symbol];
                 if (obj != undefined && obj.names != undefined) {
                     const doc = new MarkdownString("Element of `" + symbol + "`");
                     obj.names.map((name: string) => {
-                        if (token.isCancellationRequested) return;
                         const item = new CompletionItem(name, CompletionItemKind.Field)
                         item.detail = "[session]";
                         item.documentation = doc;
@@ -196,11 +195,10 @@ export function activate(context: ExtensionContext) {
         languages.registerCompletionItemProvider("r", {
             provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext) {
                 let items = [];
+                if (token.isCancellationRequested) return items;
 
                 if (context.triggerCharacter === undefined) {
                     Object.keys(globalenv).map((key) => {
-                        if (token.isCancellationRequested)
-                            return items;
                         const obj = globalenv[key];
                         const item = new CompletionItem(key,
                             obj.type === "closure" || obj.type === "builtin" ?
@@ -225,8 +223,6 @@ export function activate(context: ExtensionContext) {
                         }
                     }
                     elements.map((key) => {
-                        if (token.isCancellationRequested)
-                            return items;
                         const item = new CompletionItem(key, CompletionItemKind.Field);
                         item.detail = "[session]";
                         item.documentation = doc;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -233,10 +233,11 @@ export function activate(context: ExtensionContext) {
                         items.push(item);
                     });
                 }
-                
-                // object elements in brackets
-                getBracketCompletionItems(document, position, token, items);
-                
+
+                if (context.triggerCharacter === undefined || context.triggerCharacter === '"' || context.triggerCharacter === "'") {
+                    getBracketCompletionItems(document, position, token, items);
+                }
+
                 return items;
             },
         }, "", "$", "@", '"', "'");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -203,7 +203,7 @@ export function activate(context: ExtensionContext) {
                             return items;
                         const obj = globalenv[key];
                         const item = new CompletionItem(key,
-                            obj.class === "function" ?
+                            obj.type === "closure" || obj.type === "builtin" ?
                                 CompletionItemKind.Function :
                                 CompletionItemKind.Field);
                         item.detail = "[session]";


### PR DESCRIPTION
**What problem did you solve?**

Closes #164
Closes #170

This PR provides

* Completion of session symbols, showing symbol `str` in documentation. The latest languageserver already supports workspace completion (global variables in code), scope completion (local variables in scope). This PR adds session completion as a new kind of completion.
* Completion of elements in list-like objects (list, environment, S4 objects). As for R6 object, they are basically environments so that they are covered too.
* Completion of symbols in brackets `[]`, mainly for subsetting and extracting using `"col"`, or accessing elements with dynamic scoping in brackets (usage of `data.table`).

**(If you have)Screenshot**

Session symbol completion

![image](https://user-images.githubusercontent.com/4662568/71503105-cacbdd00-28ae-11ea-90ee-74b95aba6317.png)

![image](https://user-images.githubusercontent.com/4662568/71503175-154d5980-28af-11ea-9d74-8f813dffa53b.png)

Completion for elements in list-like objects

<img width="407" alt="image" src="https://user-images.githubusercontent.com/4662568/71641844-2518d380-2cdd-11ea-88a2-cb39a195f7bb.png">

<img width="462" alt="image" src="https://user-images.githubusercontent.com/4662568/71641851-3cf05780-2cdd-11ea-865d-ccb15aa223b5.png">

<img width="494" alt="image" src="https://user-images.githubusercontent.com/4662568/71641860-66a97e80-2cdd-11ea-9ea0-405f9126b64a.png">

<img width="447" alt="image" src="https://user-images.githubusercontent.com/4662568/71641870-6f9a5000-2cdd-11ea-95d0-dc3b89acc930.png">

Completion for brackets

Quoted symbol:

<img width="725" alt="image" src="https://user-images.githubusercontent.com/4662568/71680789-f88cb680-2dc5-11ea-88f7-de1067523a04.png">

Element completion for dynamic scoping in data.table:

<img width="745" alt="image" src="https://user-images.githubusercontent.com/4662568/71680959-6f29b400-2dc6-11ea-9e7d-9781afca18b3.png">

<img width="775" alt="image" src="https://user-images.githubusercontent.com/4662568/71680850-2d990900-2dc6-11ea-80d1-a56f1c3ed614.png">
