### PR TITLE
Fix issues in rstudioapi emulation

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -324,7 +324,7 @@ if (interactive() &&
       }
 
       attach <- function() {
-        rstudioapi_util_env$update_addin_registry(addin_registry)
+        rstudioapi_util_env$update_addin_registry_safely(addin_registry)
         request("attach",
           tempdir = tempdir,
           plot = getOption("vsc.plot", "Two"))

--- a/R/init.R
+++ b/R/init.R
@@ -444,13 +444,13 @@ if (interactive() &&
         file.create(response_file, showWarnings = FALSE)
         addin_registry <- file.path(dir_session, "addins.json")
         # This is created in attach()
-      
+
         get_response_timestamp <- function() {
           readLines(response_lock_file)
         }
         # initialise the reponse timestamp to empty string
         response_time_stamp <- ""
-      
+
         get_response_lock <- function() {
           lock_time_stamp <- get_response_timestamp()
           if (isTRUE(lock_time_stamp != response_time_stamp)) {
@@ -460,7 +460,7 @@ if (interactive() &&
             FALSE
           }
         }
-      
+
         request_response <- function(command, ...) {
           request(command, ..., sd = dir_session)
           wait_start <- Sys.time()
@@ -475,7 +475,7 @@ if (interactive() &&
           }
           jsonlite::read_json(response_file)
         }
-      
+
         rstudioapi_util_env <- new.env()
         rstudioapi_env <- new.env(parent = rstudioapi_util_env)
         source(file.path(dir_extension, "rstudioapi_util.R"),
@@ -486,7 +486,9 @@ if (interactive() &&
         )
         setHook(
           packageEvent("rstudioapi", "onLoad"),
-          function(...) rstudioapi_util_env$rstudioapi_patch_hook(rstudioapi_env)
+          function(...) {
+            rstudioapi_util_env$rstudioapi_patch_hook(rstudioapi_env)
+          }
         )
       }
 

--- a/R/init.R
+++ b/R/init.R
@@ -324,7 +324,7 @@ if (interactive() &&
       }
 
       attach <- function() {
-        rstudioapi_util_env$update_addin_registry_safely(addin_registry)
+        rstudioapi_util_env$update_addin_registry(addin_registry)
         request("attach",
           tempdir = tempdir,
           plot = getOption("vsc.plot", "Two"))

--- a/R/init.R
+++ b/R/init.R
@@ -432,6 +432,10 @@ if (interactive() &&
       )
 
       # rstudioapi
+      rstudioapi_enabled <- function() {
+        isTRUE(getOption("vsc.rstudioapi"))
+      }
+
       if (rstudioapi_enabled()) {
         response_timeout <- 5
         response_lock_file <- file.path(dir_session, "response.lock")

--- a/R/rstudioapi.R
+++ b/R/rstudioapi.R
@@ -228,16 +228,27 @@ viewer <- function(url, height = NULL) {
     .vsc.viewer(url)
 }
 
+getVersion <- function() {
+    numeric_version(0)
+}
+
+versionInfo <- function() {
+    list(
+        citation = "",
+        mode = "vscode",
+        version = numeric_version(0),
+        release_name = "vscode"
+    )
+}
 # Unimplemented API calls that will error if called.
 
 .vsc_not_yet_implemented <- function(...) {
     stop("This {rstudioapi} function is not currently implemented for VSCode.")
 }
 
+
 getConsoleEditorContext <- .vsc_not_yet_implemented
 sourceMarkers <- .vsc_not_yet_implemented
-versionInfo <- .vsc_not_yet_implemented
-getVersion <- .vsc_not_yet_implemented
 documentClose <- .vsc_not_yet_implemented
 sendToConsole <- .vsc_not_yet_implemented
 showPrompt <- .vsc_not_yet_implemented

--- a/R/rstudioapi_util.R
+++ b/R/rstudioapi_util.R
@@ -2,7 +2,13 @@ rstudioapi_call <- function(action, ...) {
     request_response("rstudioapi", action = action, args = list(...))
 }
 
+rstudioapi_enabled <- function() {
+    isTRUE(getOption("vsc.rstudioapi"))
+}
+
 rstudioapi_patch_hook <- function(api_env) {
+    if (!rstudioapi_enabled()) return(NULL)
+
     patch_rstudioapi_fn <-
         function(old, new) {
             if (namespace_has(old, "rstudioapi")) {
@@ -237,6 +243,8 @@ update_addin_registry <- function(addin_registry) {
 }
 
 update_addin_registry_safely <- function(addin_registry) {
+    if (!rstudioapi_enabled()) return(NULL)
+
     tryCatch(update_addin_registry(addin_registry),
         error = function(cond) {
             message(

--- a/R/rstudioapi_util.R
+++ b/R/rstudioapi_util.R
@@ -2,10 +2,6 @@ rstudioapi_call <- function(action, ...) {
     request_response("rstudioapi", action = action, args = list(...))
 }
 
-rstudioapi_enabled <- function() {
-    isTRUE(getOption("vsc.rstudioapi"))
-}
-
 rstudioapi_patch_hook <- function(api_env) {
     patch_rstudioapi_fn <-
         function(old, new) {

--- a/R/rstudioapi_util.R
+++ b/R/rstudioapi_util.R
@@ -7,10 +7,6 @@ rstudioapi_enabled <- function() {
 }
 
 rstudioapi_patch_hook <- function(api_env) {
-    if (!rstudioapi_enabled()) {
-        return(NULL)
-    }
-
     patch_rstudioapi_fn <-
         function(old, new) {
             if (namespace_has(old, "rstudioapi")) {
@@ -199,10 +195,6 @@ normalise_text_arg <- function(text, location_length) {
 }
 
 update_addin_registry <- function(addin_registry) {
-    if (!rstudioapi_enabled()) {
-        return(NULL)
-    }
-
     pkgs <- .packages(all.available = TRUE)
     addin_files <- vapply(pkgs, function(pkg) {
         system.file("rstudio/addins.dcf", package = pkg)

--- a/R/rstudioapi_util.R
+++ b/R/rstudioapi_util.R
@@ -208,8 +208,7 @@ update_addin_registry <- function(addin_registry) {
                         "package"
                     )
                 description_result <-
-                    tryCatch(
-                        {
+                    tryCatch({
                             addin_description <-
                                 as.data.frame(read.dcf(package_dcf),
                                     stringsAsFactors = FALSE
@@ -231,7 +230,8 @@ update_addin_registry <- function(addin_registry) {
                             message(
                                 "addins.dcf file for ", package,
                                 " could not be read from R library. ",
-                                "The RStudio addin picker will not contain it's addins"
+                                "The RStudio addin picker will not ",
+                                "contain it's addins"
                             )
 
                             NULL

--- a/R/rstudioapi_util.R
+++ b/R/rstudioapi_util.R
@@ -212,10 +212,10 @@ update_addin_registry <- function(addin_registry) {
                         stringsAsFactors = FALSE
                     )
 
-                if (ncol(addin_description) < 5) {
-                    return(NULL)
+                if (ncol(addin_description) < 4) {
+                    NULL
                 }
-                ## if less than 5 columns it's malformed
+                ## if less than 4 columns it's malformed
                 ## a NULL will be ignored in the rbind
 
                 addin_description$package <- package
@@ -241,8 +241,8 @@ update_addin_registry_safely <- function(addin_registry) {
         error = function(cond) {
             message(
                 "List of installed addins could not",
-                "be read from R library.",
-                "Possibly due to malformed addins.dcf files.",
+                "be read from R library. ",
+                "Possibly due to malformed addins.dcf files. ",
                 "The RStudio addin picker will not function."
             )
         }

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ The `"Two" | "Active" | "Beside"` are popular values from `ViewColumn` to specif
 
 The session watcher allows RStudio addins to be executed via an `{rstudioapi}` emulation layer.
 
+To enable this feature, set `options(vsc.rstudioapi = TRUE)` in your .Rprofile. 
+
 The extension provides the command `r.launchAddinPicker` which opens a filterable list of installed addins that can be launched. Bind this to a key, or access it from the command palette as `R: Launch RStudio Addin`.
 
 Alternatively, individual addin functions can be bound to keys using `r.runRCommand` as described in _Creating keybindings for R commands_ below.

--- a/src/rstudioapi.ts
+++ b/src/rstudioapi.ts
@@ -303,8 +303,6 @@ export async function launchAddinPicker() {
     throw ('No active R terminal session, attach one to use RStudio addins.');
   }
 
-  const activeRTerm = await chooseTerminal();
-
   const addinPickerOptions: QuickPickOptions = {
     matchOnDescription: true,
     matchOnDetail: true,


### PR DESCRIPTION
Resolves the issues discussed in #421:

1. If an `addins.dcf` file from a package is malformed it could cause an error when trying to write the JSON to drive the addin picker. This error could cause the `vsc.attach` function to fail to run fully. This was not very common. I found only one example in `{shrcts}`. 

I added extra checks to look for malformed files, and to only select the first few columns, assuming those contain the information I want to display. The whole `update_addins_registry` call is wrapped in a try-catch so that if it throws an error it is converted to a message about the failure and the consequences. `vsc.attach` will complete otherwise normally.

2. On Windows `library(tidyverse)` fails due to the `cli` package trying to interrogate the version of RStudio if it is available. I have put in implementations for `getVersion` and `versionInfo` that should allow this to work in the short term.

The plan is to discuss this with RStudio to see if we can get something less fragile.

Finally, to use the RStudio API emulation the user must set `options(vsc.rstudioapi = TRUE)` in the .Rprofile. I have put documentation about this in the README and will add it to the wiki.

Sorry for the hassles!
