### PR TITLE
Make rebind also work with attached packages

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -217,10 +217,21 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
         }
 
         rebind <- function(sym, value, ns) {
-          ns <- getNamespace(ns)
-          unlockBinding(sym, ns)
-          on.exit(lockBinding(sym, ns))
-          assign(sym, value, envir = ns)
+          if (is.character(ns)) {
+            Recall(sym, value, getNamespace(ns))
+            pkg <- paste0("package:", ns)
+            if (pkg %in% search()) {
+              Recall(sym, value, as.environment(pkg))
+            }
+          } else if (is.environment(ns)) {
+            if (bindingIsLocked(sym, ns)) {
+              unlockBinding(sym, ns)
+              on.exit(lockBinding(sym, ns))
+            }
+            assign(sym, value, ns)
+          } else {
+            stop("ns must be a string or environment")
+          }
         }
 
         setHook("plot.new", new_plot, "replace")


### PR DESCRIPTION
**What problem did you solve?**

Closes #263 

Previously, if a user attaches `utils` for some reason before calling `source("~/.vscode-R/init.R")`, then `utils::View` is replaced but `View` is still not. As a result, `View` cannot not trigger web view and user has use `utils::View` as a walk-around.

This PR makes `rebind` in `init.R` more robust so that it also works in this case too.

**(If you do not have screenshot) How can I check this pull request?**

1. Insert `library(utils)` before sourcing `~/.vscode-R/init.R` in `~/.Rprofile`
2. Start a new R session
3. Run `View(mtcars)` and it should work.
