### PR TITLE
Add configurable command runner functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Here are some example entries from `keybindings.json`:
         "key": "ctrl+i",
         "command": "r.runCommandWithEditorPath",
         "when": "editorTextFocus",
-        "args": "rmarkdown::render('$$', output_format = rmarkdown::html_document(), output_dir = \".\", clean = TRUE)"
+        "args": "rmarkdown::render(\"$$\", output_format = rmarkdown::html_document(), output_dir = \".\", clean = TRUE)"
     },
 ...
 ]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Requires [R](https://www.r-project.org/).
 
 * Package development short cut (`Load All`, `Test Package`, `Install Package`, `Build Package` and `Document`)
 
+* Bind keys to custom R commands using command runner functions (`r.runCommand`, `r.runCommandWithEditorPath`, `r.runCommandWithSelectionOrWord`)
+
 ## Requirements
 
 * R base from <https://www.r-project.org/>
@@ -138,6 +140,43 @@ attach to currently active session.
 
 *The R terminal used in the screenshot is [radian](https://github.com/randy3k/radian) which is cross-platform and
 supports syntax highlighting, auto-completion and many other features.*
+
+## Creating keybindings for R commands
+
+There are 3 ways you can use extension functions to create keybindings that run R commands in the terminal:
+
+1. `r.runCommand` to make a keybinding to run any R expression. 
+2. `r.runCommandWithEditorPath` to create a keybinding for an R expression where the placeholder value `$$` is interpolated with the current file path.
+3. `runCommandWithSelectionOrWord` to create a keybinding for an R expression where `$$` is interpolated with the current selection or the current word the cursor is on.
+
+Here are some example entries from `keybindings.json`:
+
+```
+[
+    {
+        "description": "run drake::r_make()",
+        "key": "ctrl+;",
+        "command": "r.runCommand",
+        "when": "editorTextFocus",
+        "args": "drake::r_make()"
+    },
+    {
+        "description": "load drake target at cursor",
+        "key": "ctrl+shift+;",
+        "command": "r.runCommandWithSelectionOrWord",
+        "when": "editorTextFocus",
+        "args": "drake::loadd($$)"
+    },
+    {
+        "description": "knit to html",
+        "key": "ctrl+i",
+        "command": "r.runCommandWithEditorPath",
+        "when": "editorTextFocus",
+        "args": "rmarkdown::render($$, output_format = rmarkdown::html_document(), output_dir = \".\", clean = TRUE)"
+    },
+...
+]
+```
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Here are some example entries from `keybindings.json`:
         "key": "ctrl+i",
         "command": "r.runCommandWithEditorPath",
         "when": "editorTextFocus",
-        "args": "rmarkdown::render($$, output_format = rmarkdown::html_document(), output_dir = \".\", clean = TRUE)"
+        "args": "rmarkdown::render('$$', output_format = rmarkdown::html_document(), output_dir = \".\", clean = TRUE)"
     },
 ...
 ]

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "onCommand:r.runSourcewithEcho",
     "onCommand:r.runSelection",
     "onCommand:r.runSelectionInActiveTerm",
-    "onCommand:r.createGitignore"
+    "onCommand:r.createGitignore",
+    "onCommand:r.runCommandWithSelectionOrWord",
+    "onCommand:r.runCommand"
   ],
   "main": "./dist/extension",
   "contributes": {
@@ -251,6 +253,16 @@
         "title": "Show Plot History",
         "category": "R",
         "command": "r.showPlotHistory"
+      },
+      {
+        "title": "Run Command With Selection or Word in Terminal",
+        "category": "R",
+        "command": "r.runCommandWithSelectionOrWord"
+      },
+      {
+        "title": "Run Command in Terminal",
+        "category": "R",
+        "command": "r.runCommand"
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "onCommand:r.runSelectionInActiveTerm",
     "onCommand:r.createGitignore",
     "onCommand:r.runCommandWithSelectionOrWord",
+    "onCommand:r.runCommandWithEditorPath",
     "onCommand:r.runCommand"
   ],
   "main": "./dist/extension",
