### PR TITLE
Remove single quote from doesLineEndInOperator

### DIFF
--- a/src/lineCache.ts
+++ b/src/lineCache.ts
@@ -47,7 +47,7 @@ function cleanLine(text: string) {
 }
 
 function doesLineEndInOperator(text: string) {
-    const endingOperatorIndex = text.search(/(,|\+|!|\$|\^|&|\*|-|=|:|\'|~|\||\/|\?|%.*%)(\s*|\s*\#.*)$/);
+    const endingOperatorIndex = text.search(/(,|\+|!|\$|\^|&|\*|-|=|:|~|\||\/|\?|%.*%)(\s*|\s*\#.*)$/);
     const spacesOnlyIndex = text.search(/^\s*$/);
 
     return ((endingOperatorIndex >= 0) || (spacesOnlyIndex >= 0));

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -449,6 +449,36 @@ suite('Extension Tests', () => {
         assert.equal(extendSelection(9, f, doc.length).endLine, 9);
     });
 
+    test('Selecting single line with double quotes', () => {
+        const doc = `
+        "hello"
+        a + b
+        `.split('\n');
+        function f(i) { return (doc[i]); }
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 1);
+    });
+
+    test('Selecting single line with single quotes', () => {
+        const doc = `
+        'hello'
+        a + b
+        `.split('\n');
+        function f(i) { return (doc[i]); }
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 1);
+    });
+
+    test('Selecting single line with backticks', () => {
+        const doc = `
+        \`hello\`
+        a + b
+        `.split('\n');
+        function f(i) { return (doc[i]); }
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 1);
+    });
+
     test('Selecting multi-line bracket with unmatched brackets in string', () => {
         const doc = `
         lapply(1:5, function(i) {


### PR DESCRIPTION
**What problem did you solve?**

Close #356 

Single quote should not be treated as an operator that continues the code line. Therefore, I removed it from the search pattern in `doesLineEndInOperator`.

New test cases are added. The single quote test case fails with current master and passes with this PR.

**(If you have)Screenshot**

**(If you do not have screenshot) How can I check this pull request?**

Sending the first line of the following code to terminal no longer sends both lines but only the first line.

```r
'hello'
"hello"
```
