### PR TITLE
Check url in browser

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -329,6 +329,20 @@ if (interactive() &&
           plot = getOption("vsc.plot", "Two"))
       }
 
+      path_to_uri <- function(path) {
+        if (length(path) == 0) {
+          return(character())
+        }
+        path <- path.expand(path)
+        if (.Platform$OS.type == "windows") {
+          prefix <- "file:///"
+          path <- gsub("\\", "/", path, fixed = TRUE)
+        } else {
+          prefix <- "file://"
+        }
+        paste0(prefix, utils::URLencode(path))
+      }
+
       browser <- function(url, title = url, ...,
         viewer = getOption("vsc.browser", "Active")) {
         if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
@@ -338,15 +352,18 @@ if (interactive() &&
           message("Opening in external browser...")
           request("browser", url = url, title = title, ..., viewer = FALSE)
         } else if (file.exists(url)) {
-          url <- normalizePath(url)
+          url <- normalizePath(url, "/", mustWork = TRUE)
           if (grepl("\\.html?$", url, ignore.case = TRUE)) {
             message("VSCode WebView has restricted access to local file.")
             message("Opening in external browser...")
-            request("browser", url = url, title = title, ..., viewer = FALSE)
+            request("browser", url = path_to_uri(url),
+              title = title, ..., viewer = FALSE)
           } else {
             request("dataview", source = "object", type = "txt",
               title = title, file = url, viewer = viewer)
           }
+        } else {
+          stop("File not exists")
         }
       }
 

--- a/R/init.R
+++ b/R/init.R
@@ -331,7 +331,23 @@ if (interactive() &&
 
       browser <- function(url, title = url, ...,
         viewer = getOption("vsc.browser", "Active")) {
-        request("browser", url = url, title = title, ..., viewer = viewer)
+        if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
+          request("browser", url = url, title = title, ..., viewer = viewer)
+        } else if (grepl("^https?\\://", url)) {
+          message("VSCode WebView only supports showing local http content.")
+          message("Opening in external browser...")
+          request("browser", url = url, title = title, ..., viewer = FALSE)
+        } else if (file.exists(url)) {
+          url <- normalizePath(url)
+          if (grepl("\\.html?$", url, ignore.case = TRUE)) {
+            message("VSCode WebView has restricted access to local file.")
+            message("Opening in external browser...")
+            request("browser", url = url, title = title, ..., viewer = FALSE)
+          } else {
+            request("dataview", source = "object", type = "txt",
+              title = title, file = url, viewer = viewer)
+          }
+        }
       }
 
       webview <- function(url, title, ..., viewer) {


### PR DESCRIPTION
**What problem did you solve?**

Closes #371 

**(If you do not have screenshot) How can I check this pull request?**

Following localhost http content it should work:

```r
?get
shiny::runExample("01_hello")
```

External http content should open in external web browser due to WebView restrictions on external web content:

```r
browseURL("https://google.com")
```

Local HTML file should open in external web browser due to WebView restrictions on resource location:

```r
tmpfile <- tempfile(fileext = ".html")
writeLines(c("<html>hello</html>"), tmpfile) 
browseURL(tmpfile)
```

Local non-HTML file should open in vscode editor as text document:

```r
tmpfile <- tempfile(fileext = ".txt")
writeLines("hello", tmpfile)
browseURL(tmpfile)
```
