### PR TITLE
Add r.runSelectionRetainCursor

### DIFF
--- a/package.json
+++ b/package.json
@@ -333,6 +333,11 @@
         "title": "Run from Beginning to Line",
         "category": "R",
         "command": "r.runFromBeginningToLine"
+      },
+      {
+        "title": "Run Selection/Line (Retain Cursor)",
+        "category": "R",
+        "command": "r.runSelectionRetainCursor"
       }
     ],
     "keybindings": [
@@ -347,6 +352,12 @@
         "key": "Ctrl+enter",
         "mac": "cmd+enter",
         "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
+        "command": "r.runSelectionRetainCursor",
+        "key": "alt+enter",
+        "mac": "option+enter",
+        "when": "editorTextFocus && editorLangId == 'r'"
       },
       {
         "command": "r.nrow",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,7 +93,7 @@ export function activate(context: ExtensionContext) {
         if (callableTerminal === undefined) {
             return;
         }
-        runSelectionInTerm(callableTerminal);
+        runSelectionInTerm(callableTerminal, true);
     }
 
     async function runSelectionInActiveTerm() {
@@ -101,7 +101,15 @@ export function activate(context: ExtensionContext) {
         if (callableTerminal === undefined) {
             return;
         }
-        runSelectionInTerm(callableTerminal);
+        runSelectionInTerm(callableTerminal, true);
+    }
+
+    async function runSelectionRetainCursor() {
+        const callableTerminal = await chooseTerminal();
+        if (callableTerminal === undefined) {
+            return;
+        }
+        runSelectionInTerm(callableTerminal, false);
     }
 
     async function runSelectionOrWord(rFunctionName: string[]) {
@@ -185,6 +193,7 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand('r.runSelection', runSelection),
         commands.registerCommand('r.runSelectionInActiveTerm', runSelectionInActiveTerm),
         commands.registerCommand('r.runFromBeginningToLine', runFromBeginningToLine),
+        commands.registerCommand('r.runSelectionRetainCursor', runSelectionRetainCursor),
         commands.registerCommand('r.createGitignore', createGitignore),
         commands.registerCommand('r.previewDataframe', previewDataframe),
         commands.registerCommand('r.previewEnvironment', previewEnvironment),

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -98,9 +98,9 @@ export async function chooseTerminal(active: boolean = false) {
     return rTerm;
 }
 
-export function runSelectionInTerm(term: Terminal) {
+export function runSelectionInTerm(term: Terminal, moveCursor: boolean) {
     const selection = getSelection();
-    if (selection.linesDownToMoveCursor > 0) {
+    if (moveCursor && selection.linesDownToMoveCursor > 0) {
         commands.executeCommand('cursorMove', { to: 'down', value: selection.linesDownToMoveCursor });
         commands.executeCommand('cursorMove', { to: 'wrappedLineFirstNonWhitespaceCharacter' });
     }


### PR DESCRIPTION
**What problem did you solve?**

Closes #324 

This PR adds a new command `r.runSelectionRetainCursor` that runs selection but does not move cursor.

**(If you do not have screenshot) How can I check this pull request?**

Run command `r.runSelectionRetainCursor` when cursor is at the first line of the following code:

```r
m <- rnorm(100)
n <- rnorm(100)
```

then the first line should be sent to terminal but the cursor does not move.

It should also work with multi-line expression. Run when cursor is at first of last line:

```r
m <- local({
  x <- rnorm(100)
  y <- rnorm(100)
})
```

Both should send the entire expression but cursor should not move.