### PR TITLE
Fix leading slash in tmpDir path

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -105,7 +105,7 @@ async function waitForFileToFinish(filePath: string) {
 }
 
 function makeTmpDir() {
-    let tmpDir = workspace.workspaceFolders[0].uri.path;
+    let tmpDir = workspace.workspaceFolders[0].uri.fsPath;
     if (process.platform === "win32") {
         tmpDir = tmpDir.replace(/\\/g, "/");
         tmpDir += "/tmp";


### PR DESCRIPTION
Fixes #139 

**What problem did you solve?**

For some users, `Preview Dataframe` and `Preview Environment` fail with error `EINVAL: invalid argument, mkdir`, and a path with a leading slash (e.g., `/c:/.../tmp`).

This PR fixes that issue. Tested on Windows 10 (for which I had been experiencing the issue) and Ubuntu (for which I had not been experiencing the issue).