### PR TITLE
Use dev.args option when creating png device before replay

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -72,7 +72,8 @@ if (interactive() && !identical(Sys.getenv("RSTUDIO"), "1")) {
               plot_updated <<- FALSE
               record <- recordPlot()
               if (length(record[[1]])) {
-                png(plot_file)
+                dev_args <- getOption("dev.args")
+                do.call(png, c(list(filename = plot_file), dev_args))
                 on.exit({
                   dev.off()
                   if (!is.null(plot_history_file)) {


### PR DESCRIPTION
**What problem did you solve?**

Closes #163 

This PR uses `getOption("dev.args")` to allow user to specify arguments of the PNG device to be created to capture the replayed graphics.

For example, user could specify `dev.args` option before any plot to adjust plot size.

```r
options(dev.args = list(width = 720, height = 720))
plot(rnorm(100))
```

`dev.args` is simply passed to `png(...)`.