### PR TITLE
Show plot history

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -21,7 +21,7 @@ if (interactive() && !identical(Sys.getenv("RSTUDIO"), "1")) {
 
         new_plot <- function() {
           plot_history_file <<- file.path(dir_plot_history,
-            format(Sys.time(), "%Y%m%d-%H%M%OS3.png"))
+            format(Sys.time(), "%Y%m%d-%H%M%OS6.png"))
           plot_updated <<- TRUE
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2175,6 +2175,14 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
+    "fotorama": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/fotorama/-/fotorama-4.6.4.tgz",
+      "integrity": "sha1-c3aWG2x+7MtsdkEazrp3lf/iLq4=",
+      "requires": {
+        "jquery": ">=1.8"
+      }
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -237,6 +237,11 @@
         "title": "Attach Active Terminal",
         "category": "R",
         "command": "r.attachActive"
+      },
+      {
+        "title": "Show Plot History",
+        "category": "R",
+        "command": "r.showPlotHistory"
       }
     ],
     "keybindings": [
@@ -404,6 +409,7 @@
     "datatables.net": "^1.10.20",
     "datatables.net-bs4": "^1.10.20",
     "datatables.net-fixedheader-jqui": "^3.1.6",
+    "fotorama": "^4.6.4",
     "fs-extra": "^8.1.0",
     "jquery": "^3.4.1",
     "jquery.json-viewer": "^1.4.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { createGitignore } from "./rGitignore";
 import { chooseTerminal, chooseTerminalAndSendText, createRTerm, deleteTerminal,
          runSelectionInTerm, runTextInTerm } from "./rTerminal";
 import { getWordOrSelection, surroundSelection } from "./selection";
-import { attachActive, deploySessionWatcher, globalenv, startResponseWatcher } from "./session";
+import { attachActive, deploySessionWatcher, globalenv, startResponseWatcher, showPlotHistory } from "./session";
 import { config, ToRStringLiteral } from "./util";
 
 const wordPattern = /(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\<\>\/\s]+)/g;
@@ -135,6 +135,7 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand("r.build", () => chooseTerminalAndSendText("devtools::build()")),
         commands.registerCommand("r.document", () => chooseTerminalAndSendText("devtools::document()")),
         commands.registerCommand("r.attachActive", attachActive),
