### PR TITLE
Improve .Rprofile

### DIFF
--- a/R/.Rprofile
+++ b/R/.Rprofile
@@ -10,8 +10,7 @@ local({
 
   try_source(Sys.getenv("R_PROFILE_USER_OLD")) ||
     try_source(".Rprofile") ||
-    try_source(file.path("~", ".Rprofile")) ||
-    try_source(file.path(R.home(), "etc", "Rprofile.site"))
+    try_source(file.path("~", ".Rprofile"))
 })
 
 if (is.null(getOption("vscodeR"))) {

--- a/R/.Rprofile
+++ b/R/.Rprofile
@@ -8,9 +8,12 @@ local({
     }
   }
 
-  try_source(Sys.getenv("R_PROFILE_USER_OLD")) ||
-    try_source(".Rprofile") ||
-    try_source(file.path("~", ".Rprofile"))
+  r_profile <- Sys.getenv("R_PROFILE_USER_OLD")
+  if (nzchar(r_profile)) {
+    try_source(r_profile)
+  } else {
+    try_source(".Rprofile") || try_source(file.path("~", ".Rprofile"))
+  }
 })
 
 if (is.null(getOption("vscodeR"))) {

--- a/R/.Rprofile
+++ b/R/.Rprofile
@@ -1,10 +1,18 @@
-if (nzchar(Sys.getenv("R_PROFILE_USER_OLD"))) {
-  source(Sys.getenv("R_PROFILE_USER_OLD"))
-} else if (file.exists(".Rprofile")) {
-  source(".Rprofile")
-} else if (file.exists("~/.Rprofile")) {
-  source("~/.Rprofile")
-}
+local({
+  try_source <- function(file) {
+    if (file.exists(file)) {
+      source(file)
+      TRUE
+    } else {
+      FALSE
+    }
+  }
+
+  try_source(Sys.getenv("R_PROFILE_USER_OLD")) ||
+    try_source(".Rprofile") ||
+    try_source(file.path("~", ".Rprofile")) ||
+    try_source(file.path(R.home(), "etc", "Rprofile.site"))
+})
 
 if (is.null(getOption("vscodeR"))) {
   source(file.path(Sys.getenv(if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"), ".vscode-R", "init.R"))

--- a/R/.Rprofile
+++ b/R/.Rprofile
@@ -14,5 +14,8 @@ local({
 })
 
 if (is.null(getOption("vscodeR"))) {
-  source(file.path(Sys.getenv(if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"), ".vscode-R", "init.R"))
+  source(file.path(
+    Sys.getenv(if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"),
+    ".vscode-R", "init.R")
+  )
 }


### PR DESCRIPTION
This PR reworks `.Rprofile` used to create R terminal so that it could mimic creating R session by user in terminal:

The rule is:

1. If `R_PROFILE_USER` is non-empty then source it if exists. (if the file does not exist, do nothing and it does not continue to source other profiles)
2. If `R_PROFILE_USER` is empty,
2.1 If project profile `.Rprofile` exists, source it, otherwise
2.2 If user profile `~/.Rprofile` exists, source it.
