### PR TITLE
Change .Platform$GUI to vscode on session start

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -232,6 +232,10 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
         }, "base")
         rebind("View", dataview, "utils")
 
+        platform <- .Platform
+        platform$GUI <- "vscode"
+        rebind(".Platform", platform, "base")
+
         update()
         removeTaskCallback("vscode-R")
         addTaskCallback(update, name = "vscode-R")
@@ -243,6 +247,6 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
       invisible()
     })
   } else {
-    message("VSCode R Session Watcher requires jsonlite. Please install it with install.packages(\"jsonlite\")")
+    message("VSCode R Session Watcher requires jsonlite. Please install it with install.packages(\"jsonlite\").")
   }
 }


### PR DESCRIPTION
This PR replaces `.Platform$GUI` to `vscode` for user to check. By default, `.Platform$GUI` is `X11` under linux and macOS, which is not the case when `init.R` is sourced and all viewer are handled by vscode-R.

This is also similar with RStudio which replaces `.Platform$GUI` with `RStudio`.
