### PR TITLE
Use Windows registry to find R path

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,7 +33,7 @@ Yes / No
 
 ```json
 // R.exe path for windows
-"r.rterm.windows": "C:\\Program Files\\R\\R-3.4.4\\bin\\x64\\R.exe",
+"r.rterm.windows": "",
 
 // R path for Mac OS X
 "r.rterm.mac": "/usr/local/bin/R",

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -20,7 +20,7 @@ Yes / No
 
 ```json
 // R.exe path for windows
-"r.rterm.windows": "C:\\Program Files\\R\\R-3.4.4\\bin\\x64\\R.exe",
+"r.rterm.windows": "",
 
 // R path for Mac OS X
 "r.rterm.mac": "/usr/local/bin/R",

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Requires [R](https://www.r-project.org/).
 
 ## Usage
 
-* For Windows, set config `r.rterm.windows` to your `R.exe` Path like `"C:\\Program Files\\R\\R-3.3.4\\bin\\x64\\R.exe"`;
+* For Windows, if `r.rterm.windows` is empty, then the path to `R.exe` will be searched in Windows registry. If your R is not installed with path written in registry or if you need a specific R executable path, set it to a path like `"C:\\Program Files\\R\\R-3.3.4\\bin\\x64\\R.exe"`.
 * For Radian console, enable config `r.bracketedPaste`
 * Open your *folder* that has R source file (**Can't work if you open only file**)
-* Use `F1` key and `R:` command or `Ctrl+Enter`(Mac: `⌘+Enter`)
+* Use `F1` key and `R:` command or `Ctrl+Enter` (Mac: `⌘+Enter`)
 
 ## Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,11 @@
       "integrity": "sha512-ds6TceMsh77Fs0Mq0Vap6Y72JbGWB8Bay4DrnJlf5d9ui2RSe1wis13oQm+XhguOeH1HUfLGzaDAoupTUtgabw==",
       "dev": true
     },
+    "@types/winreg": {
+      "version": "1.2.30",
+      "resolved": "https://registry.npmjs.org/@types/winreg/-/winreg-1.2.30.tgz",
+      "integrity": "sha1-kdZxDlNtNFucmwF8V0z2qNpkxRg="
+    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -6342,6 +6347,11 @@
       "requires": {
         "fswin": "^3.18.918"
       }
+    },
+    "winreg": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz",
+      "integrity": "sha1-ugZWKbepJRMOFXeRCM9UCZDpjRs="
     },
     "worker-farm": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -368,7 +368,7 @@
       "properties": {
         "r.rterm.windows": {
           "type": "string",
-          "default": "C:\\Program Files\\R\\R-3.5.0\\bin\\x64\\R.exe",
+          "default": "",
           "description": "R.exe path for windows"
         },
         "r.rterm.mac": {

--- a/package.json
+++ b/package.json
@@ -436,6 +436,7 @@
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.7.6",
     "@types/vscode": "^1.42.0",
+    "@types/winreg": "^1.2.30",
     "copy-webpack-plugin": "^5.1.1",
     "mocha": "^7.1.0",
     "node-atomizr": "^0.6.1",
@@ -457,6 +458,7 @@
     "jquery.json-viewer": "^1.4.0",
     "path": "^0.12.7",
     "popper.js": "^1.16.1",
-    "winattr": "^3.0.0"
+    "winattr": "^3.0.0",
+    "winreg": "^1.2.4"
   }
 }

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -12,9 +12,9 @@ import { removeSessionFiles } from "./session";
 import { config, delay, getRpath } from "./util";
 export let rTerm: Terminal;
 
