### PR TITLE
Fix WebView Uri replacing

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -163,10 +163,8 @@ async function showWebView(file: string) {
         });
     const content = await fs.readFile(file);
     const html = content.toString()
-        .replace("<style>body{background-color:white;}</style>",
-            "<style>body{background-color:white;color:black;}</style>")
-        .replace(/<script src="/g, '<script src="' + panel.webview.asWebviewUri(Uri.file(dir)) + "/")
-        .replace(/<link href="/g, '<link href="' + panel.webview.asWebviewUri(Uri.file(dir)) + "/");
+        .replace("<body>", "<body style=\"color: black;\"")
+        .replace(/<(\w+)\s+(href|src)="(?!\w+:)/g, '<$1 $2="' + panel.webview.asWebviewUri(Uri.file(dir)) + "/");
     panel.webview.html = html;
 }
 


### PR DESCRIPTION
**What problem did you solve?**

Closes #187 

This PR fixes Uri replacing method in `showWebView`. It is made more robust to only replace non-protocol-specific Uri which points to a local file in htmlwidget source code. For example, in the following HTML tags, only paths starting with `lib/` should be replaced with WebView resource Uri, and the last two should not be replaced since they are both protocol-specific Uri.

```html
<script src="lib/htmlwidgets-1.5.1/htmlwidgets.js"></script>
<script src="lib/jquery-1.12.4/jquery.min.js"></script>
<link href="lib/datatables-css-0.0.0/datatables-crosstalk.css" rel="stylesheet" />
<script src="lib/datatables-binding-0.10/datatables.js"></script>
<link href="lib/dt-core-1.10.19/css/jquery.dataTables.min.css" rel="stylesheet" />
<link href="lib/dt-core-1.10.19/css/jquery.dataTables.extra.css" rel="stylesheet" />
<script src="lib/dt-core-1.10.19/js/jquery.dataTables.min.js"></script>
<link href="lib/crosstalk-1.0.0/css/crosstalk.css" rel="stylesheet" />
<script src="lib/crosstalk-1.0.0/js/crosstalk.min.js"></script>
<script src="data:application/javascript;base64,LyohIGhpZ2hsaWd6IlxcUyJ9fSk7"></script>
<script src="https://test.com/lib1.js"></script>
```

This fixes the handling of script tags created from base64 data uri.

**(If you have)Screenshot**

<img width="786" alt="image" src="https://user-images.githubusercontent.com/4662568/72436067-8b701c80-37da-11ea-9bac-1402eb52fa99.png">
