### PR TITLE
Enable default R location to be used on mac/linux if none is supplied

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -2,11 +2,23 @@
 
 import { existsSync } from 'fs-extra';
 import path = require('path');
+import fs = require('fs');
 import { window, workspace } from 'vscode';
 import winreg = require('winreg');
 
 export function config() {
     return workspace.getConfiguration('r');
+}
+
+function getMacLinuxRpath() {
+    const os_paths: string[]|string = process.env.PATH.split(':');
+    for (const os_path of os_paths) {
+        const os_r_path: string = path.join(os_path, 'R');
+        if (fs.existsSync(os_r_path)) {
+            return os_r_path;
+        }
+    }
+    return '';
 }
 
 export async function getRpath() {
@@ -30,10 +42,18 @@ export async function getRpath() {
         return rpath;
     }
     if (process.platform === 'darwin') {
-        return config().get<string>('rterm.mac');
+        let rpath: string = config().get<string>('rterm.mac');
+        if (rpath === '') {
+            rpath = getMacLinuxRpath();
+        }
+        return rpath;
     }
     if (process.platform === 'linux') {
-        return config().get<string>('rterm.linux');
+        let rpath: string = config().get<string>('rterm.linux');
+        if (rpath === '') {
+            rpath = getMacLinuxRpath();
+        }
+        return rpath;
     }
     window.showErrorMessage(`${process.platform} can't use R`);
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,7 +10,7 @@ export function config() {
     return workspace.getConfiguration('r');
 }
 
-function getRfromEnvPath(platform) {
+function getRfromEnvPath(platform: string) {
     let splitChar: string = ':';
     let fileExtension: string = '';
     


### PR DESCRIPTION
**What problem did you solve?**

#339 

**(If you do not have screenshot) How can I check this pull request?**

* Ensure R is on your search path
* open vscode with default settings and run "create new R terminal"
* a new R session should open
* change vscode default settings for R location on mac/linux to a null/junk location
*  run "create new R terminal"
* A error message should appear saying unable to open the terminal 

Please find a gif of the above below:

![2020-05-23 22 43 27](https://user-images.githubusercontent.com/8447209/82741120-f2807d80-9d46-11ea-88c8-72caba13d565.gif)
