### PR TITLE
Add row hover and select

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -229,7 +229,7 @@ async function getTableHtml(webview: Webview, file: string) {
 </head>
 <body>
   <div class="container-fluid">
-    <table id="data-table" class="display compact table table-sm table-striped table-condensed table-hover"></table>
+    <table id="data-table" class="display table table-sm table-striped table-condensed table-hover"></table>
   </div>
   <script src="${webview.asWebviewUri(Uri.file(path.join(resDir, "jquery.min.js")))}"></script>
   <script src="${webview.asWebviewUri(Uri.file(path.join(resDir, "jquery.dataTables.min.js")))}"></script>
@@ -248,7 +248,7 @@ async function getTableHtml(webview: Webview, file: string) {
         fixedHeader: true
       });
       $("#data-table tbody").on("click", "tr", function() {
-        $(this).toggleClass("bg-dark text-light");
+        $(this).toggleClass("table-active");
       });
     });
   </script>

--- a/src/session.ts
+++ b/src/session.ts
@@ -229,7 +229,7 @@ async function getTableHtml(webview: Webview, file: string) {
 </head>
 <body>
   <div class="container-fluid">
-    <table id="data-table" class="display compact table table-sm table-striped table-condensed"></table>
+    <table id="data-table" class="display compact table table-sm table-striped table-condensed table-hover"></table>
   </div>
   <script src="${webview.asWebviewUri(Uri.file(path.join(resDir, "jquery.min.js")))}"></script>
   <script src="${webview.asWebviewUri(Uri.file(path.join(resDir, "jquery.dataTables.min.js")))}"></script>
@@ -246,6 +246,9 @@ async function getTableHtml(webview: Webview, file: string) {
         autoWidth: false,
         order: [],
         fixedHeader: true
+      });
+      $("#data-table tbody").on("click", "tr", function() {
+        $(this).toggleClass("bg-dark text-light");
       });
     });
   </script>


### PR DESCRIPTION
**What problem did you solve?**

Closes #185 

* Bootstrap CSS style `table-hover` is used to enable row hover styling.
* Row selecting is enabled by toggling Bootstrap CSS style `table-active` on row click.

**(If you have)Screenshot**

![image](https://user-images.githubusercontent.com/4662568/72503678-49e17f00-3877-11ea-9800-435b7c043420.png)
