### PR TITLE
Friendly error message when trying to launch addin picker and vsc.rstudioapi = FALSE

### DIFF
--- a/src/rstudioapi.ts
+++ b/src/rstudioapi.ts
@@ -272,7 +272,16 @@ let addinQuickPicks: AddinItem[] = undefined;
 export async function getAddinPickerItems() {
 
   if (typeof addinQuickPicks === 'undefined') {
-    const addins: any[] = await fs.readJSON(path.join(sessionDir, 'addins.json'));
+    const addins: any[] = await fs.readJSON(path.join(sessionDir, 'addins.json')).
+      then(
+        (result) => result,
+        (reason) => {
+          throw ('Could not find list of installed addins.' +
+            ' options(vsc.rstudioapi = TRUE) must be set in your .Rprofile to use.' +
+            ' RStudio Addins');
+        }
+      );
+
     const addinItems = addins.map((x) => {
       return {
         alwaysShow: true,

--- a/src/rstudioapi.ts
+++ b/src/rstudioapi.ts
@@ -277,7 +277,7 @@ export async function getAddinPickerItems() {
         (result) => result,
         (reason) => {
           throw ('Could not find list of installed addins.' +
-            ' options(vsc.rstudioapi = TRUE) must be set in your .Rprofile to use.' +
+            ' options(vsc.rstudioapi = TRUE) must be set in your .Rprofile to use ' +
             ' RStudio Addins');
         }
       );


### PR DESCRIPTION
**What problem did you solve?**

In the case that the user has not set the option `vsc.rstudioapi = TRUE` the addin picker gives an unhelpful error message. This PR adds an error message that directs the user to set the option to TRUE.

A root cause of #439 was the confusing error.

**(If you do not have screenshot) How can I check this pull request?**

In your `.Rprofile` set `vsc.rstudioapi = FALSE`. Start a new R terminal in VSCode and run the `R: Launch RStudio Addin` command. 

An error should appear:

```
Command 'R: Launch RStudio Addin' resulted in an error (Could not find list of installed addins. options(vsc.rstudioapi = TRUE) must be set in your .Rprofile to use RStudio Addins)
```