@@ -258,6 +259,11 @@
         "title": "Run Command With Selection or Word in Terminal",
         "category": "R",
         "command": "r.runCommandWithSelectionOrWord"
+      },
+      {
+        "title": "Run Command With Editor Path in Terminal",
+        "category": "R",
+        "command": "r.runCommandWithEditorPath"
       },
       {
         "title": "Run Command in Terminal",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,7 +96,7 @@ export function activate(context: ExtensionContext) {
     async function runCommandWithSelectionOrWord(rCommand: string) {
         const text = getWordOrSelection().join("\n");
         const callableTerminal = await chooseTerminal();
-        let call = rCommand.replace("$1", text);
+        let call = rCommand.replace("$$", text);
         runTextInTerm(callableTerminal, [call]);
     }
 
@@ -104,8 +104,8 @@ export function activate(context: ExtensionContext) {
         const wad: TextDocument = window.activeTextEditor.document;
         wad.save();
         const callableTerminal = await chooseTerminal();
-        let rPath = ToRStringLiteral(wad.fileName, '"');
-        let call = rCommand.replace("$1",rPath);
+        let rPath = ToRStringLiteral(wad.fileName, "");
+        let call = rCommand.replace("$$",rPath);
         runTextInTerm(callableTerminal, [call]);
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,15 +96,21 @@ export function activate(context: ExtensionContext) {
     async function runCommandWithSelectionOrWord(rCommand: string) {
         const text = getWordOrSelection().join("\n");
         const callableTerminal = await chooseTerminal();
+        let call = rCommand.replace("$1", text);
+        runTextInTerm(callableTerminal, [call]);
+    }
 
-        const call = rCommand.replace("$1", text)
-
+    async function runCommandWithEditorPath(rCommand: string) {
+        const wad: TextDocument = window.activeTextEditor.document;
+        wad.save();
+        const callableTerminal = await chooseTerminal();
+        let rPath = ToRStringLiteral(wad.fileName, '"');
+        let call = rCommand.replace("$1",rPath);
         runTextInTerm(callableTerminal, [call]);
     }
 
     async function runCommand(rCommand: string) {
         const callableTerminal = await chooseTerminal();
-
         runTextInTerm(callableTerminal, [rCommand]);
     }
 
@@ -153,6 +159,7 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand("r.attachActive", attachActive),
         commands.registerCommand("r.showPlotHistory", showPlotHistory),
         commands.registerCommand("r.runCommandWithSelectionOrWord", runCommandWithSelectionOrWord),
+        commands.registerCommand("r.runCommandWithEditorPath", runCommandWithEditorPath),
         commands.registerCommand("r.runCommand", runCommand),
         window.onDidCloseTerminal(deleteTerminal),
     );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,8 +101,23 @@ export function activate(context: ExtensionContext) {
     }
 
     async function runCommandWithEditorPath(rCommand: string) {
-        const wad: TextDocument = window.activeTextEditor.document;
-        wad.save();
+        let wad: TextDocument = window.activeTextEditor.document;
+        let is_saved :boolean;
+        
+        if (wad.isUntitled){
+            throw("Doucment is unsaved. Please save and retry running R command.")
+        }
+
+        if (wad.isDirty) {
+           is_saved = await wad.save();
+        } else {
+           is_saved = true;
+        }
+
+        if (!is_saved){
+            throw("Cannot run R command: Document could not be saved.")
+        }
+        
         const callableTerminal = await chooseTerminal();
         let rPath = ToRStringLiteral(wad.fileName, "");
         let call = rCommand.replace("$$",rPath);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,7 +96,7 @@ export function activate(context: ExtensionContext) {
     async function runCommandWithSelectionOrWord(rCommand: string) {
         const text = getWordOrSelection().join("\n");
         const callableTerminal = await chooseTerminal();
-        let call = rCommand.replace("$$", text);
+        let call = rCommand.replace(/\$\$/g, text);
         runTextInTerm(callableTerminal, [call]);
     }
 
@@ -120,7 +120,7 @@ export function activate(context: ExtensionContext) {
         
         const callableTerminal = await chooseTerminal();
         let rPath = ToRStringLiteral(wad.fileName, "");
-        let call = rCommand.replace("$$",rPath);
+        let call = rCommand.replace(/\$\$/g,rPath);
         runTextInTerm(callableTerminal, [call]);
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,6 +93,21 @@ export function activate(context: ExtensionContext) {
         runTextInTerm(callableTerminal, wrappedText);
     }
 
+    async function runCommandWithSelectionOrWord(rCommand: string) {
+        const text = getWordOrSelection().join("\n");
+        const callableTerminal = await chooseTerminal();
+
+        const call = rCommand.replace("$1", text)
+
+        runTextInTerm(callableTerminal, [call]);
+    }
+
+    async function runCommand(rCommand: string) {
+        const callableTerminal = await chooseTerminal();
+
+        runTextInTerm(callableTerminal, [rCommand]);
+    }
+
     languages.registerCompletionItemProvider("r", {
         provideCompletionItems(document: TextDocument, position: Position) {
             if (document.lineAt(position).text
@@ -137,6 +152,8 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand("r.document", () => chooseTerminalAndSendText("devtools::document()")),
         commands.registerCommand("r.attachActive", attachActive),
         commands.registerCommand("r.showPlotHistory", showPlotHistory),
+        commands.registerCommand("r.runCommandWithSelectionOrWord", runCommandWithSelectionOrWord),
+        commands.registerCommand("r.runCommand", runCommand),
         window.onDidCloseTerminal(deleteTerminal),
     );
 


### PR DESCRIPTION
**What problem did you solve?**

Addresses feature request in #199 and #183 using @renkun-ken's suggestions from #203.

I am proposing to add three functions that allow the configuration of custom keybindings:

* `runCommand`
* `runCommandWithSelectionOrWord`
* `runCommandWithEditorPath`

These allow keybindings to be configured like this:

```
[
    {
        "description": "run drake::r_make()",
        "key": "ctrl+;",
        "command": "r.runCommand",
        "when": "editorTextFocus",
        "args": "drake::r_make()"
    },
    {
        "description": "load drake target at cursor",
        "key": "ctrl+shift+;",
        "command": "r.runCommandWithSelectionOrWord",
        "when": "editorTextFocus",
        "args": "drake::loadd($1)"
    },
    {
        "description": "knit to html",
        "key": "ctrl+i",
        "command": "r.runCommandWithEditorPath",
        "when": "editorTextFocus",
        "args": "rmarkdown::render($1, output_format = rmarkdown::html_document(), output_dir = \".\", clean = TRUE, output_file = \"run_command_test.html\")"
    },
    {
        "description": "thead",
        "key": "ctrl+shift+k",
        "command": "r.runCommandWithSelectionOrWord",
        "when": "editorTextFocus",
        "args": "t(head($1))"
    }
]
```

`$1` is replaced with the selection, word at cursor, or file path as appropriate for the command. Perhaps there is a better placeholder since maybe `$1` implies a `$2` is possible when at present it is not. 

One advantage of `$1` is that R names cannot begin with a number, and so the chance of a clash with object$name style expressions is very low.

In #203 we discussed multiple selections and the possibility of running the command over each selection when there are multiple. I have looked into this and I can see they should be available in the `window.activeTextEditor.selections` array. However there is a certain amount of fiddlyness with this since each selection may be either a true selection or a zero-length one (a cursor).

Personally I can't see myself using the multiple selection feature in this way, so I propose waiting on that implementation until a compelling usecase arrives.

I would like to put together some documentation as part of this PR. Should this go in the README?

**(If you have)Screenshot**

Sorry no.

**(If you do not have screenshot) How can I check this pull request?**

You can try out the configuration examples above. You don't really need the referenced packages like `drake`. You only need to be confident the R code that gets sent to the console looks as it should with the `$1` interpolated with the selection, word, or path.