### PR TITLE
Add GitHub Action for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: release
+
+# runs when a tag v* is pushed
+# creates a release draft with the binaries
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm install
+      - uses: lannonbr/vsce-action@master
+        with:
+          args: "package"
+      - name: Identify output file # can be retrieved as steps.filenames.outputs.file_out
+        id: filenames
+        run: echo "::set-output name=file_out::$(ls | grep "^.*\.vsix$" | head -1)"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ steps.filenames.outputs.file_out }}
+          path: ${{ steps.filenames.outputs.file_out }}
+
+  release:
+    name: Release
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: "artifacts/"
+      - name: Get version from tag
+        id: get_version
+        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\/v/}
+      - name: Create release
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          files: "artifacts/*/*"
+          prerelease: false
+          draft: true # Could also be false to publish the release immediately
+


### PR DESCRIPTION
Fix #382 (or at least make it easier to fix)

This action file is being used in https://github.com/ManuelHentschel/VSCode-R-Debugger to automatically prepare a release when a tag matching `"v*"` is pushed and so far it seems to be working nicely.

The text of the release is a list of commits since the last release and the .vsix file is added to the release as a binary.

I am using `draft: true` to be able to check the release and add the binaries from the accompanying R package, but that could also be set to `false` to publish the release immediately.