### PR TITLE
Fix previewDataframe for 2+ letter variables

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -30,10 +30,9 @@ export async function previewDataframe() {
         return undefined;
     }
 
-    const selectedTextArray = getWordOrSelection();
-    const dataframeName = selectedTextArray[0];
+    const dataframeName = getWordOrSelection();
 
-    if (selectedTextArray.length !== 1 || !checkForSpecialCharacters(dataframeName)) {
+    if (!checkForSpecialCharacters(dataframeName)) {
         window.showInformationMessage('This does not appear to be a dataframe.');
 
         return false;


### PR DESCRIPTION
Fixes #389 

**What problem did you solve?**

Command `R: Preview Dataframe` does not work if data frame name is 2+ letters. E.g., `R: Preview Dataframe` works if data frame name is `a`, but not if data frame name is `cars`.

The reason is that `getWordOrSelection()` changed from returning an array of strings to returning a single string, but its use in this function was not updated.

**How can I check this pull request?**

Create a file called `temp.R` containing just the text `cars`. Place cursor on `cars` and use `R: Preview Dataframe`. Observe that preview appears as expected.

Change the text to `cars cars`. Select BOTH WORDS and use `R: Preview Dataframe`. Observer the message 'This does not appear to be a dataframe', as expected (because the selection contains a space).