### PR TITLE
merge 3 repeated keyword.operator.comparison.r in r.json file.

### DIFF
--- a/syntax/r.json
+++ b/syntax/r.json
@@ -175,19 +175,13 @@
                 {
                     "match": "(\\-|\\+|\\*|\\/|%\\/%|%%|%\\*%|%o%|%x%|\\^)",
                     "name": "keyword.operator.arithmetic.r"
-                },{
-                    "match": "<=|>=",
-                    "name": "keyword.operator.comparison.r"
-                },{
-                    "match": "==",
-                    "name": "keyword.operator.comarison.r"
                 },
                 {
                     "match": "(:=|<-|<<-|->|->>)",
                     "name": "keyword.operator.assignment.r"
                 },
                 {
-                    "match": "(!=|<>|<|>|%in%)",
+                    "match": "(==|<=|>=|!=|<>|<|>|%in%)",
                     "name": "keyword.operator.comparison.r"
                 },
                 {


### PR DESCRIPTION
**What problem did you solve?**
I found there are two Def. of keyword.operator.comparison.r and one keyword.operator.comarison.r (without letter p), I think it is a typo, so I put them together.
**(If you have)Screenshot**
No
**(If you do not have screenshot) How can I check this pull request?**
Please use _diff_ to check the changes.