### PR TITLE
Remove Ctrl + 1, 2, 3, 4, 5 shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.4.5
+
+* Remove shortcuts Ctrl + 1, 2, 3, 4, 5 #401 (Fix #368)
+
+    These conflicted with default Visual Studio Code keyboard shortcuts. If you would like to restore them, see the [instructions in the Wiki](https://github.com/Ikuyadeu/vscode-R/wiki/Keyboard-shortcuts#removed-keyboard-shortcuts).
+
 ## 1.4.4
 
 * Fix vulnerability issues

--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@ Full document is on the [Wiki page](https://github.com/Ikuyadeu/vscode-R/wiki)
 
 ## Features
 
-* Run Source(`Ctrl+Shift+S` or Push icon![icon](images/FileDownload.png)) and Run Selected Line (`Ctrl+Enter`)
-* Run `nrow`, `length`, `head`, `thead`, `names` functions (`Ctrl` + `1`, `2`, `3`, `4`, `5`)
-  * If you are using Mac `Ctrl` to `⌘`
+* Run Source(`Ctrl+Shift+S` or Push icon![icon](images/FileDownload.png)) and Run Selected Line (`Ctrl+Enter`) (Mac: `Ctrl` to `⌘`)
+* Run functions:
+  * `nrow` (`Show number of rows for selected object`)
+  * `length` (`Show length for a selected object`)
+  * `head` (`Show first part of a selected object`)
+  * `thead` (`Show first part of a selected object (transposed)`)
+  * `names` (`Show names for a selected object`)
 
 ![use Run .R](images/feature.png)
 

--- a/package.json
+++ b/package.json
@@ -382,36 +382,6 @@
         "when": "editorTextFocus && editorLangId == 'r'"
       },
       {
-        "command": "r.nrow",
-        "key": "Ctrl+1",
-        "mac": "cmd+1",
-        "when": "editorTextFocus && editorLangId == 'r'"
-      },
-      {
-        "command": "r.length",
-        "key": "Ctrl+2",
-        "mac": "cmd+2",
-        "when": "editorTextFocus && editorLangId == 'r'"
-      },
-      {
-        "command": "r.head",
-        "key": "Ctrl+3",
-        "mac": "cmd+3",
-        "when": "editorTextFocus && editorLangId == 'r'"
-      },
-      {
-        "command": "r.thead",
-        "key": "Ctrl+4",
-        "mac": "cmd+4",
-        "when": "editorTextFocus && editorLangId == 'r'"
-      },
-      {
-        "command": "r.names",
-        "key": "Ctrl+5",
-        "mac": "cmd+5",
-        "when": "editorTextFocus && editorLangId == 'r'"
-      },
-      {
         "command": "r.runSource",
         "key": "shift+Ctrl+s",
         "mac": "shift+cmd+s",


### PR DESCRIPTION
Fixes #368 

**What problem did you solve?**

Shortcuts `Ctrl + 1, 2, 3, 4, 5` overlap with default VS Code shortcuts. This PR removes these shortcuts. The commands are unchanged.

**How can I check this pull request?**

Run command `Preferences: Open Keyboard Shortcuts` and search for `Ctrl + 1`. Observe that only command is `workbench.action.focusFirstEditorGroup`.