-export function createRTerm(preserveshow?: boolean): boolean {
+export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
     const termName = "R Interactive";
-    const termPath = getRpath();
+    const termPath = await getRpath();
     console.info(`termPath: ${termPath}`);
     if (termPath === undefined) {
         return undefined;

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -12,9 +12,9 @@ import { removeSessionFiles } from "./session";
 import { config, delay, getRpath } from "./util";
 export let rTerm: Terminal;
 
-export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
+export function createRTerm(preserveshow?: boolean): boolean {
     const termName = "R Interactive";
-    const termPath = await getRpath();
+    const termPath = getRpath();
     if (termPath === undefined) {
         return undefined;
     }

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -15,6 +15,7 @@ export let rTerm: Terminal;
 export function createRTerm(preserveshow?: boolean): boolean {
     const termName = "R Interactive";
     const termPath = getRpath();
+    console.info(`termPath: ${termPath}`);
     if (termPath === undefined) {
         return undefined;
     }

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -12,36 +12,36 @@ import { removeSessionFiles } from "./session";
 import { config, delay, getRpath } from "./util";
 export let rTerm: Terminal;
 
-export function createRTerm(preserveshow?: boolean): boolean {
-        const termName = "R Interactive";
-        const termPath = getRpath();
-        if (termPath === undefined) {
-            return undefined;
-        }
-        const termOpt: string[] = config.get("rterm.option");
-        pathExists(termPath, (err, exists) => {
-            if (exists) {
-                const termOptions: TerminalOptions = {
-                    name: termName,
-                    shellPath: termPath,
-                    shellArgs: termOpt,
-                };
-                if (config.get<boolean>("sessionWatcher")) {
-                    termOptions.env = {
-                        R_PROFILE_USER_OLD: process.env.R_PROFILE_USER,
-                        R_PROFILE_USER: path.join(os.homedir(), ".vscode-R", ".Rprofile"),
-                    };
-                }
-                rTerm = window.createTerminal(termOptions);
-                rTerm.show(preserveshow);
-
-                return true;
-            }
-            window.showErrorMessage("Cannot find R client.  Please check R path in preferences and reload.");
-
-            return false;
-        });
+export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
+    const termName = "R Interactive";
+    const termPath = await getRpath();
+    if (termPath === undefined) {
+        return undefined;
     }
+    const termOpt: string[] = config.get("rterm.option");
+    pathExists(termPath, (err, exists) => {
+        if (exists) {
+            const termOptions: TerminalOptions = {
+                name: termName,
+                shellPath: termPath,
+                shellArgs: termOpt,
+            };
+            if (config.get<boolean>("sessionWatcher")) {
+                termOptions.env = {
+                    R_PROFILE_USER_OLD: process.env.R_PROFILE_USER,
+                    R_PROFILE_USER: path.join(os.homedir(), ".vscode-R", ".Rprofile"),
+                };
+            }
+            rTerm = window.createTerminal(termOptions);
+            rTerm.show(preserveshow);
+
+            return true;
+        }
+        window.showErrorMessage("Cannot find R client.  Please check R path in preferences and reload.");
+
+        return false;
+    });
+}
 
 export function deleteTerminal(term: Terminal) {
     if (isDeepStrictEqual(term, rTerm)) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,9 +19,11 @@ export function getRpath() {
                 key.get("InstallPath", (err: Error, result: winreg.RegistryItem) => {
                     if (err !== null) {
                         rpath = path.join(result.value, "bin", "R.exe");
+                        console.info(`rpath: ${rpath}`);
                     }
                 });
             } catch (e) {
+                console.info("winreg error");
                 rpath = "";
             }
         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,24 +6,22 @@ import { window, workspace } from "vscode";
 import winreg = require("winreg");
 export let config = workspace.getConfiguration("r");
 
-export async function getRpath() {
+export function getRpath() {
     if (process.platform === "win32") {
         let rpath: string = config.get<string>("rterm.windows");
         if (rpath === "") {
             // Find path from registry
             try {
-                const key = new windreg({
+                const key = new winreg({
                     hive: winreg.HKLM,
                     key: "\\Software\\R-Core\\R",
                 });
-                const item: winreg.RegistryItem = await new Promise((c, e) =>
-                    key.get('InstallPath', (err, result) => err ? e(err) : c(result)));
-                const rhome: string = String(item.value);
-                rpath = path.join(rhome, "bin", "R.exe");
+                key.get("InstallPath", (err: Error, result: winreg.RegistryItem) => {
+                    if (err !== null) {
+                        rpath = path.join(result.value, "bin", "R.exe");
+                    }
+                });
             } catch (e) {
-                rpath = "";
-            }
-            if (!existsSync(rpath)) {
                 rpath = "";
             }
         }


### PR DESCRIPTION
**What problem did you solve?**

Closes #244 

**(If you do not have screenshot) How can I check this pull request?**

If a Windows user installs R with default installation settings, the R path will be added to registry. So that user does not have to specify R executable in this case.

To test it, set `rterm.windows` to empty (now it's empty by default), run `Create R Terminal` and see if it could properly find R path and create a terminal with it.

Another thing to test is that if multiple versions are installed, the registry will contain multiple entries of R paths. Although the registry entry will have multiple subentries in this case, the value of the key should be the last installed version.