### PR TITLE
Restore R_PROFILE_USER

### DIFF
--- a/R/.Rprofile
+++ b/R/.Rprofile
@@ -9,6 +9,11 @@ local({
   }
 
   r_profile <- Sys.getenv("R_PROFILE_USER_OLD")
+  Sys.setenv(
+    R_PROFILE_USER_OLD = "",
+    R_PROFILE_USER = r_profile
+  )
+
   if (nzchar(r_profile)) {
     try_source(r_profile)
   } else {


### PR DESCRIPTION
Close #391 

This PR restores `R_PROFILE_USER` if specified so that `~/.vscode-R/.Rprofile` is hidden on user side when user gets `R_PROFILE_USER` as if it is originally specified.

When user calls `usethis::edit_r_profile()`, if user edits `~/.vscode-R/.Rprofile`, it would be confusing and of no use since the file is replaced each time the extension is activated. Restoring the original `R_PROFILE_USER` might make more sense.