### PR TITLE
Send code at EOF appends new line

### DIFF
--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -5,7 +5,7 @@ import path = require('path');
 
 import { pathExists } from 'fs-extra';
 import { isDeepStrictEqual } from 'util';
-import { commands, Range, Terminal, TerminalOptions, window } from 'vscode';
+import { commands, Position, Range, Terminal, TerminalOptions, window } from 'vscode';
 
 import { getSelection } from './selection';
 import { removeSessionFiles } from './session';
@@ -117,6 +117,11 @@ export async function chooseTerminal() {
 export function runSelectionInTerm(moveCursor: boolean) {
     const selection = getSelection();
     if (moveCursor && selection.linesDownToMoveCursor > 0) {
+        const lineCount = window.activeTextEditor.document.lineCount;
+        if (selection.linesDownToMoveCursor + window.activeTextEditor.selection.end.line === lineCount) {
+            const endPos = new Position(lineCount, window.activeTextEditor.document.lineAt(lineCount - 1).text.length);
+            window.activeTextEditor.edit(e => e.insert(endPos, '\n'));
+        }
         commands.executeCommand('cursorMove', { to: 'down', value: selection.linesDownToMoveCursor });
         commands.executeCommand('cursorMove', { to: 'wrappedLineFirstNonWhitespaceCharacter' });
     }


### PR DESCRIPTION
Closes #233

**What problem did you solve?**

Currently, sending code at last line does not append a new line but moves cursor to the first non-whitespace character.

This PR changes it so that sending code at last line appends a new line and then moves down cursor.

**How can I test this PR?**

Create file `temp.R` with text

```r
list(x = 1,
     y = 2)
```

Make sure there is no new blank line at the end of file.

Put cursor on line 2, <kbd>Ctrl-Enter</kbd>.

Verify that cursor is now on a new line at end of file (line 3).

Same thing, starting cursor on line 1. Verify that cursor is now on a new line at end of file (line 3).

I tested on Linux and Windows.

**Difference from RStudio**

Consider this case:

```r
x <- 1 
# Several blank lines. Cursor on next line.



```

The version in this PR will add another blank line at the end of the file, and move the cursor to that. In the same situation, RStudio does not do anything: no new line is added and the cursor does not move. However, the behaviour is already different to RStudio in `master`, which moves the cursor to the end of file (without adding a new line).