### PR TITLE
Remove --no-site-file from default r.rterm.option

### DIFF
--- a/package.json
+++ b/package.json
@@ -429,8 +429,7 @@
           "type": "array",
           "default": [
             "--no-save",
-            "--no-restore",
-            "--no-site-file"
+            "--no-restore"
           ],
           "description": "R command line options",
           "items": {


### PR DESCRIPTION
Close #276 

This PR removes `--no-site-file` from the default value of `r.rterm.option`.
