### PR TITLE
Recommend radian in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Requires [R](https://www.r-project.org/).
 
+We recommend using this extension with [radian](https://github.com/randy3k/radian), an alternative R console with multiline editing and rich syntax highlighting.
+
 ## Usage
 
 Full document is on the [Wiki page](https://github.com/Ikuyadeu/vscode-R/wiki)


### PR DESCRIPTION
Adds a line to the start of the README recommending radian.

This is taking the advice of this comment: https://github.com/Ikuyadeu/vscode-R/issues/415#issuecomment-702347406. I think we pretty much recommend every user of this extension also use radian, so I thought the point about emphasising it in the README made sense.

This PR changes some of the most valuable real estate in the README. If it seems like bad use of that space, feel free to disagree/discuss.