### PR TITLE
Improve handling html help

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -350,7 +350,8 @@ if (interactive() &&
       }
 
       request_browser <- function(url, title, ..., viewer) {
-        # Printing URL with specific port triggers auto port-forwarding under remote development
+        # Printing URL with specific port triggers
+        # auto port-forwarding under remote development
         message("Browsing ", url)
         request("browser", url = url, title = title, ..., viewer = viewer)
       }

--- a/R/init.R
+++ b/R/init.R
@@ -349,16 +349,22 @@ if (interactive() &&
         paste0(prefix, utils::URLencode(path))
       }
 
+      request_browser <- function(url, title, ..., viewer) {
+        # Printing URL with specific port triggers auto port-forwarding under remote development
+        message("Browsing ", url)
+        request("browser", url = url, title = title, ..., viewer = viewer)
+      }
+
       show_browser <- function(url, title = url, ...,
         viewer = getOption("vsc.browser", "Active")) {
         if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
-          request("browser", url = url, title = title, ..., viewer = viewer)
+          request_browser(url = url, title = title, ..., viewer = viewer)
         } else if (grepl("^https?\\://", url)) {
           message(
             "VSCode WebView only supports showing local http content.\n",
             "Opening in external browser..."
           )
-          request("browser", url = url, title = title, ..., viewer = FALSE)
+          request_browser(url = url, title = title, ..., viewer = FALSE)
         } else if (file.exists(url)) {
           url <- normalizePath(url, "/", mustWork = TRUE)
           if (grepl("\\.html?$", url, ignore.case = TRUE)) {
@@ -366,7 +372,7 @@ if (interactive() &&
               "VSCode WebView has restricted access to local file.\n",
               "Opening in external browser..."
             )
-            request("browser", url = path_to_uri(url),
+            request_browser(url = path_to_uri(url),
               title = title, ..., viewer = FALSE)
           } else {
             request("dataview", source = "object", type = "txt",
@@ -393,13 +399,13 @@ if (interactive() &&
           }
         }
         if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
-          request("browser", url = url, title = title, ..., viewer = viewer)
+          request_browser(url = url, title = title, ..., viewer = viewer)
         } else if (grepl("^https?\\://", url)) {
           message(
             "VSCode WebView only supports showing local http content.\n",
             "Opening in external browser..."
           )
-          request("browser", url = url, title = title, ..., viewer = FALSE)
+          request_browser(url = url, title = title, ..., viewer = FALSE)
         } else if (file.exists(url)) {
           file <- normalizePath(url, "/", mustWork = TRUE)
           request("webview", file = file, title = title, viewer = viewer, ...)

--- a/R/init.R
+++ b/R/init.R
@@ -22,7 +22,9 @@ if (interactive() &&
       request_file <- file.path(dir_extension, "request.log")
       request_lock_file <- file.path(dir_extension, "request.lock")
 
-      options(help_type = "html")
+      if (is.null(getOption("help_type"))) {
+        options(help_type = "html")
+      }
 
       get_timestamp <- function() {
         format.default(Sys.time(), nsmall = 6)


### PR DESCRIPTION
**What problem did you solve?**

Addresses #426, #380 

Some users may prefer other ways to read help documentation (e.g. `text`  and set `options(help_type="text")` in `.Rprofile`). Using session watcher will no longer override that preference if specified.

This PR also adds printing the browsing url before sending browser request to session watcher so that vscode will capture the port in url and perform auto port forwarding under remote develoment. This is a walk around of https://github.com/microsoft/vscode/issues/102449.

**(If you do not have screenshot) How can I check this pull request?**

Regarding `options(help_type=)`

1. Add `options(help_type="text")` in `~/.Rprofile`.
2. Start vscode and an R session and the session is attached.
3. Run `?get`, the documentation will show up in the terminal instead of a new WebView tab.
4. Remove the option from the `.Rprofile` and restart an R session
5. Run `?get` and the documentation will show up in a new WebView tab instead of text.

Regarding printing URL in browser request:

1. Connect to a remote server via remote development via SSH/WSL/Containers
2. Start an R session and run `?get`
3. The `Browsing <URL>` message will show up in the terminal output and auto port forwarding should be triggered.
4. A new webview is open and the HTML help documentation should show properly.