### PR TITLE
Fix lintr github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install apt-get dependencies
         run: |
           apt-get update
-          apt-get install git ssh curl bzip2 libffi6 libffi-dev -y
+          apt-get install git ssh curl bzip2 -y
       - name: Install lintr
         run: |
           Rscript -e "install.packages('lintr', repos = 'https://cloud.r-project.org')"


### PR DESCRIPTION
This PR fixes lintr github actions failure due to recent update of `rocker/tidyverse:latest`.
