### PR TITLE
Use bracketed paste for more commands #294

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,13 +110,12 @@ export function activate(context: ExtensionContext) {
             return;
         }
         const text = getWordOrSelection();
-        const wrappedText = surroundSelection(text, rFunctionName).join('\n');
+        const wrappedText = surroundSelection(text, rFunctionName);
         runTextInTerm(callableTerminal, wrappedText);
     }
 
     async function runCommandWithSelectionOrWord(rCommand: string) {
-        const text = getWordOrSelection()
-                    .join('\n');
+        const text = getWordOrSelection();
         const callableTerminal = await chooseTerminal();
         const call = rCommand.replace(/\$\$/g, text);
         runTextInTerm(callableTerminal, call);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,7 +110,7 @@ export function activate(context: ExtensionContext) {
             return;
         }
         const text = getWordOrSelection();
-        const wrappedText = surroundSelection(text, rFunctionName);
+        const wrappedText = surroundSelection(text, rFunctionName).join('\n');
         runTextInTerm(callableTerminal, wrappedText);
     }
 
@@ -119,7 +119,7 @@ export function activate(context: ExtensionContext) {
                     .join('\n');
         const callableTerminal = await chooseTerminal();
         const call = rCommand.replace(/\$\$/g, text);
-        runTextInTerm(callableTerminal, [call]);
+        runTextInTerm(callableTerminal, call);
     }
 
     async function runCommandWithEditorPath(rCommand: string) {
@@ -129,13 +129,13 @@ export function activate(context: ExtensionContext) {
             const callableTerminal = await chooseTerminal();
             const rPath = ToRStringLiteral(wad.fileName, '');
             const call = rCommand.replace(/\$\$/g, rPath);
-            runTextInTerm(callableTerminal, [call]);
+            runTextInTerm(callableTerminal, call);
         }
     }
 
     async function runCommand(rCommand: string) {
         const callableTerminal = await chooseTerminal();
-        runTextInTerm(callableTerminal, [rCommand]);
+        runTextInTerm(callableTerminal, rCommand);
     }
 
     languages.registerCompletionItemProvider('r', {

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -104,19 +104,18 @@ export function runSelectionInTerm(term: Terminal) {
         commands.executeCommand('cursorMove', { to: 'down', value: selection.linesDownToMoveCursor });
         commands.executeCommand('cursorMove', { to: 'wrappedLineFirstNonWhitespaceCharacter' });
     }
-    runTextInTerm(term, selection.selectedTextArray);
+    runTextInTerm(term, selection.selectedText);
 }
 
-export async function runTextInTerm(term: Terminal, textArray: string[]) {
-    if (textArray.length > 1 && config().get<boolean>('bracketedPaste')) {
+export async function runTextInTerm(term: Terminal, text: string) {
+    if (config().get<boolean>('bracketedPaste')) {
         if (process.platform !== 'win32') {
             // Surround with ANSI control characters for bracketed paste mode
-            textArray[0] = `\x1b[200~${textArray[0]}`;
-            textArray[textArray.length - 1] += '\x1b[201~';
+            text = `\x1b[200~${text}\x1b[201~`;
         }
-        term.sendText(textArray.join('\n'));
+        term.sendText(text);
     } else {
-        for (const line of textArray) {
+        for (const line of text.split('\n')) {
             await delay(8); // Increase delay if RTerm can't handle speed.
             term.sendText(line);
         }

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -34,7 +34,7 @@ export function surroundSelection(textArray: string[], rFunctionName: string[]) 
 }
 
 export function getSelection() {
-    const selection = { linesDownToMoveCursor: 0, selectedTextArray: [] };
+    const selection = { linesDownToMoveCursor: 0, selectedText: '' };
     const { start, end } = window.activeTextEditor.selection;
     const currentDocument = window.activeTextEditor.document;
     const range = new Range(start, end);
@@ -50,7 +50,7 @@ export function getSelection() {
         selectedLine = currentDocument.getText(new Range(newStart, newEnd));
     } else if (start.line === end.line) {
         selection.linesDownToMoveCursor = 0;
-        selection.selectedTextArray = [currentDocument.getText(new Range(start, end))];
+        selection.selectedText = currentDocument.getText(new Range(start, end));
 
         return selection;
     } else {
@@ -58,7 +58,7 @@ export function getSelection() {
     }
 
     const selectedTextArray = selectedLine.split('\n');
-    selection.selectedTextArray = removeCommentedLines(selectedTextArray);
+    selection.selectedText = removeCommentedLines(selectedTextArray).join('\n');
 
     return selection;
 }

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -61,12 +61,7 @@ export function getSelection() {
 }
 
 function removeCommentedLines(selection: string): string {
-    const selectionWithoutComments = [];
-    selection.split('\n').forEach((line) => {
-        if (!checkForBlankOrComment(line)) { selectionWithoutComments.push(line); }
-    });
-
-    return selectionWithoutComments.join('\n');
+    return selection.split('\n').filter((line) => !checkForBlankOrComment(line)).join('\n');
 }
 
 export function checkForBlankOrComment(line: string): boolean {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -4,7 +4,7 @@ import { Position, Range, window } from 'vscode';
 
 import { LineCache } from './lineCache';
 
-export function getWordOrSelection() {
+export function getWordOrSelection(): string {
     const selection = window.activeTextEditor.selection;
     const currentDocument = window.activeTextEditor.document;
     let text: string;
@@ -16,21 +16,19 @@ export function getWordOrSelection() {
         text = currentDocument.getText(window.activeTextEditor.selection);
     }
 
-    return text.split('\n');
+    return text;
 }
 
-export function surroundSelection(textArray: string[], rFunctionName: string[]) {
+export function surroundSelection(text: string, rFunctionName: string[]): string {
     if (rFunctionName && rFunctionName.length) {
         let rFunctionCall = '';
         for (const feature of rFunctionName) {
             rFunctionCall += `${feature}(`;
         }
-        textArray[0] = rFunctionCall + textArray[0].trimLeft();
-        const end = textArray.length - 1;
-        textArray[end] = textArray[end].trimRight() + ')'.repeat(rFunctionName.length);
+        text = rFunctionCall + text.trim() + ')'.repeat(rFunctionName.length);
     }
 
-    return textArray;
+    return text;
 }
 
 export function getSelection() {
@@ -57,19 +55,18 @@ export function getSelection() {
         selectedLine = currentDocument.getText(new Range(start, end));
     }
 
-    const selectedTextArray = selectedLine.split('\n');
-    selection.selectedText = removeCommentedLines(selectedTextArray).join('\n');
+    selection.selectedText = removeCommentedLines(selectedLine);
 
     return selection;
 }
 
-function removeCommentedLines(selection: string[]): string[] {
+function removeCommentedLines(selection: string): string {
     const selectionWithoutComments = [];
-    selection.forEach((line) => {
+    selection.split('\n').forEach((line) => {
         if (!checkForBlankOrComment(line)) { selectionWithoutComments.push(line); }
     });
 
-    return selectionWithoutComments;
+    return selectionWithoutComments.join('\n');
 }
 
 export function checkForBlankOrComment(line: string): boolean {


### PR DESCRIPTION
Fixes #294 

**What problem did you solve?**

Bracketed paste is not used by several of the commands that send text to the console. This PR fixes that.

The fix is changing `runTextInTerm` to take a `string` with newline characters, instead of a `string[]` that is assumed to be split on newline characters. This is consistent with how `runTextInTerm` is actually being called in most cases.

I have also done some tidying by changing in the same way the other functions that process lines of code. This tidying should not affect behaviour.

**How can I check this pull request?**

Requirements:
- Linux/Mac
- radian
- Bracketed paste enabled

Add this to `keybindings.json`:

```
{
    "key": "ctrl+1",
    "command": "r.runCommand",
    "args": "{\n1\n2"
}
```

Run command using <kbd>Ctrl+1</kbd>

Observe this output (if using radian):

```
r$> {
    1
    2
```

This should be tested with:

1. R, bracketed paste off
2. radian, bracketed paste on, on Windows, 
3. radian, bracketed paste on, on Linux/Mac

## Other tests

This PR affects all the functions that send text to the console. I have tested these to check that their behaviour is as expected, in Linux+radian, Linux+R, Windows+radian, Windows+R:

**Wrap selection**

In editor, type text 'iris', <kbd>Ctrl+4</kbd>. Should print result of `t(head(iris))`.

**Run command with selection**

```
{
    "key": "ctrl+2",
    "command": "r.runCommandWithSelectionOrWord",
    "args": "print($$)"
}
```

In editor, type text 'iris', <kbd>Ctrl+2</kbd>. Should print content of `iris`.

**Run command with editor path**

```
{
        "key": "ctrl+3",
        "command": "r.runCommandWithEditorPath",
        "args": "print(\"$$\")"
}
```

In editor, <kbd>Ctrl+3</kbd>. Should print current file's path.

**Run selections**

Using the following code block:

```
c(1, 2,
# Comment
3, 4)
```

1. Place the cursor on third line, <kbd>Ctrl+Enter</kbd>. All the text (without the comment) should be sent.
1. Select the third line, <kbd>Ctrl+Enter</kbd>. Just that line should be sent.
1. Select from '2' to '3', <kbd>Ctrl+Enter</kbd>. The selection (without the comment) should be sent.