### PR TITLE
Fix showWebView

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -193,7 +193,7 @@ async function showWebView(file: string, viewColumn: ViewColumn) {
     const html = content.toString()
         .replace("<body>", "<body style=\"color: black;\"")
         .replace(/<(\w+)\s+(href|src)="(?!\w+:)/g,
-                 `<$1 $2="${String(panel.webview.asWebviewUri(Uri.file(dir)))}"/`);
+                 `<$1 $2="${String(panel.webview.asWebviewUri(Uri.file(dir)))}/`);
     panel.webview.html = html;
     console.info("[showWebView] Done");
 }


### PR DESCRIPTION
**What problem did you solve?**

Closes #245

This PR fixes a typo introduces from previous code refactoring which transforms relative URI to the following incorrect version with unnecessary `"` that makes WebView cannot properly load the JS/CSS resources of htmlwidgets:

```html
<script src="vscode-resource://file///var/folders/dh/6nhw4l5x0sq0wqgwh346fwjm0000gn/T//RtmpD5Lncd/viewhtml8ed856cdd4ab"/lib/htmlwidgets-1.5.1/htmlwidgets.js"></script>
```

**(If you do not have screenshot) How can I check this pull request?**

```r
DT::datatable(mtcars)
```

now should properly create WebView to present htmlwidgets.

We may need a release with this PR merged since the feature is completely broken in the current release.