### PR TITLE
New feature r.runFromLineToEnd

### DIFF
--- a/package.json
+++ b/package.json
@@ -353,6 +353,11 @@
         "command": "r.runFromBeginningToLine"
       },
       {
+        "title": "Run from Line to End",
+        "category": "R",
+        "command": "r.runFromLineToEnd"
+      },
+      {
         "title": "Run Selection/Line (Retain Cursor)",
         "category": "R",
         "command": "r.runSelectionRetainCursor"
@@ -426,6 +431,12 @@
         "command": "r.runFromBeginningToLine",
         "key": "Ctrl+alt+b",
         "mac": "cmd+alt+b",
+        "when": "editorTextFocus && editorLangId == 'r'"
+      },
+      {
+        "command": "r.runFromLineToEnd",
+        "key": "Ctrl+alt+e",
+        "mac": "cmd+alt+e",
         "when": "editorTextFocus && editorLangId == 'r'"
       }
     ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -137,7 +137,7 @@ export function activate(context: ExtensionContext) {
     async function runFromLineToEnd() {
         const startLine = window.activeTextEditor.selection.start.line;
         const startPos = new Position(startLine, 0);
-        const endLine = window.activeTextEditor.document.lineCount
+        const endLine = window.activeTextEditor.document.lineCount;
         const range = new Range(startPos, new Position(endLine, 0));
         const text = window.activeTextEditor.document.getText(range);
         runTextInTerm(text);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,6 +134,15 @@ export function activate(context: ExtensionContext) {
         runTextInTerm(text);
     }
 
+    async function runFromLineToEnd() {
+        const startLine = window.activeTextEditor.selection.start.line;
+        const startPos = new Position(startLine, 0);
+        const endLine = window.activeTextEditor.document.lineCount
+        const range = new Range(startPos, new Position(endLine, 0));
+        const text = window.activeTextEditor.document.getText(range);
+        runTextInTerm(text);
+    }
+
     languages.registerCompletionItemProvider('r', {
         provideCompletionItems(document: TextDocument, position: Position) {
             if (document.lineAt(position).text
@@ -168,6 +177,7 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand('r.runSourcewithEcho', () => { runSource(true); }),
         commands.registerCommand('r.runSelection', runSelection),
         commands.registerCommand('r.runFromBeginningToLine', runFromBeginningToLine),
+        commands.registerCommand('r.runFromLineToEnd', runFromLineToEnd),
         commands.registerCommand('r.runSelectionRetainCursor', runSelectionRetainCursor),
         commands.registerCommand('r.runCurrentChunk', runCurrentChunk),
         commands.registerCommand('r.runAboveChunks', runAboveChunks),


### PR DESCRIPTION
Closes #442 

**What problem did you solve?**
New feature ` r.runFromLineToEnd` bind to VSCode hotkey `Ctrl+alt+e`, similar to `r.runFromBeginningToLine` bind to VSCode hotkey `Ctrl+alt+b`.

**(If you do not have screenshot) How can I check this pull request?**
Create file `temp.R` with text, position cursor at line 2, run `r.runFromLineToEnd` or press hotkey `Ctrl+alt+e` to run the codes from current line to end

```r
1+1
2+2  # Position cursor in this line,  run `r.runFromLineToEnd` or press hotkey `Ctrl+alt+e` 
3+3
4+4
5+5
```