### PR TITLE
Fix typo in showWebView

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -191,7 +191,7 @@ async function showWebView(file: string, viewColumn: ViewColumn) {
         });
     const content = await fs.readFile(file);
     const html = content.toString()
-        .replace('<body>', '<body style="color: black;"')
+        .replace('<body>', '<body style="color: black;">')
         .replace(/<(\w+)\s+(href|src)="(?!\w+:)/g,
                  `<$1 $2="${String(panel.webview.asWebviewUri(Uri.file(dir)))}/`);
     panel.webview.html = html;


### PR DESCRIPTION
**What problem did you solve?**

Closes #309 

**(If you have)Screenshot**

<img width="568" alt="image" src="https://user-images.githubusercontent.com/4662568/81074954-4bb17a00-8f1c-11ea-9cd7-24a013a3167d.png">

**(If you do not have screenshot) How can I check this pull request?**

Run the following code and the webview should look like above:

```r
library(knitr)
library(kableExtra)
dt <- mtcars[1:5, 1:4]

# HTML table
kable(dt, format = "html", caption = "Demo Table") %>%
  kable_styling(bootstrap_options = "striped",
    full_width = F) %>%
  add_header_above(c(" ", "Group 1" = 2, "Group 2[note]" = 2)) %>%
  add_footnote(c("table footnote"))
```


