### PR TITLE
Show WebView triggered by page_viewer in Active column

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -22,8 +22,8 @@ if (interactive() && !identical(Sys.getenv("RSTUDIO"), "1")) {
             dev.control(displaylist = "enable")
           },
           browser = function(url, ...) respond("browser", url = url, ...),
-          viewer = function(url, ...) respond("webview", file = url, ...),
-          page_viewer = function(url, ...) respond("webview", file = url, ...),
+          viewer = function(url, ...) respond("webview", file = url, ..., viewColumn = "Two"),
+          page_viewer = function(url, ...) respond("webview", file = url, ..., viewColumn = "Active"),
           help_type = "html"
         )
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -148,13 +148,13 @@ function getBrowserHtml(url: string) {
 `;
 }
 
-async function showWebView(file: string) {
+async function showWebView(file: string, viewColumn: ViewColumn) {
     const dir = path.dirname(file);
     console.info("webview uri: " + file);
     const panel = window.createWebviewPanel("webview", "WebView",
         {
             preserveFocus: true,
-            viewColumn: ViewColumn.Two,
+            viewColumn: viewColumn,
         },
         {
             enableScripts: true,
@@ -316,7 +316,8 @@ async function updateResponse(sessionStatusBarItem: StatusBarItem) {
     } else if (parseResult.command === "browser") {
         showBrowser(parseResult.url);
     } else if (parseResult.command === "webview") {
-        showWebView(parseResult.file);
+        const viewColumn: string = parseResult.viewColumn;
+        showWebView(parseResult.file, ViewColumn[viewColumn]);
     } else if (parseResult.command === "dataview") {
         showDataView(parseResult.source,
             parseResult.type, parseResult.title, parseResult.file);


### PR DESCRIPTION
Both `viewer` and `page_viewer` open WebView to show the resulted HTML file.

`viewer` is typically called by htmlwidgets to show a new page side-by-side with currently editing document while `page_viewer` (e.g. profvis) a new page in the current editor, which is consistent with RStudio behavior.

This PR distinguishes `page_viewer` and `viewer` by adding different `viewColumn` to the response they create and vscode-R handles them when updating response. Now, `viewer` uses `viewColumn = "Two"` while `page_viewer` uses `viewColumn = "Active"`.
