### PR TITLE
Change so setting changes take effect immediately

### DIFF
--- a/package.json
+++ b/package.json
@@ -413,17 +413,17 @@
         "r.rterm.windows": {
           "type": "string",
           "default": "",
-          "description": "R.exe path for windows"
+          "description": "R.exe path for windows."
         },
         "r.rterm.mac": {
           "type": "string",
           "default": "/usr/local/bin/R",
-          "description": "R path for Mac OS X"
+          "description": "R path for Mac OS X."
         },
         "r.rterm.linux": {
           "type": "string",
           "default": "/usr/bin/R",
-          "description": "R path for Linux"
+          "description": "R path for Linux."
         },
         "r.rterm.option": {
           "type": "array",
@@ -431,7 +431,7 @@
             "--no-save",
             "--no-restore"
           ],
-          "description": "R command line options",
+          "description": "R command line options.",
           "items": {
             "type": "string"
           }
@@ -439,7 +439,7 @@
         "r.source.encoding": {
           "type": "string",
           "default": "UTF-8",
-          "description": "An optional encoding to pass to R when executing the file, i.e. 'source(FILE, encoding=ENCODING)'"
+          "description": "An optional encoding to pass to R when executing the file, i.e. 'source(FILE, encoding=ENCODING)'."
         },
         "r.source.focus": {
           "type": "string",
@@ -448,22 +448,22 @@
             "editor",
             "terminal"
           ],
-          "description": "Keeping focus when running"
+          "description": "Keeping focus when running."
         },
         "r.alwaysUseActiveTerminal": {
           "type": "boolean",
           "default": false,
-          "description": "Use active terminal for all commands, rather than creating a new R terminal"
+          "description": "Use active terminal for all commands, rather than creating a new R terminal."
         },
         "r.bracketedPaste": {
           "type": "boolean",
           "default": false,
-          "description": "Use bracketed paste mode when sending code to console. Enable for Radian console"
+          "description": "Use bracketed paste mode when sending code to console. Enable for Radian console."
         },
         "r.sessionWatcher": {
           "type": "boolean",
           "default": false,
-          "description": "Enable R session watcher (experimental). Restart required to take effect"
+          "description": "Enable R session watcher (experimental). Restart required to take effect."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -463,7 +463,7 @@
         "r.sessionWatcher": {
           "type": "boolean",
           "default": false,
-          "description": "Enable R session watcher (experimental)"
+          "description": "Enable R session watcher (experimental). Restart required to take effect"
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@
 // Import the module and reference it with the alias vscode in your code below
 import { CancellationToken, commands, CompletionContext, CompletionItem, CompletionItemKind,
          ExtensionContext, Hover, IndentAction, languages, MarkdownString, Position, Range,
-         StatusBarAlignment, TextDocument, window, workspace } from 'vscode';
+         StatusBarAlignment, TextDocument, window } from 'vscode';
 
 import { previewDataframe, previewEnvironment } from './preview';
 import { createGitignore } from './rGitignore';
@@ -11,7 +11,7 @@ import { chooseTerminal, chooseTerminalAndSendText, createRTerm, deleteTerminal,
          runSelectionInTerm, runTextInTerm } from './rTerminal';
 import { getWordOrSelection, surroundSelection } from './selection';
 import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startResponseWatcher } from './session';
-import { ToRStringLiteral } from './util';
+import { config, ToRStringLiteral } from './util';
 
 const wordPattern = /(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\<\>\/\s]+)/g;
 
