### PR TITLE
Fix plot viewer

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -108,7 +108,7 @@ if (interactive() &&
       }
 
       removeTaskCallback("vsc.plot")
-      show_plot <- !identical(getOption("vsc.plot", TRUE), FALSE)
+      show_plot <- !identical(getOption("vsc.plot", "Two"), FALSE)
       if (show_plot) {
         dir_plot_history <- file.path(dir_session, "images")
         dir.create(dir_plot_history, showWarnings = FALSE, recursive = TRUE)
@@ -181,7 +181,7 @@ if (interactive() &&
         addTaskCallback(update_plot, name = "vsc.plot")
       }
 
-      show_view <- !identical(getOption("vsc.view", TRUE), FALSE)
+      show_view <- !identical(getOption("vsc.view", "Two"), FALSE)
       if (show_view) {
         dataview_data_type <- function(x) {
           if (is.numeric(x)) {
@@ -257,7 +257,7 @@ if (interactive() &&
           list(columns = columns, data = data)
         }
 
-        dataview <- function(x, title, viewer = getOption("vsc.view")) {
+        dataview <- function(x, title, viewer = getOption("vsc.view", "Two")) {
           if (missing(title)) {
             sub <- substitute(x)
             title <- deparse(sub, nlines = 1)
@@ -326,7 +326,7 @@ if (interactive() &&
       attach <- function() {
         request("attach",
           tempdir = tempdir,
-          plot = show_plot)
+          plot = getOption("vsc.plot", "Two"))
       }
 
       browser <- function(url, title = url, ...,

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The script only works with environment variable `TERM_PROGRAM=vscode`. the scrip
 
 ### Available functions and options
 
-When the session watcher is initialized on session startup, a local environment named `tools:vscode` is attached and the following functions are made available for user to manually interoperate with VSCode:
+When the session watcher is initialized on session startup, a local environment named `tools:vscode` is attached and the following functions are made available for user to interoperate with VSCode:
 
 ```r
 # Attach vscode-R with same workspace folder to current session.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ When the session watcher is initialized on session startup, a local environment 
 .vsc.page_viewer(url, title, ..., viewer)
 ```
 
-All WebView-related functions have a `viewer` argument which could be one of the values defined in [vscode-api#ViewColumn](https://code.visualstudio.com/api/references/vscode-api#ViewColumn), .e.g `"Active"` (current editor), `"Two"` (editor group 2), or `"Besides"` (always show besides the current editor).
+All WebView-related functions have a `viewer` argument which could be one of the values defined in [vscode-api#ViewColumn](https://code.visualstudio.com/api/references/vscode-api#ViewColumn), .e.g. `"Active"` (current editor), `"Two"` (editor group 2), or `"Besides"` (always show besides the current editor).
 
 The following options are available for user to customize the session watcher functionality and behavior:
 

--- a/README.md
+++ b/README.md
@@ -134,10 +134,9 @@ When the session watcher is initialized on session startup, a local environment 
 .vsc.page_viewer(url, title, ..., viewer)
 ```
 
-The following options are used to customize the session watcher functionality and behavior:
+All WebView-related functions have a `viewer` argument which could be one of the values defined in [vscode-api#ViewColumn](https://code.visualstudio.com/api/references/vscode-api#ViewColumn), .e.g `"Active"` (current editor), `"Two"` (editor group 2), or `"Besides"` (always show besides the current editor).
 
-The first value is the default and all subsequent values after `|` are available choices.
-The `"Two" | "Active" | "Besides"` values are from [vscode-api#ViewColumn](https://code.visualstudio.com/api/references/vscode-api#ViewColumn) which specify which view column should the corresponding tab appears in VSCode.
+The following options are available for user to customize the session watcher functionality and behavior:
 
 ```r
 # Watch global environemnt symbols to provide hover on session symbol.
@@ -168,6 +167,9 @@ options(vsc.page_viewer = "Active" | "Besides" | "Two" | FALSE)
 #   since it only takes effect on session startup.
 options(vsc.view = "Two" | "Active" | "Besides" | FALSE)
 ```
+
+The first values are the default and all subsequent values after `|` are available choices.
+The `"Two" | "Active" | "Besides"` are popular values from `ViewColumn` to specify which view column should the corresponding tab appears in VSCode.
 
 ### How to disable it
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ All WebView-related functions have a `viewer` argument which could be one of the
 The following options are available for user to customize the session watcher functionality and behavior:
 
 ```r
-# Watch global environemnt symbols to provide hover on session symbol.
+# Watch global environemnt symbols to provide hover on and completion after session symbol.
 # Only specify in .Rprofile since it only takes effect on session startup.
 options(vsc.globalenv = TRUE | FALSE)
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ The following options are available for user to customize the session watcher fu
 # Only specify in .Rprofile since it only takes effect on session startup.
 options(vsc.globalenv = TRUE | FALSE)
 
-# Which view column to show the plot file on graphics update (FALSE to diable plot watcher)?
+# Which view column to show the plot file on graphics update
+# Use FALSE to diable plot watcher so that the default R plot device is used.
 # Only specify in .Rprofile since it only takes effect on session startup.
 options(vsc.plot = "Two" | "Active" | "Besides" | FALSE)
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,62 @@ be executed when a local `.Rprofile` is found.
 
 The script only works with environment variable `TERM_PROGRAM=vscode`. the script will not take effect with R sessions started in a `tmux` or `screen` window that does not have it, unless this environment variable is manually set before sourcing `init.R`, for example, you may insert a line `Sys.setenv(TERM_PROGRAM="vscode")` before it.
 
+### Available functions and options
+
+When the session watcher is initialized on session startup, a local environment named `tools:vscode` is attached and the following functions are made available for user to manually interoperate with VSCode:
+
+```r
+# Attach vscode-R with same workspace folder to current session.
+.vsc.attach()
+
+# A customizable View() where title and viewer can be specified.
+.vsc.view(x, title, viewer)
+
+# Browse an URL in a WebView (used by e.g. shiny apps, R html help).
+.vsc.browser(url, title, ..., viewer)
+
+# Show viewer from a HTML file or htmlwidget object (used by most htmlwidgets).
+.vsc.viewer(url, title, ..., viewer)
+
+# Show page viewer from a HTML file or htmlwidget object (used by e.g. profvis).
+.vsc.page_viewer(url, title, ..., viewer)
+```
+
+The following options are used to customize the session watcher functionality and behavior:
+
+The first value is the default and all subsequent values after `|` are available choices.
+The `"Two" | "Active" | "Besides"` values are from [vscode-api#ViewColumn](https://code.visualstudio.com/api/references/vscode-api#ViewColumn) which specify which view column should the corresponding tab appears in VSCode.
+
+```r
+# Watch global environemnt symbols to provide hover on session symbol.
+# Only specifiy in .Rprofile since it only takes effect on session startup.
+options(vsc.globalenv = TRUE | FALSE)
+
+# Which view column to show the plot file on graphics update (FALSE to diable plot watcher)?
+# Only specifiy in .Rprofile since it only takes effect on session startup.
+options(vsc.plot = "Two" | "Active" | "Besides" | FALSE)
+
+# The arguments for the png device to replay user graphics to show in VSCode.
+options(vsc.dev.args = NULL | list(width = 800, height = 600))
+
+# Which view column to show the WebView triggered by browser (e.g. shiny apps)?
+# Use FALSE to open in external web browser.
+options(vsc.browser = "Active" | "Besides" | "Two" | FALSE)
+
+# Which view column to show the WebView triggered by viewer (e.g. htmlwidgets)?
+# Use FALSE to open in external web browser.
+options(vsc.viewer = "Two" | "Active" | "Besides" | FALSE)
+
+# Which view column to show the WebView triggered by page_viewer (e.g. profvis)?
+# Use FALSE to open in external web browser.
+options(vsc.page_viewer = "Active" | "Besides" | "Two" | FALSE)
+
+# Which view column to show the WebView triggered by View()?
+# Use FALSE for R's native View(), which should be specified in .Rprofile
+#   since it only takes effect on session startup.
+options(vsc.view = "Two" | "Active" | "Besides" | FALSE)
+```
+
 ### How to disable it
 
 For the case of basic usage, turning off `r.sessionWatcher` in VSCode settings is sufficient

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ options(vsc.globalenv = TRUE | FALSE)
 options(vsc.plot = "Two" | "Active" | "Besides" | FALSE)
 
 # The arguments for the png device to replay user graphics to show in VSCode.
+# Ignored if options(vsc.plot = FALSE).
 options(vsc.dev.args = NULL | list(width = 800, height = 600))
 
 # Which view column to show the WebView triggered by browser (e.g. shiny apps)?

--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ The following options are available for user to customize the session watcher fu
 
 ```r
 # Watch global environemnt symbols to provide hover on session symbol.
-# Only specifiy in .Rprofile since it only takes effect on session startup.
+# Only specify in .Rprofile since it only takes effect on session startup.
 options(vsc.globalenv = TRUE | FALSE)
 
 # Which view column to show the plot file on graphics update (FALSE to diable plot watcher)?
-# Only specifiy in .Rprofile since it only takes effect on session startup.
+# Only specify in .Rprofile since it only takes effect on session startup.
 options(vsc.plot = "Two" | "Active" | "Besides" | FALSE)
 
 # The arguments for the png device to replay user graphics to show in VSCode.


### PR DESCRIPTION
**What problem did you solve?**

Partially fixes #364.

This PR:

* Restores the previous defaults of plot and View position (my negligence in #359) and fixes the behavior of using `vsc.plot` that could be a string.
* Adds up a section of available functions and options to README.

I'll look into if I could make option `vsc.plot` effect immediately in another issue, which could be tricky.

We might need a quick release for this so that user could get the previous behavior of viewing both plot and `View()` in `ViewColumn.Two`.

**(If you do not have screenshot) How can I check this pull request?**

1. Write `options(vsc.plot = "Two")` in `~/.Rprofile`.
2. Start a new session and run `plot(rnorm(100))`
3. The plot file shows up at `ViewColumn.Two`.
4. Run `options(vsc.plot = "Active")` and `.vsc.attach()`.
5. Run `plot(rnorm(100))` again.
6. The plot file shows up at `ViewColumn.Active`.
