### PR TITLE
Make plot update smarter using magic null dev size

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -22,7 +22,8 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
         null_dev_size <- c(7 + pi, 7 + pi)
 
         check_null_dev <- function() {
-          identical(dev.cur(), null_dev_id) && identical(dev.size(), null_dev_size)
+          identical(dev.cur(), null_dev_id) &&
+            identical(dev.size(), null_dev_size)
         }
 
         new_plot <- function() {
@@ -76,7 +77,7 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
               info
             }, all.names = FALSE, USE.NAMES = TRUE)
             jsonlite::write_json(objs, globalenv_file, pretty = FALSE)
-            if (check_null_dev() && plot_updated) {
+            if (plot_updated && check_null_dev()) {
               plot_updated <<- FALSE
               record <- recordPlot()
               if (length(record[[1L]])) {


### PR DESCRIPTION
**What problem did you solve?**

Closes #271 

This PR makes plot update smarter using a magic null dev size so that we can check if the current device is the `NULL` device *we* create as the default device to output graphics. I don't see if there's any better way to help us identify the device we create since user has very limited capability to set metadata and limited access to the information of a device.

Now plot file is open only when graphics functions are called with the `NULL` pdf device we create. So `knitr::knit()` no longer triggers opening existing plot file, and user created device such `png` or other `pdf` will not set `plot_updated = TRUE` so VSCode won't copy the graphics from the current device.

**(If you have)Screenshot**

**(If you do not have screenshot) How can I check this pull request?**

* Basic plot

```r
plot(rnorm(100))
abline(h = 0, col = "red")
# close the plot file
png("test.png") # should not open plot file
plot(rnorm(100)) # should not open plot file
dev.off() # should not open plot file
abline(v = 0, col = "blue") # should open the plot file
```

* `knitr::knit()`

1. Create a Rmd document (e.g. `doc1.Rmd`) with the following content:

````
# hello

Hello, world!

```{r}
plot(rnorm(100))
```
````

2. Call `knitr::knit("doc1.Rmd")`
3. When the function call completes, no plot file appears.
4. Call `plot(rnorm(10))` and the plot file is open. Close this file.
5. Call `knitr::knit("doc1.Rmd")` again and the previous plot file is not open.
