### PR TITLE
Add runAboveChunks command

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "onCommand:r.runSelection",
     "onCommand:r.runSelectionInActiveTerm",
     "onCommand:r.runCurrentChunk",
+    "onCommand:r.runAboveChunks",
     "onCommand:r.createGitignore",
     "onCommand:r.runCommandWithSelectionOrWord",
     "onCommand:r.runCommandWithEditorPath",
@@ -362,6 +363,11 @@
         "command": "r.runCurrentChunk"
       },
       {
+        "title": "Run Above Chunks",
+        "category": "R",
+        "command": "r.runAboveChunks"
+      },
+      {
         "title": "Launch RStudio Addin",
         "category": "R",
         "command": "r.launchAddinPicker"
@@ -390,6 +396,12 @@
         "command": "r.runCurrentChunk",
         "key": "Ctrl+shift+enter",
         "mac": "cmd+shift+enter",
+        "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
+        "command": "r.runAboveChunks",
+        "key": "Ctrl+alt+p",
+        "mac": "cmd+alt+p",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { getWordOrSelection, surroundSelection } from './selection';
 import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startRequestWatcher } from './session';
 import { config, ToRStringLiteral } from './util';
 import { launchAddinPicker, trackLastActiveTextEditor } from './rstudioapi';
-import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk } from './rmarkdown';
+import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks } from './rmarkdown';
 
 const wordPattern = /(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\<\>\/\s]+)/g;
 
@@ -170,6 +170,7 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand('r.runFromBeginningToLine', runFromBeginningToLine),
         commands.registerCommand('r.runSelectionRetainCursor', runSelectionRetainCursor),
         commands.registerCommand('r.runCurrentChunk', runCurrentChunk),
+        commands.registerCommand('r.runAboveChunks', runAboveChunks),
         commands.registerCommand('r.runChunks', runChunksInTerm),
         commands.registerCommand('r.createGitignore', createGitignore),
         commands.registerCommand('r.previewDataframe', previewDataframe),

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -124,8 +124,13 @@ export function runSelectionInTerm(moveCursor: boolean) {
 }
 
 export async function runChunksInTerm(chunks: Range[]) {
-    const text = chunks.map((chunk) => window.activeTextEditor.document.getText(chunk)).join('\n');
-    return runTextInTerm(text);
+    const text = chunks
+        .map((chunk) => window.activeTextEditor.document.getText(chunk))
+        .filter((chunk) => chunk.trim().length > 0)
+        .join('\n');
+    if (text.length > 0) {
+        return runTextInTerm(text);
+    }
 }
 
 export async function runTextInTerm(text: string) {

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -125,8 +125,8 @@ export function runSelectionInTerm(moveCursor: boolean) {
 
 export async function runChunksInTerm(chunks: Range[]) {
     const text = chunks
-        .map((chunk) => window.activeTextEditor.document.getText(chunk))
-        .filter((chunk) => chunk.trim().length > 0)
+        .map((chunk) => window.activeTextEditor.document.getText(chunk).trim())
+        .filter((chunk) => chunk.length > 0)
         .join('\n');
     if (text.length > 0) {
         return runTextInTerm(text);


### PR DESCRIPTION
**What problem did you solve?**

Similar with `runCurrentChunk` command implemented in #429, this PR adds `runAboveChunks` command as requested by https://twitter.com/MichaelDorman84/status/1322499000164122624 which is supported in RStudio and has a keybinding of `ctrl+alt+p`.

**(If you do not have screenshot) How can I check this pull request?**

1. Create a Rmd document with the following content:

````
```{r,eval=FALSE}
m <- lm(mpg ~ ., data = mtcars)
summary(m)
```

```{r,eval=TRUE}
m <- lm(mpg ~ ., data = mtcars)
summary(m)
```

```{r chunk-1}
x <- rnorm(100)
y <- rnorm(100)
```

```{r plot1}
plot(rnorm(100))
abline(h = 0, col = "red")
```
````

Run `r.runAboveChunks` with cursor inside each chunk in the above document. For the first two chunks, the command sends nothing to the terminal. For the third chunk, the second chunk is sent to the terminal (since the first chunk has `eval=FALSE`), the for the last chunk, the 2nd and 3rd chunks are sent to the terminal.

The command by default has a keybinding of `ctrl+alt+p` which is consistent with RStudio for rmd document. Press the shortcut and see if it works as expected.