### PR TITLE
Add syntax highlighting for R code in Rcpp comment

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,11 @@
         "language": "rmd",
         "scopeName": "text.html.markdown.redcarpet",
         "path": "./syntax/Markdown Redcarpet.tmLanguage"
+      },
+      {
+        "path": "./syntax/Rcpp.tmLanguage",
+        "scopeName": "comment.block.r",
+        "injectTo": ["source.cpp"]
       }
     ],
     "commands": [

--- a/syntax/Rcpp.tmLanguage
+++ b/syntax/Rcpp.tmLanguage
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>fileTypes</key>
+	<array>
+	</array>
+	<key>injectionSelector</key>
+	<string>L:source.cpp</string>
+	<key>patterns</key>
+	<array>
+		<dict>
+			<key>include</key>
+			<string>#block</string>
+		</dict>
+	</array>
+	<key>repository</key>
+	<dict>
+		<key>block</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#rcpp</string>
+				</dict>
+			</array>
+			<key>repository</key>
+			<dict>
+				<key>rcpp</key>
+				<dict>
+					<key>begin</key>
+					<string>(^|\G)(/[\*]{3}\sR\s*)$</string>
+					<key>captures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>comment.block.cpp</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(^|\G)(\*/\s*)($|\z)</string>
+					<key>captures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>comment.block.cpp</string>
+						</dict>
+					</dict>					<key>contentName</key>
+					<string>meta.embedded.block.r</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>source.r</string>
+						</dict>
+					</array>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+	<key>scopeName</key>
+	<string>comment.block.r</string>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #43 

**What problem did you solve?**

Adds highlighting for R code in `/*** R` block comments in C++ code.

**Screenshot**

![cpp](https://user-images.githubusercontent.com/23294156/74097849-4f6b7580-4b54-11ea-8bec-7b156ce7b127.JPG)