+        commands.registerCommand("r.showPlotHistory", showPlotHistory),
         window.onDidCloseTerminal(deleteTerminal),
     );
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -325,8 +325,7 @@ function getPlotHistoryHtml(webview: Webview, files: string[]) {
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <script src="${webview.asWebviewUri(Uri.file(path.join(resDir, "jquery.min.js")))}"></script>
-  <script src="${webview.asWebviewUri(Uri.file(path.join(resDir, "fotorama.js")))}"></script>
+  <link href="${webview.asWebviewUri(Uri.file(path.join(resDir, "bootstrap.min.css")))}" rel="stylesheet">
   <link href="${webview.asWebviewUri(Uri.file(path.join(resDir, "fotorama.css")))}" rel="stylesheet">
   <style type="text/css">
     body {
@@ -335,9 +334,15 @@ function getPlotHistoryHtml(webview: Webview, files: string[]) {
   </style>
 </head>
 <body>
-  <div class="fotorama" data-maxheight="100%" data-maxwidth="100%" data-nav="thumbs" data-keyboard="true">
-    ${imgs}
+  <div class="container">
+    <div class="text-center">
+      <div class="fotorama" data-width="100%" data-maxheight="100%" data-nav="thumbs" data-keyboard="true">
+        ${imgs}
+      </div>
+    </div>
   </div>
+  <script src="${webview.asWebviewUri(Uri.file(path.join(resDir, "jquery.min.js")))}"></script>
+  <script src="${webview.asWebviewUri(Uri.file(path.join(resDir, "fotorama.js")))}"></script>
 </body>
 </html>
 `;

--- a/src/session.ts
+++ b/src/session.ts
@@ -13,6 +13,8 @@ let responseWatcher: FileSystemWatcher;
 let globalEnvWatcher: FileSystemWatcher;
 let plotWatcher: FileSystemWatcher;
 let PID: string;
+let tempDir: string;
+let plotDir: string;
 let resDir: string;
 const sessionDir = path.join(".vscode", "vscode-R");
 
@@ -294,6 +296,53 @@ async function getListHtml(webview: Webview, file: string) {
 `;
 }
 
+export async function showPlotHistory() {
+    if (config.get("sessionWatcher")) {
+        const files = await fs.readdir(plotDir);
+        const panel = window.createWebviewPanel("plotHistory", "Plot History",
+            {
+                preserveFocus: true,
+                viewColumn: ViewColumn.Two,
+            },
+            {
+                enableScripts: true,
+                localResourceRoots: [Uri.file(resDir), Uri.file(plotDir)],
+            });
+        const html = getPlotHistoryHtml(panel.webview, files)
+        panel.webview.html = html;
+    } else {
+        window.showInformationMessage("This command requires that r.sessionWatcher be enabled.");
+    }
+}
+
+function getPlotHistoryHtml(webview: Webview, files: string[]) {
+    const imgs = files
+        .map((file) => `<img src="${webview.asWebviewUri(Uri.file(path.join(plotDir, file)))}" />`)
+        .join("\n");
+    return `
+<!doctype HTML>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script src="${webview.asWebviewUri(Uri.file(path.join(resDir, "jquery.min.js")))}"></script>
+  <script src="${webview.asWebviewUri(Uri.file(path.join(resDir, "fotorama.js")))}"></script>
+  <link href="${webview.asWebviewUri(Uri.file(path.join(resDir, "fotorama.css")))}" rel="stylesheet">
+  <style type="text/css">
+    body {
+        background-color: white;
+    }
+  </style>
+</head>
+<body>
+  <div class="fotorama" data-maxheight="100%" data-maxwidth="100%" data-nav="thumbs" data-keyboard="true">
+    ${imgs}
+  </div>
+</body>
+</html>
+`;
+}
+
 async function updateResponse(sessionStatusBarItem: StatusBarItem) {
     console.info("Response file updated!");
     // Read last line from response file
@@ -307,6 +356,8 @@ async function updateResponse(sessionStatusBarItem: StatusBarItem) {
     const parseResult = JSON.parse(lastLine);
     if (parseResult.command === "attach") {
         PID = String(parseResult.pid);
+        tempDir = parseResult.tempdir;
+        plotDir = path.join(tempDir, "images");
         console.info("Got PID: " + PID);
         sessionStatusBarItem.text = "R: " + PID;
         sessionStatusBarItem.show();

--- a/src/session.ts
+++ b/src/session.ts
@@ -305,6 +305,7 @@ export async function showPlotHistory() {
                 viewColumn: ViewColumn.Two,
             },
             {
+                retainContextWhenHidden: true,
                 enableScripts: true,
                 localResourceRoots: [Uri.file(resDir), Uri.file(plotDir)],
             });

--- a/src/session.ts
+++ b/src/session.ts
@@ -298,19 +298,27 @@ async function getListHtml(webview: Webview, file: string) {
 
 export async function showPlotHistory() {
     if (config.get("sessionWatcher")) {
-        const files = await fs.readdir(plotDir);
-        const panel = window.createWebviewPanel("plotHistory", "Plot History",
-            {
-                preserveFocus: true,
-                viewColumn: ViewColumn.Two,
-            },
-            {
-                retainContextWhenHidden: true,
-                enableScripts: true,
-                localResourceRoots: [Uri.file(resDir), Uri.file(plotDir)],
-            });
-        const html = getPlotHistoryHtml(panel.webview, files)
-        panel.webview.html = html;
+        if (plotDir === undefined) {
+            window.showErrorMessage("No session is attached.")
+        } else {
+            const files = await fs.readdir(plotDir);
+            if (files.length > 0) {
+                const panel = window.createWebviewPanel("plotHistory", "Plot History",
+                    {
+                        preserveFocus: true,
+                        viewColumn: ViewColumn.Two,
+                    },
+                    {
+                        retainContextWhenHidden: true,
+                        enableScripts: true,
+                        localResourceRoots: [Uri.file(resDir), Uri.file(plotDir)],
+                    });
+                const html = getPlotHistoryHtml(panel.webview, files)
+                panel.webview.html = html;
+            } else {
+                window.showInformationMessage("There is no plot to show yet.")
+            }
+        }
     } else {
         window.showInformationMessage("This command requires that r.sessionWatcher be enabled.");
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,6 +50,8 @@ const config = {
       { from: './node_modules/datatables.net-fixedheader/js/dataTables.fixedHeader.min.js', to: 'resources' },
       { from: './node_modules/datatables.net-fixedheader-jqui/js/fixedHeader.jqueryui.min.js', to: 'resources' },
       { from: './node_modules/datatables.net-fixedheader-jqui/css/fixedHeader.jqueryui.min.css', to: 'resources' },
+      { from: './node_modules/fotorama/fotorama.js', to: 'resources' },
+      { from: './node_modules/fotorama/fotorama.css', to: 'resources' },
     ]),
   ],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,6 +52,8 @@ const config = {
       { from: './node_modules/datatables.net-fixedheader-jqui/css/fixedHeader.jqueryui.min.css', to: 'resources' },
       { from: './node_modules/fotorama/fotorama.js', to: 'resources' },
       { from: './node_modules/fotorama/fotorama.css', to: 'resources' },
+      { from: './node_modules/fotorama/fotorama.png', to: 'resources' },
+      { from: './node_modules/fotorama/fotorama@2x.png', to: 'resources' },
     ]),
   ],
 };


### PR DESCRIPTION
**What problem did you solve?**

Closes #171 

This PR:

* Preserves historic plots in `{tempdir}/images` by updating the history plot file on `plot.new` and `grid.new` hook.
* Adds a command `Show Plot History` to show a WebView of historic plots.
* [Fotorama](https://fotorama.io/) is used in the WebView to present the plot history that provides thumbnails of images and allows user to navigate via click and arrow keys.

Known limitation:

* Currently, we replay plot on task callback, i.e. top level of user input. If user uses `par(mfrow = c(a, b))` and produces multi-page images in a single callback (i.e. create plots of more than `a*b` so the page is cleared and a new page is created), only the last page can be replayed.
* If user uses `par(mfrow = c(a, b))`, when user adds a plot to the current page, it will be regarded as a new plot and saved to a new history plot file since I don't know a way to know if a page is flushed. For example, for `par(mfrow = c(1, 2))`, and user runs `plot(rnorm(100))` twice, two plots files are preserved as history plots, unless user produces two plots in a single callback.

**(If you have)Screenshot**

<img width="524" alt="image" src="https://user-images.githubusercontent.com/4662568/71995446-8ad50480-3275-11ea-8230-37205b8a0cae.png">
