### PR TITLE
platform independent content string splitting

### DIFF
--- a/R/rstudioapi_util.R
+++ b/R/rstudioapi_util.R
@@ -43,7 +43,8 @@ extract_document_ranges <- function(vsc_selections) {
 }
 
 to_content_lines <- function(contents, ranges) {
-    content_lines <- strsplit(contents, "\n")[[1]]
+    content_lines <- strsplit(contents, "\n|\r\n|\r$")[[1]]
+
 
     # edge case handling: The cursor is at the start of a new empty line,
     # and that line is the final line.


### PR DESCRIPTION
**What problem did you solve?**
On my Windows installation, even with VSCode line ending set to "\n", `rstudioapi::getActiveDocumentContext()` gets document contents that have "\r\n" line endings.

This adjusts some string splitting code to handle the presence of "\r".

**How to test**

1. On Windows, open a document in VSCode and attach an R session.

2. Run `rstudioapi::getActiveDocumentContext()$contents` and observe that you get a vector of type character, one element per line, that has no line separators in the text "\r" or "\n".

3. For completeness you could also run 

```
rstudioapi::insertText("Line 1\r\nLine 2\r\n")
rstudioapi::insertText("Line 1\nLine 2\n")
```
And verify that on the input side, the use of "\r" has no effect.