### PR TITLE
extendSelection only handles brackets outside quotes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
           node-version: "13.x"
       - run: npm ci
       - name: Run eslint
-        run: ./node_modules/.bin/eslint -c ./.eslintrc.js src/*.ts test/*.ts
+        run: ./node_modules/.bin/eslint -c ./.eslintrc.js './src/**'
   lintr:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
           node-version: "13.x"
       - run: npm ci
       - name: Run eslint
-        run: ./node_modules/.bin/eslint -c ./.eslintrc.js src/*.ts
+        run: ./node_modules/.bin/eslint -c ./.eslintrc.js src/*.ts test/*.ts
   lintr:
     runs-on: ubuntu-latest
     container:

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -220,17 +220,17 @@ export function extendSelection(line: number, getLine: (line: number) => string,
                 }
             }
         } else {
-            if (lookingForward) {
-                if (nextChar === quoteChar && curChar !== '\\') {
-                    quoteChar = '';
-                }
-            } else {
-                if (nextChar === quoteChar) {
+            if (nextChar === quoteChar) {
+                if (lookingForward) {
+                    if (curChar !== '\\') {
+                        quoteChar = '';
+                    }
+                } else {
                     const next = getNextChar(poss[lookingForward ? 1 : 0],
-                            lookingForward,
-                            getLineFromCache,
-                            getEndsInOperatorFromCache,
-                            lineCount);
+                        lookingForward,
+                        getLineFromCache,
+                        getEndsInOperatorFromCache,
+                        lineCount);
                     if (next.nextChar !== '\\') {
                         quoteChar = '';
                     }

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -87,6 +87,10 @@ function isBracket(c: string, lookingForward: boolean) {
     return ((c === ')') || (c === ']') || (c === '}'));
 }
 
+function isQuote(c: string) {
+    return c === '"' || c === '\'' || c === '`';
+}
+
 /**
  * From a given position, return the 'next' character, its position in the document,
  * whether it is start/end of a code line (possibly broken over multiple text lines), and whether it is the
@@ -188,7 +192,9 @@ export function extendSelection(line: number, getLine: (line: number) => string,
     const poss = { 0: new PositionNeg(line, 0), 1: new PositionNeg(line, -1) };
     const flagsFinish = { 0: false, 1: false }; // 1 represents looking forward, 0 represents looking back.
     let flagAbort = false;
-    const unmatched = { 0: [] as string[], 1: [] as string[]};
+    const unmatched = { 0: [] as string[], 1: [] as string[] };
+    let curChar = '';
+    let quoteChar = '';
     while (!flagAbort && !(flagsFinish[0] && flagsFinish[1])) {
         const { nextChar, nextPos, isEndOfCodeLine, isEndOfFile }
         = getNextChar(poss[lookingForward ? 1 : 0],
@@ -197,17 +203,42 @@ export function extendSelection(line: number, getLine: (line: number) => string,
                       getEndsInOperatorFromCache,
                       lineCount);
         poss[Number(lookingForward)] = nextPos;
-        if (isBracket(nextChar, lookingForward)) {
-            unmatched[lookingForward ? 1 : 0].push(nextChar);
-        } else if (isBracket(nextChar, !lookingForward)) {
-            if (unmatched[lookingForward ? 1 : 0].length === 0) {
-                lookingForward = !lookingForward;
-                unmatched[lookingForward ? 1 : 0].push(nextChar);
-                flagsFinish[Number(lookingForward)] = false;
-            } else if (!doBracketsMatch(nextChar, unmatched[lookingForward ? 1 : 0].pop())) {
-                flagAbort = true;
+        if (quoteChar === '') {
+            if (isQuote(nextChar)) {
+                quoteChar = nextChar;
+            } else {
+                if (isBracket(nextChar, lookingForward)) {
+                    unmatched[lookingForward ? 1 : 0].push(nextChar);
+                } else if (isBracket(nextChar, !lookingForward)) {
+                    if (unmatched[lookingForward ? 1 : 0].length === 0) {
+                        lookingForward = !lookingForward;
+                        unmatched[lookingForward ? 1 : 0].push(nextChar);
+                        flagsFinish[Number(lookingForward)] = false;
+                    } else if (!doBracketsMatch(nextChar, unmatched[lookingForward ? 1 : 0].pop())) {
+                        flagAbort = true;
+                    }
+                }
             }
-        } else if (isEndOfCodeLine) {
+        } else {
+            if (lookingForward) {
+                if (nextChar === quoteChar && curChar !== '\\') {
+                    quoteChar = '';
+                }
+            } else {
+                if (nextChar === quoteChar) {
+                    const next = getNextChar(poss[lookingForward ? 1 : 0],
+                            lookingForward,
+                            getLineFromCache,
+                            getEndsInOperatorFromCache,
+                            lineCount);
+                    if (next.nextChar !== '\\') {
+                        quoteChar = '';
+                    }
+                }
+            }
+        }
+
+        if (isEndOfCodeLine) {
             if (unmatched[lookingForward ? 1 : 0].length === 0) {
                 // We have found everything we need to in this direction. Continue looking in the other direction.
                 flagsFinish[Number(lookingForward)] = true;
@@ -217,6 +248,8 @@ export function extendSelection(line: number, getLine: (line: number) => string,
                 flagAbort = true;
             }
         }
+        
+        curChar = nextChar;
     }
     if (flagAbort) {
         return ({ startLine: line, endLine: line });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -496,18 +496,6 @@ suite('Extension Tests', () => {
         })
         `.split('\n');
         function f(i) { return (doc[i]); }
-        assert.equal(extendSelection(1, f, doc.length).endLine, 3);
-        assert.equal(extendSelection(3, f, doc.length).startLine, 0);
-        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
-    });
-
-    test('Selecting multi-line brackets with escaped quote', () => {
-        const doc = `
-        lapply(1:5, function(i) {
-            paste0("\"", i)
-        })
-        `.split('\n');
-        function f(i) { return (doc[i]); }
         assert.equal(extendSelection(1, f, doc.length).startLine, 0);
         assert.equal(extendSelection(1, f, doc.length).endLine, 3);
         assert.equal(extendSelection(3, f, doc.length).startLine, 0);
@@ -529,16 +517,30 @@ suite('Extension Tests', () => {
         assert.equal(extendSelection(3, f, doc.length).endLine, 3);
     });
 
-    test('Selecting multi-line brackets with escaped quotes', () => {
+    test('Selecting multi-line brackets with escaped quote', () => {
         const doc = `
-        print("\"hello"
+        lapply(1:5, function(i) {
+            paste0("\\"", i)
+        })
+        `.split('\n');
+        function f(i) { return (doc[i]); }
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
+    });
+
+    test('Selecting multi-line brackets with escaped quotes in multi-line string', () => {
+        const doc = `
+        print("\\"hello
+        hello\\""
         )
         `.split('\n');
         function f(i) { return (doc[i]); }
         assert.equal(extendSelection(1, f, doc.length).startLine, 0);
-        assert.equal(extendSelection(1, f, doc.length).endLine, 2);
-        assert.equal(extendSelection(2, f, doc.length).startLine, 0);
-        assert.equal(extendSelection(2, f, doc.length).endLine, 2);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
     });
 
     test('Selecting multi-line brackets with multi-line string and unmatched brackets', () => {
@@ -551,9 +553,9 @@ suite('Extension Tests', () => {
         `.split('\n');
         function f(i) { return (doc[i]); }
         assert.equal(extendSelection(1, f, doc.length).startLine, 0);
-        assert.equal(extendSelection(1, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 5);
         assert.equal(extendSelection(5, f, doc.length).startLine, 0);
-        assert.equal(extendSelection(5, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(5, f, doc.length).endLine, 5);
     });
 
     test('Selecting multi-line expression with escaped backtick and ending operator', () => {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -449,4 +449,123 @@ suite('Extension Tests', () => {
         assert.equal(extendSelection(9, f, doc.length).endLine, 9);
     });
 
+    test('Selecting multi-line bracket with unmatched brackets in string', () => {
+        const doc = `
+        lapply(1:5, function(i) {
+            paste0("[[", i)
+        })
+        `.split('\n');
+        function f(i) { return (doc[i]); }
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
+    });
+
+    test('Selecting multi-line call with square bracket function', () => {
+        const doc = `
+        \`[[\`(
+            c(1, 2, 3),
+        3
+        )
+        `.split('\n');
+        function f(i) { return (doc[i]); }
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(4, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(4, f, doc.length).endLine, 4);
+    });
+
+    test('Selecting multi-line function definition with unmatched bracket', () => {
+        const doc = `
+        \`[.test\` <- function(x, i) {
+            x[i]
+        }
+        `.split('\n');
+        function f(i) { return (doc[i]); }
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
+    });
+
+    test('Selecting multi-line brackets with mixed quotes', () => {
+        const doc = `
+        lapply(1:5, function(i) {
+            paste0('"', i)
+        })
+        `.split('\n');
+        function f(i) { return (doc[i]); }
+        assert.equal(extendSelection(1, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
+    });
+
+    test('Selecting multi-line brackets with escaped quote', () => {
+        const doc = `
+        lapply(1:5, function(i) {
+            paste0("\"", i)
+        })
+        `.split('\n');
+        function f(i) { return (doc[i]); }
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
+    });
+
+    test('Selecting multi-line brackets with pipe and unmatched bracket in string', () => {
+        const doc = `
+        list(x = 1,
+            y = "[") %>%
+            print()
+        `.split('\n');
+        function f(i) { return (doc[i]); }
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 3);
+        assert.equal(extendSelection(3, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(3, f, doc.length).endLine, 3);
+    });
+
+    test('Selecting multi-line brackets with escaped quotes', () => {
+        const doc = `
+        print("\"hello"
+        )
+        `.split('\n');
+        function f(i) { return (doc[i]); }
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 2);
+    });
+
+    test('Selecting multi-line brackets with multi-line string and unmatched brackets', () => {
+        const doc = `
+        print("
+            # hello
+            [ is a function
+            \`[[\` is also a function"
+        )
+        `.split('\n');
+        function f(i) { return (doc[i]); }
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 4);
+        assert.equal(extendSelection(5, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(5, f, doc.length).endLine, 4);
+    });
+
+    test('Selecting multi-line expression with escaped backtick and ending operator', () => {
+        const doc = `
+        \`hello\\\`\` +
+            1
+        `.split('\n');
+        function f(i) { return (doc[i]); }
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 2);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 2);
+    });
+
 });


### PR DESCRIPTION
**What problem did you solve?**

Closes #173 

This PR enhances `extendSelection` so that it could handle string and symbol enclosed between quotes (`"`, `'`, `` ` ``). Raw string is not yet handled due to its complexity. This should be working for most cases at the moment.

**(If you do not have screenshot) How can I check this pull request?**

Put cursor at the first and last line of each code chunk and send it to terminal via `extendSelection`, and all should work and send code correctly.

```r
lapply(1:5, function(i) {
  paste0("[[", i)
})

`[[`(
  c(1, 2, 3),
  3
)

`[.test` <- function(x, i) {
  x[i]
}

lapply(1:5, function(i) {
  paste0("\"", i)
})

lapply(1:5, function(i) {
  paste0('"', i)
})

lapply(1:5, function(i) {
  paste0('\"\'', i)
})

print("
  # hello
  [ is a function
  `[[` is also a function"
)

print("\"hello"    
)
```

The following example should send the same code to terminal when cursor is at any line from 2 to 4.

```r
library(magrittr)
list(x = 1,
  y = "[") %>%
  print()
```