### PR TITLE
Avoid duplicate handling of response update

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -17,6 +17,7 @@ let PID: string;
 let tempDir: string;
 let plotDir: string;
 let resDir: string;
+let responseLineCount: number;
 const sessionDir = path.join(".vscode", "vscode-R");
 
 export function deploySessionWatcher(extensionPath: string) {
@@ -37,6 +38,7 @@ export function deploySessionWatcher(extensionPath: string) {
 
 export function startResponseWatcher(sessionStatusBarItem: StatusBarItem) {
     console.info("[startResponseWatcher] Starting");
+    responseLineCount = 0;
     responseWatcher = workspace.createFileSystemWatcher(
         new RelativePattern(
             workspace.workspaceFolders[0],
@@ -389,29 +391,34 @@ async function updateResponse(sessionStatusBarItem: StatusBarItem) {
     console.info("[updateResponse] responseLogFile: " + responseLogFile);
     const content = await fs.readFile(responseLogFile, "utf8");
     const lines = content.split("\n");
-    console.info("[updateResponse] lines: " + lines.length.toString());
-    const lastLine = lines[lines.length - 2];
-    console.info("[updateResponse] lastLine: " + lastLine);
-    const parseResult = JSON.parse(lastLine);
-    if (parseResult.command === "attach") {
-        PID = String(parseResult.pid);
-        tempDir = parseResult.tempdir;
-        plotDir = path.join(tempDir, "images");
-        console.info("[updateResponse] attach PID: " + PID);
-        sessionStatusBarItem.text = "R: " + PID;
-        sessionStatusBarItem.show();
-        updateSessionWatcher();
-        _updateGlobalenv();
-        _updatePlot();
-    } else if (parseResult.command === "browser") {
-        showBrowser(parseResult.url);
-    } else if (parseResult.command === "webview") {
-        const viewColumn: string = parseResult.viewColumn;
-        showWebView(parseResult.file, ViewColumn[viewColumn]);
-    } else if (parseResult.command === "dataview") {
-        showDataView(parseResult.source,
-            parseResult.type, parseResult.title, parseResult.file);
+    if (lines.length > responseLineCount) {
+        responseLineCount = lines.length;
+        console.info("[updateResponse] lines: " + responseLineCount.toString());
+        const lastLine = lines[lines.length - 2];
+        console.info("[updateResponse] lastLine: " + lastLine);
+        const parseResult = JSON.parse(lastLine);
+        if (parseResult.command === "attach") {
+            PID = String(parseResult.pid);
+            tempDir = parseResult.tempdir;
+            plotDir = path.join(tempDir, "images");
+            console.info("[updateResponse] attach PID: " + PID);
+            sessionStatusBarItem.text = "R: " + PID;
+            sessionStatusBarItem.show();
+            updateSessionWatcher();
+            _updateGlobalenv();
+            _updatePlot();
+        } else if (parseResult.command === "browser") {
+            showBrowser(parseResult.url);
+        } else if (parseResult.command === "webview") {
+            const viewColumn: string = parseResult.viewColumn;
+            showWebView(parseResult.file, ViewColumn[viewColumn]);
+        } else if (parseResult.command === "dataview") {
+            showDataView(parseResult.source,
+                parseResult.type, parseResult.title, parseResult.file);
+        } else {
+            console.error("[updateResponse] Unsupported command: " + parseResult.command);
+        }
     } else {
-        console.error("Unsupported command: " + parseResult.command);
+        console.warn("[updateResponse] Duplicate update on response change");
     }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -391,7 +391,7 @@ async function updateResponse(sessionStatusBarItem: StatusBarItem) {
     console.info("[updateResponse] responseLogFile: " + responseLogFile);
     const content = await fs.readFile(responseLogFile, "utf8");
     const lines = content.split("\n");
-    if (lines.length > responseLineCount) {
+    if (lines.length != responseLineCount) {
         responseLineCount = lines.length;
         console.info("[updateResponse] lines: " + responseLineCount.toString());
         const lastLine = lines[lines.length - 2];


### PR DESCRIPTION
Closes #205 

Some software may watch a folder and modifies the file on file change in the folder, which causes a new line in `response.log` to be handled multiple times.

One example is OneDrive software under both Windows and macOS. It is constantly syncing a OneDrive folder. If a workspace folder in the OneDrive folder is open in VSCode, any update of `response.log` will result in duplicate handling, e.g. `View(mtcars)` creates multiple tabs of the same data.

To avoid this, we record the number of lines of `response.log` on each scan of the file. We only handle the last line when the number of lines ~~increase~~ changes. As a result, if a new line is appended to `response.log`, and `updateResponse` is called multiple times due to the syncing may cause the file to be somehow updated multiple times, only the first time it is handled will take effect.
