### PR TITLE
On Mac & Linux, rely on PATH being set up

### DIFF
--- a/package.json
+++ b/package.json
@@ -457,12 +457,12 @@
         "r.rterm.windows": {
           "type": "string",
           "default": "",
-          "description": "R.exe path for windows."
+          "description": "R.exe path for Windows."
         },
         "r.rterm.mac": {
           "type": "string",
           "default": "",
-          "description": "R path for Mac OS X."
+          "description": "R path for macOS."
         },
         "r.rterm.linux": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -461,12 +461,12 @@
         },
         "r.rterm.mac": {
           "type": "string",
-          "default": "/usr/local/bin/R",
+          "default": "",
           "description": "R path for Mac OS X."
         },
         "r.rterm.linux": {
           "type": "string",
-          "default": "/usr/bin/R",
+          "default": "",
           "description": "R path for Linux."
         },
         "r.rterm.option": {


### PR DESCRIPTION
Hardcoding the path should only be necessary in case the default configuration via `PATH` fails.