### PR TITLE
Remove command Run Selection/Line in Active Terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,11 +257,6 @@
         "command": "r.runSelection"
       },
       {
-        "title": "Run Selection/Line in Active Terminal",
-        "category": "R",
-        "command": "r.runSelectionInActiveTerm"
-      },
-      {
         "title": "Show number of rows for selected object",
         "category": "R",
         "command": "r.nrow"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { CancellationToken, commands, CompletionContext, CompletionItem, Complet
 
 import { previewDataframe, previewEnvironment } from './preview';
 import { createGitignore } from './rGitignore';
-import { chooseTerminal, chooseTerminalAndSendText, createRTerm, deleteTerminal,
+import { chooseTerminal, createRTerm, deleteTerminal,
          runSelectionInTerm, runTextInTerm } from './rTerminal';
 import { getWordOrSelection, surroundSelection } from './selection';
 import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startRequestWatcher } from './session';
@@ -65,7 +65,7 @@ export function activate(context: ExtensionContext) {
             if (echo) {
                 rPath = [rPath, 'echo = TRUE'].join(', ');
             }
-            chooseTerminalAndSendText(`source(${rPath})`);
+            runTextInTerm(`source(${rPath})`);
         }
     }
 
@@ -81,9 +81,9 @@ export function activate(context: ExtensionContext) {
                 rPath = [rPath, 'echo = TRUE'].join(', ');
             }
             if (outputFormat === undefined) {
-                chooseTerminalAndSendText(`rmarkdown::render(${rPath})`);
+                runTextInTerm(`rmarkdown::render(${rPath})`);
             } else {
-                chooseTerminalAndSendText(`rmarkdown::render(${rPath}, "${outputFormat}")`);
+                runTextInTerm(`rmarkdown::render(${rPath}, "${outputFormat}")`);
             }
         }
     }
@@ -182,11 +182,11 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand('r.createGitignore', createGitignore),
         commands.registerCommand('r.previewDataframe', previewDataframe),
         commands.registerCommand('r.previewEnvironment', previewEnvironment),
