### PR TITLE
Fix R code formatting according to linting results

### DIFF
--- a/R/.lintr
+++ b/R/.lintr
@@ -1,0 +1,1 @@
+linter: with_defaults(cyclocomp_linter = NULL)


### PR DESCRIPTION
This PR fixes the `init.R` code formatting according to linting results and also adds `.lintr` so that unneeded linters are disabled.
