### PR TITLE
Improve getBrowserHtml

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -166,11 +166,16 @@ function getBrowserHtml(url: string) {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html, body {
+        height: 100%;
+        padding: 0;
+        overflow: hidden;
+    }
+  </style>
 </head>
 <body>
-    <div style="border:0px;position:absolute;left:0px;top:0px;bottom:0px;right:0px;">
-        <iframe src="${url}"; width="100%" height="100%" frameborder="0" />
-    </div>
+    <iframe src="${url}" width="100%" height="100%" frameborder="0" />
 </body>
 </html>
 `;


### PR DESCRIPTION
As suggested at https://github.com/nx10/httpgd/issues/1#issuecomment-637503382, the browser WebView code is improved to better present embedded iframe. The original code might produce a slight margin on iframe so that a scroll bar appears on the webpage when the page is 100% in the webview while the new code make the webpage better fill in the WebView without a margin.

There are several ways to test this:

* R html help

```r
?get
```

* Shiny example

```r
shiny::runExample("01_hello")
```

* httpgd live page

```r
httpgd::httpgd()
utils::browseURL(httpgd::httpgdURL())

plot(rnorm(100), main = "title")
abline(h = 0, col = "red")
points(rnorm(100), col = "blue")

library(ggplot2)

ggplot(mpg, aes(displ, hwy, colour = class)) +
  geom_point()

par(mfrow = c(2, 2))
m <- lm(mpg ~ cyl, data = mtcars)
plot(m)
```