### PR TITLE
Change runSelectionInActiveTerm effect to warning

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,11 +97,7 @@ export function activate(context: ExtensionContext) {
     }
 
     async function runSelectionInActiveTerm() {
-        const callableTerminal = await chooseTerminal(true);
-        if (callableTerminal === undefined) {
-            return;
-        }
-        runSelectionInTerm(callableTerminal, true);
+        window.showWarningMessage('This command has been removed. Enable setting "Always Use Active Terminal".');
     }
 
     async function runSelectionRetainCursor() {


### PR DESCRIPTION
Part of #306 

**What problem did you solve?**

Replaces effect of `R: Run Selection/Line in Active Terminal` with warning message, in preparation for its eventual removal.

**How can I check this pull request?**

Use command `R: Run Selection/Line in Active Terminal`. Observe code is NOT sent to terminal. Observe warning message 'This command has been removed. Enable setting "Always Use Active Terminal".'