-        commands.registerCommand('r.loadAll', () => chooseTerminalAndSendText('devtools::load_all()')),
-        commands.registerCommand('r.test', () => chooseTerminalAndSendText('devtools::test()')),
-        commands.registerCommand('r.install', () => chooseTerminalAndSendText('devtools::install()')),
-        commands.registerCommand('r.build', () => chooseTerminalAndSendText('devtools::build()')),
-        commands.registerCommand('r.document', () => chooseTerminalAndSendText('devtools::document()')),
+        commands.registerCommand('r.loadAll', () => runTextInTerm('devtools::load_all()')),
+        commands.registerCommand('r.test', () => runTextInTerm('devtools::test()')),
+        commands.registerCommand('r.install', () => runTextInTerm('devtools::install()')),
+        commands.registerCommand('r.build', () => runTextInTerm('devtools::build()')),
+        commands.registerCommand('r.document', () => runTextInTerm('devtools::document()')),
         commands.registerCommand('r.attachActive', attachActive),
         commands.registerCommand('r.showPlotHistory', showPlotHistory),
         commands.registerCommand('r.runCommandWithSelectionOrWord', runCommandWithSelectionOrWord),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -109,49 +109,38 @@ export function activate(context: ExtensionContext) {
     }
 
     async function runSelectionOrWord(rFunctionName: string[]) {
-        const callableTerminal = await chooseTerminal();
-        if (callableTerminal === undefined) {
-            return;
-        }
         const text = getWordOrSelection();
         const wrappedText = surroundSelection(text, rFunctionName);
-        runTextInTerm(callableTerminal, wrappedText);
+        runTextInTerm(wrappedText);
     }
 
     async function runCommandWithSelectionOrWord(rCommand: string) {
         const text = getWordOrSelection();
-        const callableTerminal = await chooseTerminal();
         const call = rCommand.replace(/\$\$/g, text);
-        runTextInTerm(callableTerminal, call);
+        runTextInTerm(call);
     }
 
     async function runCommandWithEditorPath(rCommand: string) {
         const wad: TextDocument = window.activeTextEditor.document;
         const isSaved = await saveDocument(wad);
         if (isSaved) {
-            const callableTerminal = await chooseTerminal();
             const rPath = ToRStringLiteral(wad.fileName, '');
             const call = rCommand.replace(/\$\$/g, rPath);
-            runTextInTerm(callableTerminal, call);
+            runTextInTerm(call);
         }
     }
 
     async function runCommand(rCommand: string) {
-        const callableTerminal = await chooseTerminal();
-        runTextInTerm(callableTerminal, rCommand);
+        runTextInTerm(rCommand);
     }
 
     async function runFromBeginningToLine() {
-        const callableTerminal = await chooseTerminal();
-        if (callableTerminal === undefined) {
-            return;
-        }
         const endLine = window.activeTextEditor.selection.end.line;
         const charactersOnLine = window.activeTextEditor.document.lineAt(endLine).text.length;
         const endPos = new Position(endLine, charactersOnLine);
         const range = new Range(new Position(0, 0), endPos);
         const text = window.activeTextEditor.document.getText(range);
-        runTextInTerm(callableTerminal, text);
+        runTextInTerm(text);
     }
 
     languages.registerCompletionItemProvider('r', {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -142,7 +142,7 @@ export function activate(context: ExtensionContext) {
     }
 
     async function runFromBeginningToLine() {
-        const callableTerminal = await chooseTerminal(true);
+        const callableTerminal = await chooseTerminal();
         if (callableTerminal === undefined) {
             return;
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { CancellationToken, commands, CompletionContext, CompletionItem, Complet
 
 import { previewDataframe, previewEnvironment } from './preview';
 import { createGitignore } from './rGitignore';
-import { chooseTerminal, createRTerm, deleteTerminal,
+import { createRTerm, deleteTerminal,
          runSelectionInTerm, runTextInTerm } from './rTerminal';
 import { getWordOrSelection, surroundSelection } from './selection';
 import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startRequestWatcher } from './session';
@@ -89,11 +89,7 @@ export function activate(context: ExtensionContext) {
     }
 
     async function runSelection() {
-        const callableTerminal = await chooseTerminal();
-        if (callableTerminal === undefined) {
-            return;
-        }
-        runSelectionInTerm(callableTerminal, true);
+        runSelectionInTerm(true);
     }
 
     async function runSelectionInActiveTerm() {
@@ -101,11 +97,7 @@ export function activate(context: ExtensionContext) {
     }
 
     async function runSelectionRetainCursor() {
-        const callableTerminal = await chooseTerminal();
-        if (callableTerminal === undefined) {
-            return;
-        }
-        runSelectionInTerm(callableTerminal, false);
+        runSelectionInTerm(false);
     }
 
     async function runSelectionOrWord(rFunctionName: string[]) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,10 +92,6 @@ export function activate(context: ExtensionContext) {
         runSelectionInTerm(true);
     }
 
-    async function runSelectionInActiveTerm() {
-        window.showWarningMessage('This command has been removed. Enable setting "Always Use Active Terminal".');
-    }
-
     async function runSelectionRetainCursor() {
         runSelectionInTerm(false);
     }
@@ -168,7 +164,6 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand('r.createRTerm', createRTerm),
         commands.registerCommand('r.runSourcewithEcho', () => { runSource(true); }),
         commands.registerCommand('r.runSelection', runSelection),
-        commands.registerCommand('r.runSelectionInActiveTerm', runSelectionInActiveTerm),
         commands.registerCommand('r.runFromBeginningToLine', runFromBeginningToLine),
         commands.registerCommand('r.runSelectionRetainCursor', runSelectionRetainCursor),
         commands.registerCommand('r.createGitignore', createGitignore),

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -3,7 +3,7 @@
 import { existsSync, mkdirSync, removeSync, statSync } from 'fs-extra';
 import { commands, extensions, window, workspace } from 'vscode';
 
-import { chooseTerminalAndSendText } from './rTerminal';
+import { runTextInTerm } from './rTerminal';
 import { getWordOrSelection } from './selection';
 import { checkForSpecialCharacters, checkIfFileExists, delay } from './util';
 
@@ -21,7 +21,7 @@ export async function previewEnvironment() {
                              + `${envClass},`
                              + `${envOut}), '`
                              + `${pathToTmpCsv}', row.names=FALSE, quote = TRUE)`;
-    chooseTerminalAndSendText(rWriteCsvCommand);
+    runTextInTerm(rWriteCsvCommand);
     await openTmpCSV(pathToTmpCsv, tmpDir);
 }
 
@@ -44,7 +44,7 @@ export async function previewDataframe() {
     const pathToTmpCsv = `${tmpDir}/${dataframeName}.csv`;
     const rWriteCsvCommand = `write.csv(${dataframeName}, `
                             + `'${pathToTmpCsv}', row.names = FALSE, quote = FALSE)`;
-    chooseTerminalAndSendText(rWriteCsvCommand);
+    runTextInTerm(rWriteCsvCommand);
     await openTmpCSV(pathToTmpCsv, tmpDir);
 }
 

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -136,15 +136,6 @@ export async function runTextInTerm(text: string) {
     setFocus(term);
 }
 
-export async function chooseTerminalAndSendText(text: string) {
-    const callableTerminal = await chooseTerminal();
-    if (callableTerminal === undefined) {
-        return;
-    }
-    callableTerminal.sendText(text);
-    setFocus(callableTerminal);
-}
-
 function setFocus(term: Terminal) {
     const focus: string = config().get('source.focus');
     term.show(focus !== 'terminal');

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -106,7 +106,7 @@ export async function chooseTerminal() {
     return rTerm;
 }
 
-export function runSelectionInTerm(term: Terminal, moveCursor: boolean) {
+export function runSelectionInTerm(moveCursor: boolean) {
     const selection = getSelection();
     if (moveCursor && selection.linesDownToMoveCursor > 0) {
         commands.executeCommand('cursorMove', { to: 'down', value: selection.linesDownToMoveCursor });

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -71,7 +71,7 @@ export async function chooseTerminal() {
             if (rTermNameOptions.includes(activeTerminalName)) {
                 return window.activeTerminal;
             }
-            for (let i = window.terminals.length - 1; i >= 0; i--){ 
+            for (let i = window.terminals.length - 1; i >= 0; i--){
                 const terminal = window.terminals[i];
                 const terminalName = terminal.name;
                 if (rTermNameOptions.includes(terminalName)) {

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -53,8 +53,8 @@ export function deleteTerminal(term: Terminal) {
     }
 }
 
-export async function chooseTerminal(active: boolean = false) {
-    if (active || config().get('alwaysUseActiveTerminal')) {
+export async function chooseTerminal() {
+    if (config().get('alwaysUseActiveTerminal')) {
         if (window.terminals.length < 1) {
             window.showInformationMessage('There are no open terminals.');
 

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -112,10 +112,14 @@ export function runSelectionInTerm(term: Terminal, moveCursor: boolean) {
         commands.executeCommand('cursorMove', { to: 'down', value: selection.linesDownToMoveCursor });
         commands.executeCommand('cursorMove', { to: 'wrappedLineFirstNonWhitespaceCharacter' });
     }
-    runTextInTerm(term, selection.selectedText);
+    runTextInTerm(selection.selectedText);
 }
 
-export async function runTextInTerm(term: Terminal, text: string) {
+export async function runTextInTerm(text: string) {
+    const term = await chooseTerminal();
+    if (term === undefined) {
+        return;
+    }
     if (config().get<boolean>('bracketedPaste')) {
         if (process.platform !== 'win32') {
             // Surround with ANSI control characters for bracketed paste mode

--- a/src/session.ts
+++ b/src/session.ts
@@ -7,7 +7,7 @@ import path = require('path');
 import { URL } from 'url';
 import { commands, StatusBarItem, Uri, ViewColumn, Webview, window, workspace, env } from 'vscode';
 
-import { chooseTerminalAndSendText } from './rTerminal';
+import { runTextInTerm } from './rTerminal';
 import { config } from './util';
 import { FSWatcher } from 'fs-extra';
 
@@ -65,7 +65,7 @@ export function startRequestWatcher(sessionStatusBarItem: StatusBarItem) {
 export function attachActive() {
     if (config().get<boolean>('sessionWatcher')) {
         console.info('[attachActive]');
-        chooseTerminalAndSendText('.vsc.attach()');
+        runTextInTerm('.vsc.attach()');
     } else {
         window.showInformationMessage('This command requires that r.sessionWatcher be enabled.');
     }
@@ -112,7 +112,7 @@ function updateSessionWatcher() {
     } else {
         console.info('[updateSessionWatcher] globalenvLockFile not found');
     }
-    
+
     console.info('[updateSessionWatcher] Create plotWatcher');
     plotFile = path.join(sessionDir, 'plot.png');
     plotLockFile = path.join(sessionDir, 'plot.lock');
@@ -449,7 +449,7 @@ function isFromWorkspace(dir: string) {
             }
         }
     }
-    
+
     return false;
 }
 


### PR DESCRIPTION
Closes #306

**What problem did you solve?**

This PR makes two changes:

1. It completely removes command `R: Run Selection/Line in Active Terminal`. Current behaviour of this command is to show a window stating that the command is being removed.
2. It refactors and simplifies code used to choose the terminal and send text to it. Currently, most commands that send text to the terminal explicitly choose the terminal too. This was to enable `R: Run Selection/Line in Active Terminal` to always choose the active terminal. Since that command is being removed, the code that chooses the terminal can be moved further down the sequence of function calls. Making this change means that `runTextInTerm()` and `chooseTerminalAndSendText()` do the same thing, although `chooseTerminalAndSendText()` works for only one line of code, so I removed `chooseTerminalAndSendText()`.

**How can I check this pull request?**

1. Check command `Run Selection/Line in Active Terminal` does NOT exist. (E.g., <kbd>Ctrl+Shift+P</kbd>, type 'Run Selection/Line in Active Terminal', confirm there is no such command.)

This PR involves code paths from many commands. It should not change the behaviour of any of them. Here is how to test they still work.

Add the following to `keybindings.json`:

```json
[
    {
        "key": "ctrl+1",
        "command": "r.runCommand",
        "when": "editorTextFocus",
        "args": "TEST runCommand"
    },
    {
        "key": "ctrl+2",
        "command": "r.runCommandWithSelectionOrWord",
        "when": "editorTextFocus",
        "args": "TEST runCommandWithSelectionOrWord $$"
    },
    {
        "key": "ctrl+3",
        "command": "r.runCommandWithEditorPath",
        "when": "editorTextFocus",
        "args": "TEST runCommandWithEditorPath $$"
    }
]
```

Make a directory `r-test` containing a file `temp.R`, with this content:

```R
1
print("hello world")
```

Place cursor on word 'hello'.

I recommend doing the below once with setting `r.alwaysUseActiveTerminal` enabled and once with it disabled.

1. Run command `R: Run Source`. Confirm `source([file path])` is sent to terminal.
1. Run command `R: Knit Rmd`. Confirm file is knitted in terminal.
1. Run command `R: Run Selection/Line`. Confirm `print("hello world")` is sent to terminal.
1. Run command `R: Run Selection/Line (Retain Cursor)`. Confirm `print("hello world")` is sent to terminal.
1. Run command `R: Show length for a selected object`. Confirm `length(hello)` is sent to terminal. (It's not a variable so it will cause an error - that's fine.)
1. Press <kbd>Ctrl+1</kbd>. Confirm `TEST runCommand` is sent to terminal. (It's not valid R code so it will cause an error - that's fine.)
1. Press <kbd>Ctrl+2</kbd>. Confirm `TEST runCommandWithSelectionOrWord hello` is sent to terminal. (It's not valid R code so it will cause an error - that's fine.)
1. Press <kbd>Ctrl+3</kbd>. Confirm `TEST runCommandWithEditorPath [file path]` is sent to terminal. (It's not valid R code so it will cause an error - that's fine.)
1. Place cursor on line 1, run command `R: Run from Beginning to Line`. Confirm `1` is sent to terminal.
1. Run command `R: Load All`. Confirm `devtools::load_all()` is sent to terminal. (It will cause an error - that's fine.)
1. Run command `R: Test Package`. Confirm `devtools::test()` is sent to terminal. (It will cause an error - that's fine.)
1. Run command `R: Install Package`. Confirm `devtools::install()` is sent to terminal. (It will cause an error - that's fine.)
1. Run command `R: Build Package`. Confirm `devtools::build()` is sent to terminal. (It will cause an error - that's fine.)
1. Run command `R: Document`. Confirm `devtools::document()` is sent to terminal. (It will cause an error - that's fine.)
1. Run command `R: Attach Active Terminal`. Confirm `.vsc.attach()` is sent to terminal.
1. Run command `R: Preview Environment`. Confirm something starting with `write.csv` is sent to the terminal. (This command is buggy so it might produce an error.)
1. Run command `R: Preview Dataframe`. Confirm something starting with `write.csv` is sent to the terminal. (`hello` is not a variable, so it might produce an error because of that, or it might produce a different error because it the command is buggy.)