@@ -59,7 +59,7 @@ export function activate(context: ExtensionContext) {
         const isSaved = await saveDocument(wad);
         if (isSaved) {
             let rPath: string = ToRStringLiteral(wad.fileName, '"');
-            let encodingParam = workspace.getConfiguration('r').get<string>('source.encoding');
+            let encodingParam = config().get<string>('source.encoding');
             encodingParam = `encoding = "${encodingParam}"`;
             rPath = [rPath, encodingParam].join(', ');
             if (echo) {
@@ -74,7 +74,7 @@ export function activate(context: ExtensionContext) {
         const isSaved = await saveDocument(wad);
         if (isSaved) {
             let rPath = ToRStringLiteral(wad.fileName, '"');
-            let encodingParam = workspace.getConfiguration('r').get<string>('source.encoding');
+            let encodingParam = config().get<string>('source.encoding');
             encodingParam = `encoding = "${encodingParam}"`;
             rPath = [rPath, encodingParam].join(', ');
             if (echo) {
@@ -188,7 +188,7 @@ export function activate(context: ExtensionContext) {
         window.onDidCloseTerminal(deleteTerminal),
     );
 
-    if (workspace.getConfiguration('r').get<boolean>('sessionWatcher')) {
+    if (config().get<boolean>('sessionWatcher')) {
         console.info('Initialize session watcher');
         languages.registerHoverProvider('r', {
             provideHover(document, position, token) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { chooseTerminal, chooseTerminalAndSendText, createRTerm, deleteTerminal,
          runSelectionInTerm, runTextInTerm } from './rTerminal';
 import { getWordOrSelection, surroundSelection } from './selection';
 import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startResponseWatcher } from './session';
-import { config, ToRStringLiteral } from './util';
+import { ToRStringLiteral } from './util';
 
 const wordPattern = /(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\<\>\/\s]+)/g;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@
 // Import the module and reference it with the alias vscode in your code below
 import { CancellationToken, commands, CompletionContext, CompletionItem, CompletionItemKind,
          ExtensionContext, Hover, IndentAction, languages, MarkdownString, Position, Range,
-         StatusBarAlignment, TextDocument, window } from 'vscode';
+         StatusBarAlignment, TextDocument, window, workspace } from 'vscode';
 
 import { previewDataframe, previewEnvironment } from './preview';
 import { createGitignore } from './rGitignore';
@@ -59,7 +59,7 @@ export function activate(context: ExtensionContext) {
         const isSaved = await saveDocument(wad);
         if (isSaved) {
             let rPath: string = ToRStringLiteral(wad.fileName, '"');
-            let encodingParam = config.get<string>('source.encoding');
+            let encodingParam = workspace.getConfiguration('r').get<string>('source.encoding');
             encodingParam = `encoding = "${encodingParam}"`;
             rPath = [rPath, encodingParam].join(', ');
             if (echo) {
@@ -74,7 +74,7 @@ export function activate(context: ExtensionContext) {
         const isSaved = await saveDocument(wad);
         if (isSaved) {
             let rPath = ToRStringLiteral(wad.fileName, '"');
-            let encodingParam = config.get<string>('source.encoding');
+            let encodingParam = workspace.getConfiguration('r').get<string>('source.encoding');
             encodingParam = `encoding = "${encodingParam}"`;
             rPath = [rPath, encodingParam].join(', ');
             if (echo) {
@@ -188,7 +188,7 @@ export function activate(context: ExtensionContext) {
         window.onDidCloseTerminal(deleteTerminal),
     );
 
-    if (config.get<boolean>('sessionWatcher')) {
+    if (workspace.getConfiguration('r').get<boolean>('sessionWatcher')) {
         console.info('Initialize session watcher');
         languages.registerHoverProvider('r', {
             provideHover(document, position, token) {

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -5,7 +5,7 @@ import path = require('path');
 
 import { pathExists } from 'fs-extra';
 import { isDeepStrictEqual } from 'util';
-import { commands, Terminal, TerminalOptions, window } from 'vscode';
+import { commands, Terminal, TerminalOptions, window, workspace } from 'vscode';
 
 import { getSelection } from './selection';
 import { removeSessionFiles } from './session';
@@ -19,7 +19,7 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
     if (termPath === undefined) {
         return undefined;
     }
-    const termOpt: string[] = config.get('rterm.option');
+    const termOpt: string[] = workspace.getConfiguration('r').get('rterm.option');
     pathExists(termPath, (err, exists) => {
         if (exists) {
             const termOptions: TerminalOptions = {
@@ -27,7 +27,7 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
                 shellPath: termPath,
                 shellArgs: termOpt,
             };
-            if (config.get<boolean>('sessionWatcher')) {
+            if (workspace.getConfiguration('r').get<boolean>('sessionWatcher')) {
                 termOptions.env = {
                     R_PROFILE_USER_OLD: process.env.R_PROFILE_USER,
                     R_PROFILE_USER: path.join(os.homedir(), '.vscode-R', '.Rprofile'),
@@ -46,7 +46,7 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
 
 export function deleteTerminal(term: Terminal) {
     if (isDeepStrictEqual(term, rTerm)) {
-        if (config.get<boolean>('sessionWatcher')) {
+        if (workspace.getConfiguration('r').get<boolean>('sessionWatcher')) {
             removeSessionFiles();
         }
         rTerm = undefined;
@@ -54,7 +54,7 @@ export function deleteTerminal(term: Terminal) {
 }
 
 export async function chooseTerminal(active: boolean = false) {
-    if (active || config.get('alwaysUseActiveTerminal')) {
+    if (active || workspace.getConfiguration('r').get('alwaysUseActiveTerminal')) {
         if (window.terminals.length < 1) {
             window.showInformationMessage('There are no open terminals.');
 
@@ -108,7 +108,7 @@ export function runSelectionInTerm(term: Terminal) {
 }
 
 export async function runTextInTerm(term: Terminal, textArray: string[]) {
-    if (textArray.length > 1 && config.get<boolean>('bracketedPaste')) {
+    if (textArray.length > 1 && workspace.getConfiguration('r').get<boolean>('bracketedPaste')) {
         if (process.platform !== 'win32') {
             // Surround with ANSI control characters for bracketed paste mode
             textArray[0] = `\x1b[200~${textArray[0]}`;
@@ -134,6 +134,6 @@ export async function chooseTerminalAndSendText(text: string) {
 }
 
 function setFocus(term: Terminal) {
-    const focus: string = config.get('source.focus');
+    const focus: string = workspace.getConfiguration('r').get('source.focus');
     term.show(focus !== 'terminal');
 }

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -9,7 +9,7 @@ import { commands, Terminal, TerminalOptions, window, workspace } from 'vscode';
 
 import { getSelection } from './selection';
 import { removeSessionFiles } from './session';
-import { config, delay, getRpath } from './util';
+import { delay, getRpath } from './util';
 export let rTerm: Terminal;
 
 export async function createRTerm(preserveshow?: boolean): Promise<boolean> {

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -5,11 +5,11 @@ import path = require('path');
 
 import { pathExists } from 'fs-extra';
 import { isDeepStrictEqual } from 'util';
-import { commands, Terminal, TerminalOptions, window, workspace } from 'vscode';
+import { commands, Terminal, TerminalOptions, window } from 'vscode';
 
 import { getSelection } from './selection';
 import { removeSessionFiles } from './session';
-import { delay, getRpath } from './util';
+import { config, delay, getRpath } from './util';
 export let rTerm: Terminal;
 
 export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
@@ -19,7 +19,7 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
     if (termPath === undefined) {
         return undefined;
     }
-    const termOpt: string[] = workspace.getConfiguration('r').get('rterm.option');
+    const termOpt: string[] = config().get('rterm.option');
     pathExists(termPath, (err, exists) => {
         if (exists) {
             const termOptions: TerminalOptions = {
@@ -27,7 +27,7 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
                 shellPath: termPath,
                 shellArgs: termOpt,
             };
-            if (workspace.getConfiguration('r').get<boolean>('sessionWatcher')) {
+            if (config().get<boolean>('sessionWatcher')) {
                 termOptions.env = {
                     R_PROFILE_USER_OLD: process.env.R_PROFILE_USER,
                     R_PROFILE_USER: path.join(os.homedir(), '.vscode-R', '.Rprofile'),
@@ -46,7 +46,7 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
 
 export function deleteTerminal(term: Terminal) {
     if (isDeepStrictEqual(term, rTerm)) {
-        if (workspace.getConfiguration('r').get<boolean>('sessionWatcher')) {
+        if (config().get<boolean>('sessionWatcher')) {
             removeSessionFiles();
         }
         rTerm = undefined;
@@ -54,7 +54,7 @@ export function deleteTerminal(term: Terminal) {
 }
 
 export async function chooseTerminal(active: boolean = false) {
-    if (active || workspace.getConfiguration('r').get('alwaysUseActiveTerminal')) {
+    if (active || config().get('alwaysUseActiveTerminal')) {
         if (window.terminals.length < 1) {
             window.showInformationMessage('There are no open terminals.');
 
@@ -108,7 +108,7 @@ export function runSelectionInTerm(term: Terminal) {
 }
 
 export async function runTextInTerm(term: Terminal, textArray: string[]) {
-    if (textArray.length > 1 && workspace.getConfiguration('r').get<boolean>('bracketedPaste')) {
+    if (textArray.length > 1 && config().get<boolean>('bracketedPaste')) {
         if (process.platform !== 'win32') {
             // Surround with ANSI control characters for bracketed paste mode
             textArray[0] = `\x1b[200~${textArray[0]}`;
@@ -134,6 +134,6 @@ export async function chooseTerminalAndSendText(text: string) {
 }
 
 function setFocus(term: Terminal) {
-    const focus: string = workspace.getConfiguration('r').get('source.focus');
+    const focus: string = config().get('source.focus');
     term.show(focus !== 'terminal');
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -8,6 +8,7 @@ import { URL } from 'url';
 import { commands, FileSystemWatcher, RelativePattern, StatusBarItem, Uri, ViewColumn, Webview, window, workspace } from 'vscode';
 
 import { chooseTerminalAndSendText } from './rTerminal';
+import { config } from './util';
 
 export let globalenv: any;
 let responseWatcher: FileSystemWatcher;
@@ -49,7 +50,7 @@ export function startResponseWatcher(sessionStatusBarItem: StatusBarItem) {
 }
 
 export function attachActive() {
-    if (workspace.getConfiguration('r').get<boolean>('sessionWatcher')) {
+    if (config().get<boolean>('sessionWatcher')) {
         console.info('[attachActive]');
         chooseTerminalAndSendText('getOption(\'vscodeR\')$attach()');
     } else {
@@ -329,7 +330,7 @@ async function getListHtml(webview: Webview, file: string) {
 }
 
 export async function showPlotHistory() {
-    if (workspace.getConfiguration('r').get<boolean>('sessionWatcher')) {
+    if (config().get<boolean>('sessionWatcher')) {
         if (plotDir === undefined) {
             window.showErrorMessage('No session is attached.');
         } else {

--- a/src/session.ts
+++ b/src/session.ts
@@ -8,7 +8,6 @@ import { URL } from 'url';
 import { commands, FileSystemWatcher, RelativePattern, StatusBarItem, Uri, ViewColumn, Webview, window, workspace } from 'vscode';
 
 import { chooseTerminalAndSendText } from './rTerminal';
-import { config } from './util';
 
 export let globalenv: any;
 let responseWatcher: FileSystemWatcher;

--- a/src/session.ts
+++ b/src/session.ts
@@ -50,7 +50,7 @@ export function startResponseWatcher(sessionStatusBarItem: StatusBarItem) {
 }
 
 export function attachActive() {
-    if (config.get<boolean>('sessionWatcher')) {
+    if (workspace.getConfiguration('r').get<boolean>('sessionWatcher')) {
         console.info('[attachActive]');
         chooseTerminalAndSendText('getOption(\'vscodeR\')$attach()');
     } else {
@@ -330,7 +330,7 @@ async function getListHtml(webview: Webview, file: string) {
 }
 
 export async function showPlotHistory() {
-    if (config.get<boolean>('sessionWatcher')) {
+    if (workspace.getConfiguration('r').get<boolean>('sessionWatcher')) {
         if (plotDir === undefined) {
             window.showErrorMessage('No session is attached.');
         } else {

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,9 +5,13 @@ import path = require('path');
 import { window, workspace } from 'vscode';
 import winreg = require('winreg');
 
+export function config() {
+    return workspace.getConfiguration('r');
+}
+
 export async function getRpath() {
     if (process.platform === 'win32') {
-        let rpath: string = workspace.getConfiguration('r').get<string>('rterm.windows');
+        let rpath: string = config().get<string>('rterm.windows');
         if (rpath === '') {
             // Find path from registry
             try {
@@ -26,10 +30,10 @@ export async function getRpath() {
         return rpath;
     }
     if (process.platform === 'darwin') {
-        return workspace.getConfiguration('r').get<string>('rterm.mac');
+        return config().get<string>('rterm.mac');
     }
     if (process.platform === 'linux') {
-        return workspace.getConfiguration('r').get<string>('rterm.linux');
+        return config().get<string>('rterm.linux');
     }
     window.showErrorMessage(`${process.platform} can't use R`);
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,7 +4,6 @@ import { existsSync } from 'fs-extra';
 import path = require('path');
 import { window, workspace } from 'vscode';
 import winreg = require('winreg');
-export let config = workspace.getConfiguration('r');
 
 export async function getRpath() {
     if (process.platform === 'win32') {

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,7 +8,7 @@ export let config = workspace.getConfiguration('r');
 
 export async function getRpath() {
     if (process.platform === 'win32') {
-        let rpath: string = config.get<string>('rterm.windows');
+        let rpath: string = workspace.getConfiguration('r').get<string>('rterm.windows');
         if (rpath === '') {
             // Find path from registry
             try {
@@ -27,10 +27,10 @@ export async function getRpath() {
         return rpath;
     }
     if (process.platform === 'darwin') {
-        return config.get<string>('rterm.mac');
+        return workspace.getConfiguration('r').get<string>('rterm.mac');
     }
     if (process.platform === 'linux') {
-        return config.get<string>('rterm.linux');
+        return workspace.getConfiguration('r').get<string>('rterm.linux');
     }
     window.showErrorMessage(`${process.platform} can't use R`);
 


### PR DESCRIPTION
Closes #299 

**What problem did you solve?**

Currently, changing a vscode-R setting requires a reload of the extension before the setting change takes effect. This PR makes setting changes take effect immediately.

**How can I check this pull request?**

Create a file `temp.R` with content

```
echo "Hello World"
```

Enable setting `R: Always Use Active Terminal`.

Open a terminal. Do NOT start R.

<kbd>Ctrl+Enter</kbd> in `temp.R`.

Observe that `Hello World` is sent to the terminal.

Disable setting `R: Always Use Active Terminal`.

<kbd>Ctrl+Enter</kbd> in `temp.R`.

Observe that a new R session starts in the terminal (with an error because `echo` is not valid R code).

Previously, `R: Always Use Active Terminal` would not have taken effect until the extension was reloaded (e.g., by restarting VS Code).
