### PR TITLE
Use fs.watch instead of vscode.FileSystemWatcher

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -1,4 +1,6 @@
-if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
+if (interactive() &&
+  Sys.getenv("RSTUDIO") == "" &&
+  Sys.getenv("TERM_PROGRAM") == "vscode") {
   if (requireNamespace("jsonlite", quietly = TRUE)) {
     local({
       pid <- Sys.getpid()

--- a/R/init.R
+++ b/R/init.R
@@ -18,13 +18,19 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
         request_file <- file.path(dir, "request.log")
         request_lock_file <- file.path(dir, "request.lock")
         globalenv_file <- file.path(dir_session, "globalenv.json")
+        globalenv_lock_file <- file.path(dir_session, "globalenv.lock")
         plot_file <- file.path(dir_session, "plot.png")
+        plot_lock_file <- file.path(dir_session, "plot.lock")
         plot_history_file <- NULL
         plot_updated <- FALSE
         null_dev_id <- c(pdf = 2L)
         null_dev_size <- c(7 + pi, 7 + pi)
 
-        file.create(globalenv_file, plot_file, showWarnings = FALSE)
+        file.create(globalenv_lock_file, plot_lock_file, showWarnings = FALSE)
+
+        get_timestamp <- function() {
+          format.default(Sys.time(), nsmall = 6)
+        }
 
         check_null_dev <- function() {
           identical(dev.cur(), null_dev_id) &&
@@ -69,7 +75,7 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
             ...
           ), auto_unbox = TRUE)
           cat(json, "\n", sep = "", file = request_file)
-          cat(as.numeric(Sys.time()), file = request_lock_file)
+          cat(get_timestamp(), file = request_lock_file)
         }
 
         unbox <- jsonlite::unbox
@@ -101,6 +107,7 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
               info
             }, all.names = FALSE, USE.NAMES = TRUE)
             jsonlite::write_json(objs, globalenv_file, pretty = FALSE)
