### PR TITLE
Handle undefined workspace folders

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -437,7 +437,10 @@ function getPlotHistoryHtml(webview: Webview, files: string[]) {
 
 function isFromWorkspace(dir: string) {
     if (workspace.workspaceFolders === undefined) {
-        return true;
+        const rel = path.relative(os.homedir(), dir);
+        if (rel === '') {
+            return true;
+        }
     } else {
         for (const folder of workspace.workspaceFolders) {
             const rel = path.relative(folder.uri.fsPath, dir);

--- a/src/session.ts
+++ b/src/session.ts
@@ -436,12 +436,17 @@ function getPlotHistoryHtml(webview: Webview, files: string[]) {
 }
 
 function isFromWorkspace(dir: string) {
-    for (const folder of workspace.workspaceFolders) {
-        const rel = path.relative(folder.uri.fsPath, dir);
-        if (!rel.startsWith('..') && !path.isAbsolute(rel)) {
-            return true;
+    if (workspace.workspaceFolders === undefined) {
+        return true;
+    } else {
+        for (const folder of workspace.workspaceFolders) {
+            const rel = path.relative(folder.uri.fsPath, dir);
+            if (!rel.startsWith('..') && !path.isAbsolute(rel)) {
+                return true;
+            }
         }
     }
+    
     return false;
 }
 


### PR DESCRIPTION
**What problem did you solve?**

Close #366 

Currently, when user starts an R session with session watcher init, it writes `attach` request to the global `~/.vscode-R/request.log`, and vscode-R checks if the working directory of that R session is identical to or child of any of the workspace folders.

However, when VSCode has no workspace folder open, then `workspace.workspaceFolders` is `undefined`, and R session started always does not attach. This PR makes `isFromWorkspace` handle this case so that `attach` requests from home folder is accepted so that session watcher could work with no folder open.

We only attach R session started from home folder because if it allows all sessions to attach, then if multiple VSCode is started on the the same machine with different workspace folders, then a VSCode with no folder open will respond to all requests from different workspace folders, which could be messy and useless.

**(If you do not have screenshot) How can I check this pull request?**

1. Open VSCode without a folder open.
2. Open an R script to activate the extension.
3. Start an R session with session watcher enabled.
4. Check if the session watcher is attached by looking at the `pid` in status bar item.
5. Change terminal folder (e.g. `cd ~/.vscode-R`), and start R again.
6. The session is not attached since it is not started from home folder.