### PR TITLE
Remove Run in Active Terminal from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,7 @@ Full document is on the [Wiki page](https://github.com/Ikuyadeu/vscode-R/wiki)
 
 ![Create R terminal](images/terminal.png)
 
-* Run code in terminal containing existing R session, for example over SSH (`Run Selection/Line in Active Terminal`)
 * Run all commands in terminal containing existing R session (enable config `r.alwaysUseActiveTerminal`)
-
-![R over SSH](images/ssh.gif)
 
 * Extended Syntax(R, R Markdown, R Documentation)
 


### PR DESCRIPTION
Fixes #412 

**What problem did you solve?**

`Run Selection/Line in Active Terminal` was removed in #409, but it is still mentioned in the README in text and in an animation. This PR removes those.

I've removed the equivalent text in the Wiki.