+            cat(get_timestamp(), file = globalenv_lock_file)
             if (plot_updated && check_null_dev()) {
               plot_updated <<- FALSE
               record <- recordPlot()
@@ -109,6 +116,7 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
                 do.call(png, c(list(filename = plot_file), dev_args))
                 on.exit({
                   dev.off()
+                  cat(get_timestamp(), file = plot_lock_file)
                   if (!is.null(plot_history_file)) {
                     file.copy(plot_file, plot_history_file, overwrite = TRUE)
                   }

--- a/R/init.R
+++ b/R/init.R
@@ -3,15 +3,15 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
     local({
       pid <- Sys.getpid()
       tempdir <- tempdir()
-      dir <- normalizePath(file.path(".vscode", "vscode-R"), mustWork = FALSE)
-      dir_session <- file.path(dir, pid)
+      dir <- normalizePath(file.path("~", ".vscode-R"), mustWork = FALSE)
+      dir_session <- file.path(tempdir, "vscode-R")
       if (dir.create(dir_session, showWarnings = FALSE, recursive = TRUE) ||
         dir.exists(dir_session)) {
         reg.finalizer(.GlobalEnv, function(e) {
           unlink(dir_session, recursive = TRUE, force = TRUE)
         }, onexit = TRUE)
 
-        dir_plot_history <- file.path(tempdir, "images")
+        dir_plot_history <- file.path(dir_session, "images")
         dir.create(dir_plot_history, showWarnings = FALSE, recursive = TRUE)
 
         response_file <- file.path(dir, "response.log")
@@ -21,6 +21,8 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
         plot_updated <- FALSE
         null_dev_id <- c(pdf = 2L)
         null_dev_size <- c(7 + pi, 7 + pi)
+
+        file.create(globalenv_file, plot_file, showWarnings = FALSE)
 
         check_null_dev <- function() {
           identical(dev.cur(), null_dev_id) &&

--- a/R/init.R
+++ b/R/init.R
@@ -4,7 +4,10 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
       pid <- Sys.getpid()
       wd <- getwd()
       tempdir <- tempdir()
-      dir <- normalizePath(file.path("~", ".vscode-R"), mustWork = FALSE)
+      homedir <- Sys.getenv(
+        if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"
+      )
+      dir_extension <- file.path(homedir, ".vscode-R")
       dir_session <- file.path(tempdir, "vscode-R")
       if (dir.create(dir_session, showWarnings = FALSE, recursive = TRUE) ||
         dir.exists(dir_session)) {
@@ -15,8 +18,8 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
         dir_plot_history <- file.path(dir_session, "images")
         dir.create(dir_plot_history, showWarnings = FALSE, recursive = TRUE)
 
-        request_file <- file.path(dir, "request.log")
-        request_lock_file <- file.path(dir, "request.lock")
+        request_file <- file.path(dir_extension, "request.log")
+        request_lock_file <- file.path(dir_extension, "request.lock")
         globalenv_file <- file.path(dir_session, "globalenv.json")
         globalenv_lock_file <- file.path(dir_session, "globalenv.lock")
         plot_file <- file.path(dir_session, "plot.png")

--- a/R/init.R
+++ b/R/init.R
@@ -16,6 +16,7 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
         dir.create(dir_plot_history, showWarnings = FALSE, recursive = TRUE)
 
         request_file <- file.path(dir, "request.log")
+        request_lock_file <- file.path(dir, "request.lock")
         globalenv_file <- file.path(dir_session, "globalenv.json")
         plot_file <- file.path(dir_session, "plot.png")
         plot_history_file <- NULL
@@ -67,7 +68,8 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
             command = command,
             ...
           ), auto_unbox = TRUE)
-          cat(json, "\n", sep = "", file = request_file, append = TRUE)
+          cat(json, "\n", sep = "", file = request_file)
+          cat(as.numeric(Sys.time()), file = request_lock_file)
         }
 
         unbox <- jsonlite::unbox

--- a/R/init.R
+++ b/R/init.R
@@ -9,311 +9,305 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
       )
       dir_extension <- file.path(homedir, ".vscode-R")
       dir_session <- file.path(tempdir, "vscode-R")
-      if (dir.create(dir_session, showWarnings = FALSE, recursive = TRUE) ||
-        dir.exists(dir_session)) {
-        reg.finalizer(.GlobalEnv, function(e) {
-          unlink(dir_session, recursive = TRUE, force = TRUE)
-        }, onexit = TRUE)
+      dir.create(dir_session, showWarnings = FALSE, recursive = TRUE)
+      dir_plot_history <- file.path(dir_session, "images")
+      dir.create(dir_plot_history, showWarnings = FALSE, recursive = TRUE)
 
-        dir_plot_history <- file.path(dir_session, "images")
-        dir.create(dir_plot_history, showWarnings = FALSE, recursive = TRUE)
+      request_file <- file.path(dir_extension, "request.log")
+      request_lock_file <- file.path(dir_extension, "request.lock")
+      globalenv_file <- file.path(dir_session, "globalenv.json")
+      globalenv_lock_file <- file.path(dir_session, "globalenv.lock")
+      plot_file <- file.path(dir_session, "plot.png")
+      plot_lock_file <- file.path(dir_session, "plot.lock")
+      plot_history_file <- NULL
+      plot_updated <- FALSE
+      null_dev_id <- c(pdf = 2L)
+      null_dev_size <- c(7 + pi, 7 + pi)
 
-        request_file <- file.path(dir_extension, "request.log")
-        request_lock_file <- file.path(dir_extension, "request.lock")
-        globalenv_file <- file.path(dir_session, "globalenv.json")
-        globalenv_lock_file <- file.path(dir_session, "globalenv.lock")
-        plot_file <- file.path(dir_session, "plot.png")
-        plot_lock_file <- file.path(dir_session, "plot.lock")
-        plot_history_file <- NULL
-        plot_updated <- FALSE
-        null_dev_id <- c(pdf = 2L)
-        null_dev_size <- c(7 + pi, 7 + pi)
+      file.create(globalenv_lock_file, plot_lock_file, showWarnings = FALSE)
 
-        file.create(globalenv_lock_file, plot_lock_file, showWarnings = FALSE)
+      get_timestamp <- function() {
+        format.default(Sys.time(), nsmall = 6)
+      }
 
-        get_timestamp <- function() {
-          format.default(Sys.time(), nsmall = 6)
+      check_null_dev <- function() {
+        identical(dev.cur(), null_dev_id) &&
+          identical(dev.size(), null_dev_size)
+      }
+
+      new_plot <- function() {
+        if (check_null_dev()) {
+          plot_history_file <<- file.path(dir_plot_history,
+            format(Sys.time(), "%Y%m%d-%H%M%OS6.png"))
+          plot_updated <<- TRUE
         }
+      }
 
-        check_null_dev <- function() {
-          identical(dev.cur(), null_dev_id) &&
-            identical(dev.size(), null_dev_size)
-        }
+      options(
+        vscodeR = environment(),
+        device = function(...) {
+          pdf(NULL,
+            width = null_dev_size[[1L]],
+            height = null_dev_size[[2L]],
+            bg = "white")
+          dev.control(displaylist = "enable")
+        },
+        browser = function(url, ...) {
+          request("browser", url = url, ...)
+        },
+        viewer = function(url, ...) {
+          request("webview", file = url, ..., viewColumn = "Two")
+        },
+        page_viewer = function(url, ...) {
+          request("webview", file = url, ..., viewColumn = "Active")
+        },
+        help_type = "html"
+      )
 
-        new_plot <- function() {
-          if (check_null_dev()) {
-            plot_history_file <<- file.path(dir_plot_history,
-              format(Sys.time(), "%Y%m%d-%H%M%OS6.png"))
-            plot_updated <<- TRUE
-          }
-        }
+      request <- function(command, ...) {
+        json <- jsonlite::toJSON(list(
+          time = Sys.time(),
+          pid = pid,
+          wd = wd,
+          command = command,
+          ...
+        ), auto_unbox = TRUE)
+        cat(json, "\n", sep = "", file = request_file)
+        cat(get_timestamp(), file = request_lock_file)
+      }
 
-        options(
-          vscodeR = environment(),
-          device = function(...) {
-            pdf(NULL,
-              width = null_dev_size[[1L]],
-              height = null_dev_size[[2L]],
-              bg = "white")
-            dev.control(displaylist = "enable")
-          },
-          browser = function(url, ...) {
-            request("browser", url = url, ...)
-          },
-          viewer = function(url, ...) {
-            request("webview", file = url, ..., viewColumn = "Two")
-          },
-          page_viewer = function(url, ...) {
-            request("webview", file = url, ..., viewColumn = "Active")
-          },
-          help_type = "html"
+      unbox <- jsonlite::unbox
+
+      capture_str <- function(object) {
+        utils::capture.output(
+          utils::str(object, max.level = 0, give.attr = FALSE)
         )
+      }
 
-        request <- function(command, ...) {
-          json <- jsonlite::toJSON(list(
-            time = Sys.time(),
-            pid = pid,
-            wd = wd,
-            command = command,
-            ...
-          ), auto_unbox = TRUE)
-          cat(json, "\n", sep = "", file = request_file)
-          cat(get_timestamp(), file = request_lock_file)
-        }
-
-        unbox <- jsonlite::unbox
-
-        capture_str <- function(object) {
-          utils::capture.output(
-            utils::str(object, max.level = 0, give.attr = FALSE)
-          )
-        }
-
-        update <- function(...) {
-          tryCatch({
-            objs <- eapply(.GlobalEnv, function(obj) {
-              str <- capture_str(obj)[[1L]]
-              info <- list(
-                class = class(obj),
-                type = unbox(typeof(obj)),
-                length = unbox(length(obj)),
-                str = unbox(trimws(str))
-              )
-              if ((is.list(obj) ||
-                is.environment(obj)) &&
-                !is.null(names(obj))) {
-                info$names <- names(obj)
-              }
-              if (isS4(obj)) {
-                info$slots <- slotNames(obj)
-              }
-              info
-            }, all.names = FALSE, USE.NAMES = TRUE)
-            jsonlite::write_json(objs, globalenv_file, pretty = FALSE)
-            cat(get_timestamp(), file = globalenv_lock_file)
-            if (plot_updated && check_null_dev()) {
-              plot_updated <<- FALSE
-              record <- recordPlot()
-              if (length(record[[1L]])) {
-                dev_args <- getOption("dev.args")
-                do.call(png, c(list(filename = plot_file), dev_args))
-                on.exit({
-                  dev.off()
-                  cat(get_timestamp(), file = plot_lock_file)
-                  if (!is.null(plot_history_file)) {
-                    file.copy(plot_file, plot_history_file, overwrite = TRUE)
-                  }
-                })
-                replayPlot(record)
-              }
+      update <- function(...) {
+        tryCatch({
+          objs <- eapply(.GlobalEnv, function(obj) {
+            str <- capture_str(obj)[[1L]]
+            info <- list(
+              class = class(obj),
+              type = unbox(typeof(obj)),
+              length = unbox(length(obj)),
+              str = unbox(trimws(str))
+            )
+            if ((is.list(obj) ||
+              is.environment(obj)) &&
+              !is.null(names(obj))) {
+              info$names <- names(obj)
             }
-          }, error = message)
-          TRUE
-        }
-
-        attach <- function() {
-          request("attach", tempdir = tempdir)
-        }
-
-        dataview_data_type <- function(x) {
-          if (is.numeric(x)) {
-            if (is.null(attr(x, "class"))) {
-              "num"
-            } else {
-              "num-fmt"
+            if (isS4(obj)) {
+              info$slots <- slotNames(obj)
             }
-          } else if (inherits(x, "Date")) {
-            "date"
-          } else {
-            "string"
+            info
+          }, all.names = FALSE, USE.NAMES = TRUE)
+          jsonlite::write_json(objs, globalenv_file, pretty = FALSE)
+          cat(get_timestamp(), file = globalenv_lock_file)
+          if (plot_updated && check_null_dev()) {
+            plot_updated <<- FALSE
+            record <- recordPlot()
+            if (length(record[[1L]])) {
+              dev_args <- getOption("dev.args")
+              do.call(png, c(list(filename = plot_file), dev_args))
+              on.exit({
+                dev.off()
+                cat(get_timestamp(), file = plot_lock_file)
+                if (!is.null(plot_history_file)) {
+                  file.copy(plot_file, plot_history_file, overwrite = TRUE)
+                }
+              })
+              replayPlot(record)
+            }
           }
-        }
+        }, error = message)
+        TRUE
+      }
 
-        dataview_table <- function(data) {
-          if (is.data.frame(data)) {
-            nrow <- nrow(data)
-            colnames <- colnames(data)
-            if (is.null(colnames)) {
-              colnames <- sprintf("(X%d)", seq_len(ncol(data)))
-            } else {
-              colnames <- trimws(colnames)
-            }
-            if (.row_names_info(data) > 0L) {
-              rownames <- rownames(data)
-              rownames(data) <- NULL
-            } else {
-              rownames <- seq_len(nrow)
-            }
-            data <- c(list(" " = rownames), .subset(data))
-            colnames <- c(" ", colnames)
-            types <- vapply(data, dataview_data_type,
-              character(1L), USE.NAMES = FALSE)
-            data <- vapply(data, function(x) {
-              trimws(format(x))
-            }, character(nrow), USE.NAMES = FALSE)
-            dim(data) <- c(length(rownames), length(colnames))
-          } else if (is.matrix(data)) {
-            if (is.factor(data)) {
-              data <- format(data)
-            }
-            types <- rep(dataview_data_type(data), ncol(data))
-            colnames <- colnames(data)
-            colnames(data) <- NULL
-            if (is.null(colnames)) {
-              colnames <- sprintf("(X%d)", seq_len(ncol(data)))
-            } else {
-              colnames <- trimws(colnames)
-            }
+      attach <- function() {
+        request("attach", tempdir = tempdir)
+      }
+
+      dataview_data_type <- function(x) {
+        if (is.numeric(x)) {
+          if (is.null(attr(x, "class"))) {
+            "num"
+          } else {
+            "num-fmt"
+          }
+        } else if (inherits(x, "Date")) {
+          "date"
+        } else {
+          "string"
+        }
+      }
+
+      dataview_table <- function(data) {
+        if (is.data.frame(data)) {
+          nrow <- nrow(data)
+          colnames <- colnames(data)
+          if (is.null(colnames)) {
+            colnames <- sprintf("(X%d)", seq_len(ncol(data)))
+          } else {
+            colnames <- trimws(colnames)
+          }
+          if (.row_names_info(data) > 0L) {
             rownames <- rownames(data)
             rownames(data) <- NULL
-            data <- trimws(format(data))
-            if (is.null(rownames)) {
-              types <- c("num", types)
-              rownames <- seq_len(nrow(data))
-            } else {
-              types <- c("string", types)
-              rownames <- trimws(rownames)
-            }
-            dim(data) <- c(length(rownames), length(colnames))
-            colnames <- c(" ", colnames)
-            data <- cbind(rownames, data)
           } else {
-            stop("data must be data.frame or matrix")
+            rownames <- seq_len(nrow)
           }
-          columns <- .mapply(function(title, type) {
-            class <- if (type == "string") "text-left" else "text-right"
-            list(title = jsonlite::unbox(title),
-              className = jsonlite::unbox(class),
-              type = jsonlite::unbox(type))
-          }, list(colnames, types), NULL)
-          list(columns = columns, data = data)
-        }
-
-        dataview <- function(x, title) {
-          if (missing(title)) {
-            sub <- substitute(x)
-            title <- deparse(sub)[[1]]
+          data <- c(list(" " = rownames), .subset(data))
+          colnames <- c(" ", colnames)
+          types <- vapply(data, dataview_data_type,
+            character(1L), USE.NAMES = FALSE)
+          data <- vapply(data, function(x) {
+            trimws(format(x))
+          }, character(nrow), USE.NAMES = FALSE)
+          dim(data) <- c(length(rownames), length(colnames))
+        } else if (is.matrix(data)) {
+          if (is.factor(data)) {
+            data <- format(data)
           }
-          if (is.environment(x)) {
-            x <- eapply(x, function(obj) {
-              data.frame(
-                class = paste0(class(obj), collapse = ", "),
-                type = typeof(obj),
-                length = length(obj),
-                size = as.integer(object.size(obj)),
-                value = trimws(capture_str(obj)),
-                stringsAsFactors = FALSE,
-                check.names = FALSE
-              )
-            }, all.names = FALSE, USE.NAMES = TRUE)
-            if (length(x)) {
-              x <- do.call(rbind, x)
-            } else {
-              x <- data.frame(
-                class = character(),
-                type = character(),
-                length = integer(),
-                size = integer(),
-                value = character(),
-                stringsAsFactors = FALSE,
-                check.names = FALSE
-              )
-            }
-          }
-          if (is.data.frame(x) || is.matrix(x)) {
-            data <- dataview_table(x)
-            file <- tempfile(tmpdir = tempdir, fileext = ".json")
-            jsonlite::write_json(data, file, matrix = "rowmajor")
-            request("dataview", source = "table", type = "json",
-              title = title, file = file)
-          } else if (is.list(x)) {
-            tryCatch({
-              file <- tempfile(tmpdir = tempdir, fileext = ".json")
-              jsonlite::write_json(x, file, auto_unbox = TRUE)
-              request("dataview", source = "list", type = "json",
-                title = title, file = file)
-            }, error = function(e) {
-              file <- file.path(tempdir, paste0(make.names(title), ".txt"))
-              text <- utils::capture.output(print(x))
-              writeLines(text, file)
-              request("dataview", source = "object", type = "txt",
-                title = title, file = file)
-            })
+          types <- rep(dataview_data_type(data), ncol(data))
+          colnames <- colnames(data)
+          colnames(data) <- NULL
+          if (is.null(colnames)) {
+            colnames <- sprintf("(X%d)", seq_len(ncol(data)))
           } else {
-            file <- file.path(tempdir, paste0(make.names(title), ".R"))
-            if (is.primitive(x)) {
-              code <- utils::capture.output(print(x))
-            } else {
-              code <- deparse(x)
-            }
-            writeLines(code, file)
-            request("dataview", source = "object", type = "R",
-              title = title, file = file)
+            colnames <- trimws(colnames)
           }
-        }
-
-        rebind <- function(sym, value, ns) {
-          if (is.character(ns)) {
-            Recall(sym, value, getNamespace(ns))
-            pkg <- paste0("package:", ns)
-            if (pkg %in% search()) {
-              Recall(sym, value, as.environment(pkg))
-            }
-          } else if (is.environment(ns)) {
-            if (bindingIsLocked(sym, ns)) {
-              unlockBinding(sym, ns)
-              on.exit(lockBinding(sym, ns))
-            }
-            assign(sym, value, ns)
+          rownames <- rownames(data)
+          rownames(data) <- NULL
+          data <- trimws(format(data))
+          if (is.null(rownames)) {
+            types <- c("num", types)
+            rownames <- seq_len(nrow(data))
           } else {
-            stop("ns must be a string or environment")
+            types <- c("string", types)
+            rownames <- trimws(rownames)
           }
+          dim(data) <- c(length(rownames), length(colnames))
+          colnames <- c(" ", colnames)
+          data <- cbind(rownames, data)
+        } else {
+          stop("data must be data.frame or matrix")
         }
-
-        setHook("plot.new", new_plot, "replace")
-        setHook("grid.newpage", new_plot, "replace")
-
-        rebind(".External.graphics", function(...) {
-          out <- .Primitive(".External.graphics")(...)
-          if (check_null_dev()) {
-            plot_updated <<- TRUE
-          }
-          out
-        }, "base")
-        rebind("View", dataview, "utils")
-
-        platform <- .Platform
-        platform[["GUI"]] <- "vscode"
-        rebind(".Platform", platform, "base")
-
-        update()
-        removeTaskCallback("vscode-R")
-        addTaskCallback(update, name = "vscode-R")
-        lockEnvironment(environment(), bindings = TRUE)
-        unlockBinding("plot_updated", environment())
-        unlockBinding("plot_history_file", environment())
-        attach()
+        columns <- .mapply(function(title, type) {
+          class <- if (type == "string") "text-left" else "text-right"
+          list(title = jsonlite::unbox(title),
+            className = jsonlite::unbox(class),
+            type = jsonlite::unbox(type))
+        }, list(colnames, types), NULL)
+        list(columns = columns, data = data)
       }
+
+      dataview <- function(x, title) {
+        if (missing(title)) {
+          sub <- substitute(x)
+          title <- deparse(sub)[[1]]
+        }
+        if (is.environment(x)) {
+          x <- eapply(x, function(obj) {
+            data.frame(
+              class = paste0(class(obj), collapse = ", "),
+              type = typeof(obj),
+              length = length(obj),
+              size = as.integer(object.size(obj)),
+              value = trimws(capture_str(obj)),
+              stringsAsFactors = FALSE,
+              check.names = FALSE
+            )
+          }, all.names = FALSE, USE.NAMES = TRUE)
+          if (length(x)) {
+            x <- do.call(rbind, x)
+          } else {
+            x <- data.frame(
+              class = character(),
+              type = character(),
+              length = integer(),
+              size = integer(),
+              value = character(),
+              stringsAsFactors = FALSE,
+              check.names = FALSE
+            )
+          }
+        }
+        if (is.data.frame(x) || is.matrix(x)) {
+          data <- dataview_table(x)
+          file <- tempfile(tmpdir = tempdir, fileext = ".json")
+          jsonlite::write_json(data, file, matrix = "rowmajor")
+          request("dataview", source = "table", type = "json",
+            title = title, file = file)
+        } else if (is.list(x)) {
+          tryCatch({
+            file <- tempfile(tmpdir = tempdir, fileext = ".json")
+            jsonlite::write_json(x, file, auto_unbox = TRUE)
+            request("dataview", source = "list", type = "json",
+              title = title, file = file)
+          }, error = function(e) {
+            file <- file.path(tempdir, paste0(make.names(title), ".txt"))
+            text <- utils::capture.output(print(x))
+            writeLines(text, file)
+            request("dataview", source = "object", type = "txt",
+              title = title, file = file)
+          })
+        } else {
+          file <- file.path(tempdir, paste0(make.names(title), ".R"))
+          if (is.primitive(x)) {
+            code <- utils::capture.output(print(x))
+          } else {
+            code <- deparse(x)
+          }
+          writeLines(code, file)
+          request("dataview", source = "object", type = "R",
+            title = title, file = file)
+        }
+      }
+
+      rebind <- function(sym, value, ns) {
+        if (is.character(ns)) {
+          Recall(sym, value, getNamespace(ns))
+          pkg <- paste0("package:", ns)
+          if (pkg %in% search()) {
+            Recall(sym, value, as.environment(pkg))
+          }
+        } else if (is.environment(ns)) {
+          if (bindingIsLocked(sym, ns)) {
+            unlockBinding(sym, ns)
+            on.exit(lockBinding(sym, ns))
+          }
+          assign(sym, value, ns)
+        } else {
+          stop("ns must be a string or environment")
+        }
+      }
+
+      setHook("plot.new", new_plot, "replace")
+      setHook("grid.newpage", new_plot, "replace")
+
+      rebind(".External.graphics", function(...) {
+        out <- .Primitive(".External.graphics")(...)
+        if (check_null_dev()) {
+          plot_updated <<- TRUE
+        }
+        out
+      }, "base")
+      rebind("View", dataview, "utils")
+
+      platform <- .Platform
+      platform[["GUI"]] <- "vscode"
+      rebind(".Platform", platform, "base")
+
+      update()
+      removeTaskCallback("vscode-R")
+      addTaskCallback(update, name = "vscode-R")
+      lockEnvironment(environment(), bindings = TRUE)
+      unlockBinding("plot_updated", environment())
+      unlockBinding("plot_history_file", environment())
+      attach()
       invisible()
     })
   } else {

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ For the case of advanced usage, user should, in addition, comment out or remove 
 * When user creates or updates a plot, the `{tempDir}/vscode-R/plot.png` is updated, and vscode-R will open the plot file.
 * When user calls `View()` with a data frame, list, environment, or any other object, the request is written to `~/.vscode-R/request.log` and
 vscode-R will open a WebView to show the data or open a text document to show the content of the object.
-* When user calls the viewer (e.g. htmlwidget, provis) or browser (e.g. shiny app, HTML help documentation), the request is wrtten to `~/.vscode-R/request.log` and vscode-R will open a WebView to present the viewer content.
+* When user calls the viewer (e.g. htmlwidget, provis) or browser (e.g. shiny app, HTML help documentation), the request is written to `~/.vscode-R/request.log` and vscode-R will open a WebView to present the viewer content.
 
 R sessions started from the workspace root folder or a subfolder will be automatically attached. The session watcher is designed to work in a wide range of scenarios:
 

--- a/README.md
+++ b/README.md
@@ -122,15 +122,25 @@ For the case of advanced usage, user should, in addition, comment out or remove 
 
 ### How it works
 
-This script writes the metadata of symbols in the global environment and plot file to `${workspaceFolder}/.vscode/vscode-R/PID` where `PID` is the R process ID. It also captures user input and append command lines to `${workspaceFolder}/.vscode/vscode-R/response.log`, which enables the communication between vscode-R and a live R sesson.
+* When vscode-R is activated with session watcher enabled, it deploys the initialization script to `~/.vscode-R/init.R`.
+* vscode-R watches `~/.vscode-R/request.log` for requests from user R sessions.
+* When a new R session is created, it sources `init.R` to initialize the session watcher and writes attach request to `~/.vscode-R/request.log`.
+* vscode-R reads the attach request and knows the working directory and session temp directory (`{tempDir}`) of the attaching session.
+* vscode-R watches `{tempDir}/vscode-R/globalenv.json` for global environment info and `{tempDir}/vscode-R/plot.png` for plot graphics.
+* In the R session, the global environment info will be updated on each evaluation of top-level expression.
+* When user creates or updates a plot, the `{tempDir}/vscode-R/plot.png` is updated, and vscode-R will open the plot file.
+* When user calls `View()` with a data frame, list, environment, or any other object, the request is written to `~/.vscode-R/request.log` and
+vscode-R will open a WebView to show the data or open a text document to show the content of the object.
+* When user calls the viewer (e.g. htmlwidget, provis) or browser (e.g. shiny app, HTML help documentation), the request is wrtten to `~/.vscode-R/request.log` and vscode-R will open a WebView to present the viewer content.
 
-Each time the extension is activated, the latest session watcher script (`init.R`) will be deployed to `~/.vscode-R/init.R`.
-
-R sessions started from the workspace root folder will be automatically attached. The session watcher is designed to work in a wide range of scenarios:
+R sessions started from the workspace root folder or a subfolder will be automatically attached. The session watcher is designed to work in a wide range of scenarios:
 
 * Official R terminal or `radian` console
 * R session started by vscode-R or user
 * R session in a `tmux` or `screen` window
+* Multiple R sessions in VSCode terminal
+* Multiple R sessions in `tmux` windows or panes.
+* Multi-root workspace in VSCode
 * Switch between multiple running R sessions
 * [Remote Development](https://code.visualstudio.com/docs/remote/remote-overview) via SSH, WSL and Docker
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ import { createGitignore } from './rGitignore';
 import { chooseTerminal, chooseTerminalAndSendText, createRTerm, deleteTerminal,
          runSelectionInTerm, runTextInTerm } from './rTerminal';
 import { getWordOrSelection, surroundSelection } from './selection';
-import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startResponseWatcher } from './session';
+import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startRequestWatcher } from './session';
 import { config, ToRStringLiteral } from './util';
 
 const wordPattern = /(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\<\>\/\s]+)/g;
@@ -324,7 +324,7 @@ export function activate(context: ExtensionContext) {
         sessionStatusBarItem.show();
 
         deploySessionWatcher(context.extensionPath);
-        startResponseWatcher(sessionStatusBarItem);
+        startRequestWatcher(sessionStatusBarItem);
     }
 }
 


### PR DESCRIPTION
* Close #347
* Close #352 
* Support multi-root workspace (Close #236)
* Support workspace in cloud drive (Close #179, Close #272, Close #330) and read-only file systems

This PR uses `fs.watch` to replace `vscode.FileSystemWatcher` and the `response.log` renamed to `request.log` and is moved to `~/.vscode-R/request.log`; `globalenv.json` and `plot.png` are moved to `{tempdir}/vscode-R/`.

Note that `fs.watch` may trigger multiple events when the watched file is being written. If we directly watch `request.log`, `globalenv.json`, and `plot.png`, respectively, it is likely that we might read a partial file that is still being written. To avoid this, I use lock files for each of them, i.e., `resquest.lock`, `globalenv.lock`, `plot.lock`. In `init.R`, these lock files are written a timestamp after the underlying file is finished writing. Only when the file watch triggers an event and the timestamp changes do we read or open the underlying file to avoid duplicate reading or partial reading.

All functionalities of session watcher should not change. The only visible change is that it no longer creates `{workspaceFolder}/.vscode/vscode-R`.

**Testing this PR**

* General functionalities
  - attach
  - symbol hover
  - `View(mtcars)`
  - `View(baseenv())`
  - `plot(rnorm(100))`
  - R session started from a subfolder of the VSCode workspace root should work now.
* Multi-session support
  - Open a workspace at folder A
  - Create multiple terminals
  - Each should be able to attach
  - Click status bar in previously created terminal and it should attach
  - In the attached session, `plot(rnorm(100))` should open the png file
  - In any of the sessions, `View(mtcars)` should trigger the WebView
* Multi-root workspace support
  - Create a multi-root workspace
  - Start an R session from one workspace folder should work
  - Start an R session from the second workspace folder should work too
* Cloud-drive support
  - Create a workspace in a cloud-drive (e.g. OneDrive, Google Drive)
  - Start an R session from the workspace folder
  - The session watcher should work normally
* Read-only file system support
  - Open a workspace in a read-only file system (e.g. a read-only mounted drive, or non-writable directory for our user)
  - Start an R session from the workspace folder
  - The session watcher should work normally