### PR TITLE
Refine .Rprofile to remove unnecessary printing in R startup message.

### DIFF
--- a/R/.Rprofile
+++ b/R/.Rprofile
@@ -14,6 +14,8 @@ local({
   } else {
     try_source(".Rprofile") || try_source(file.path("~", ".Rprofile"))
   }
+
+  invisible()
 })
 
 if (is.null(getOption("vscodeR"))) {


### PR DESCRIPTION
**What problem did you solve?**

An uncessary `[1] TRUE` is printed at startup if user runs `R: Create R terminal`, which is caused by `local(...)` in `R/.Rprofile` returning a logical value visibly.

**(If you have)Screenshot**

<img width="445" alt="image" src="https://user-images.githubusercontent.com/4662568/80866936-05fa7480-8cc4-11ea-8e06-d91d74b03c06.png">

**(If you do not have screenshot) How can I check this pull request?**

1. Create R terminal
2. `[1] TRUE` should not appear in the startup message.
