### PR TITLE
Add command Run from Beginning to Line

### DIFF
--- a/package.json
+++ b/package.json
@@ -328,6 +328,11 @@
         "title": "Run Command in Terminal",
         "category": "R",
         "command": "r.runCommand"
+      },
+      {
+        "title": "Run from Beginning to Line",
+        "category": "R",
+        "command": "r.runFromBeginningToLine"
       }
     ],
     "keybindings": [
@@ -389,6 +394,12 @@
         "command": "r.runSourcewithEcho",
         "key": "shift+Ctrl+enter",
         "mac": "shift+cmd+enter",
+        "when": "editorTextFocus && editorLangId == 'r'"
+      },
+      {
+        "command": "r.runFromBeginningToLine",
+        "key": "Ctrl+alt+b",
+        "mac": "cmd+alt+b",
         "when": "editorTextFocus && editorLangId == 'r'"
       }
     ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -137,6 +137,19 @@ export function activate(context: ExtensionContext) {
         runTextInTerm(callableTerminal, rCommand);
     }
 
+    async function runFromBeginningToLine() {
+        const callableTerminal = await chooseTerminal(true);
+        if (callableTerminal === undefined) {
+            return;
+        }
+        const endLine = window.activeTextEditor.selection.end.line;
+        const charactersOnLine = window.activeTextEditor.document.lineAt(endLine).text.length;
+        const endPos = new Position(endLine, charactersOnLine);
+        const range = new Range(new Position(0, 0), endPos);
+        const text = window.activeTextEditor.document.getText(range);
+        runTextInTerm(callableTerminal, text);
+    }
+
     languages.registerCompletionItemProvider('r', {
         provideCompletionItems(document: TextDocument, position: Position) {
             if (document.lineAt(position).text
@@ -171,6 +184,7 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand('r.runSourcewithEcho', () => { runSource(true); }),
         commands.registerCommand('r.runSelection', runSelection),
         commands.registerCommand('r.runSelectionInActiveTerm', runSelectionInActiveTerm),
+        commands.registerCommand('r.runFromBeginningToLine', runFromBeginningToLine),
         commands.registerCommand('r.createGitignore', createGitignore),
         commands.registerCommand('r.previewDataframe', previewDataframe),
         commands.registerCommand('r.previewEnvironment', previewEnvironment),


### PR DESCRIPTION
Closes #288 

**What problem did you solve?**

Adds command `Run from Beginning to Line`. Binds it to <kbd>Ctrl+Alt+B</kbd> (not used by VS Code).

If there is a selection, it uses the line at the END of the selection (like RStudio).

**How can I check this pull request?**

Create `temp.R` with text

```
x <- 1
y <- 2
z <- 3
```

Place cursor anywhere on line `y <- 2`. Run command `Run from Beginning to Line`. Verify that text sent to console is

```
x <- 1
y <- 2
```

Do same thing with selection including both line `x <- 1` and `x <- 2`. Result should be same.