### PR TITLE
Add terminal information to chooseTerminal error

### DIFF
--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -95,8 +95,12 @@ export async function chooseTerminal() {
                     return window.terminals[0];
                 }
             } else {
+                let msg = `There are ${window.terminals.length} terminals: `;
+                for (let i = 0; i < window.terminals.length; i++){
+                    msg += `Terminal ${i}: ${window.terminals[i].name} `;
+                }
                 // tslint:disable-next-line: max-line-length
-                window.showInformationMessage('Error identifying terminal! This shouldn\'t happen, so please file an issue at https://github.com/Ikuyadeu/vscode-R/issues');
+                window.showErrorMessage(`Error identifying terminal! Please copy this message to https://github.com/Ikuyadeu/vscode-R/issues: ${msg}`);
 
                 return undefined;
             }

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -72,6 +72,11 @@ export async function chooseTerminal() {
         return window.activeTerminal;
     }
 
+    let msg = '[chooseTerminal] ';
+    msg += `A. There are ${window.terminals.length} terminals: `;
+    for (let i = 0; i < window.terminals.length; i++){
+        msg += `Terminal ${i}: ${window.terminals[i].name} `;
+    }
     if (window.terminals.length > 0) {
         const rTermNameOptions = ['R', 'R Interactive'];
         if (window.activeTerminal !== undefined) {
@@ -88,6 +93,10 @@ export async function chooseTerminal() {
                 }
             }
         } else {
+            msg += `B. There are ${window.terminals.length} terminals: `;
+            for (let i = 0; i < window.terminals.length; i++){
+                msg += `Terminal ${i}: ${window.terminals[i].name} `;
+            }
             // Creating a terminal when there aren't any already does not seem to set activeTerminal
             if (window.terminals.length === 1) {
                 const activeTerminalName = window.terminals[0].name;
@@ -95,12 +104,13 @@ export async function chooseTerminal() {
                     return window.terminals[0];
                 }
             } else {
-                let msg = `There are ${window.terminals.length} terminals: `;
+                msg += `C. There are ${window.terminals.length} terminals: `;
                 for (let i = 0; i < window.terminals.length; i++){
                     msg += `Terminal ${i}: ${window.terminals[i].name} `;
                 }
+                console.info(msg);
                 // tslint:disable-next-line: max-line-length
-                window.showErrorMessage(`Error identifying terminal! Please copy this message to https://github.com/Ikuyadeu/vscode-R/issues: ${msg}`);
+                window.showErrorMessage('Error identifying terminal! Please run command "Developer: Toggle Developer Tools", find the message starting with "[chooseTerminal]", and copy the message to https://github.com/Ikuyadeu/vscode-R/issues');
 
                 return undefined;
             }


### PR DESCRIPTION
**What problem did you solve?**

This is related to #385. I can't reproduce the error, so this PR adds more information to the error message, which users can pass on to us.
  
**Screenshot**

I can't reproduce the error, so I made this screenshot by copy-pasting the message code to the top of `chooseTerminal()`.

EDIT: Updated the image. 

![terminals3](https://user-images.githubusercontent.com/23294156/99144830-90c51e80-26ac-11eb-840e-bd0e8b02d7ae.png)

**How can I check this pull request?**

I don't have instructions for how to reproduce the error, so I think review will have to be code review only, without testing.