### PR TITLE
WIP Add runCodeWithPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ Requires [R](https://www.r-project.org/).
 
 * Package development short cut (`Load All`, `Test Package`, `Install Package`, `Build Package` and `Document`)
 
+* Commands for use in `keybindings.json`:
+
+    * `r.runCodeWithPath`: Wraps current file path in `args`. Example `keybindings.json`:
+
+        ```
+        [
+            {
+                "key": "ctrl+alt+shift+1;"",
+                "command": "r.runCodeWithPath",
+                "when": "editorTextFocus",
+                "args": [ "rmarkdown::run(", ")" ]
+            }
+        ]
+        ```
+
 ## Requirements
 
 * R base from <https://www.r-project.org/>

--- a/package.json
+++ b/package.json
@@ -242,6 +242,11 @@
         "title": "Show Plot History",
         "category": "R",
         "command": "r.showPlotHistory"
+      },
+      {
+        "title": "Run Code with Path",
+        "category": "R",
+        "command": "r.runCodeWithPath"
       }
     ],
     "keybindings": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,34 +36,20 @@ export function activate(context: ExtensionContext) {
     // Now provide the implementation of the command with  registerCommand
     // The commandId parameter must match the command field in package.json
 
-    function runSource(echo: boolean)  {
+    function runCodeWithPath(args: any[]) {
         const wad = window.activeTextEditor.document;
         wad.save();
-        let rPath: string = ToRStringLiteral(wad.fileName, '"');
-        let encodingParam = config.get<string>("source.encoding");
-        encodingParam = `encoding = "${encodingParam}"`;
-        rPath = [rPath, encodingParam].join(", ");
-        if (echo) {
-            rPath = [rPath, "echo = TRUE"].join(", ");
-        }
-        chooseTerminalAndSendText(`source(${rPath})`);
+        const rPath: string = ToRStringLiteral(wad.fileName, '"');
+        chooseTerminalAndSendText(`${args[0]}${rPath}${args[1]}`);
     }
 
-    function knitRmd(echo: boolean, outputFormat: string)  {
-        const wad: TextDocument = window.activeTextEditor.document;
-        wad.save();
-        let rPath = ToRStringLiteral(wad.fileName, '"');
+    function runSource(echo: boolean) {
         let encodingParam = config.get<string>("source.encoding");
-        encodingParam = `encoding = "${encodingParam}"`;
-        rPath = [rPath, encodingParam].join(", ");
+        encodingParam = `, encoding = "${encodingParam}")`;
         if (echo) {
-            rPath = [rPath, "echo = TRUE"].join(", ");
+            encodingParam = [", echo = TRUE", encodingParam].join("");
         }
-        if (outputFormat === undefined) {
-            chooseTerminalAndSendText(`rmarkdown::render(${rPath})`);
-        } else {
-            chooseTerminalAndSendText(`rmarkdown::render(${rPath}, "${outputFormat}")`);
-        }
+        runCodeWithPath(["source(", encodingParam]);
     }
 
     async function runSelection() {
@@ -117,11 +103,15 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand("r.head", () => runSelectionOrWord(["head"])),
         commands.registerCommand("r.thead", () => runSelectionOrWord(["t", "head"])),
         commands.registerCommand("r.names", () => runSelectionOrWord(["names"])),
+        commands.registerCommand("r.runCodeWithPath", (args: any[]) => runCodeWithPath(args)),
         commands.registerCommand("r.runSource", () => { runSource(false); }),
-        commands.registerCommand("r.knitRmd", () => { knitRmd(false, undefined); }),
-        commands.registerCommand("r.knitRmdToPdf", () => { knitRmd(false, "pdf_document"); }),
-        commands.registerCommand("r.knitRmdToHtml", () => { knitRmd(false, "html_document"); }),
-        commands.registerCommand("r.knitRmdToAll", () => { knitRmd(false, "all"); }),
+        commands.registerCommand("r.knitRmd", () => { runCodeWithPath(["rmarkdown::render(", ")"]); }),
+        commands.registerCommand("r.knitRmdToPdf", () => {
+            runCodeWithPath(["rmarkdown::render(", ", \"pdf_document\")"]); }),
+        commands.registerCommand("r.knitRmdToHtml", () => {
+            runCodeWithPath(["rmarkdown::render(", ", \"html_document\")"]); }),
+        commands.registerCommand("r.knitRmdToAll", () => {
+            runCodeWithPath(["rmarkdown::render(", ", \"all\")"]); }),
         commands.registerCommand("r.createRTerm", createRTerm),
         commands.registerCommand("r.runSourcewithEcho", () => { runSource(true); }),
         commands.registerCommand("r.runSelection", runSelection),


### PR DESCRIPTION
Closes #183 

**What problem did you solve?**

Adds a command `r.runCodeWithPath` that can be used in `keybindings.json` to run code containing the current editor file's path.

This PR includes refactoring for `runSource` and `knitRmd` commands but does not affect their behaviour.

**How can I check this pull request?**

1. In `keybindings.json`, add:

    ```
    [
      {
        "key": "ctrl+alt+shift+1",
        "command": "r.runCodeWithPath",
        "when": "editorTextFocus",
        "args": [ "rmarkdown::run(", ")" ]
      }
    ]
    ```

2. Create an R Markdown file `temp.Rmd`:

```
    ---
    title: temp
    ---
 
    ```{r}
    iris
    ```
```

3. Open an R console
4. Make sure R extension is active, by, e.g., running `Run Selection/Line`
4. Press <kbd>Ctrl+Alt+Shift+1</kbd>. The following command will be sent to the R console 

```
rmarkdown::run("PATH/temp.Rmd")
```

**Note**

The `r.runCodeWithPath` command is only for use in `keybindings.json`. If the user runs the command `Run Code with Path` from the command palette, it fails with the vague message "Running the contributed command: 'r.runCodeWithPath' failed". I tried adding a check in `runCodeWithPath` that gives a sensible error message if `args.length === 0`, but the same message still appeared. The failure might occur before `runCodeWithPath` is actually called.