### PR TITLE
Fix checking workspaceFolders in rHelpProviderOptions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ export async function activate(context: ExtensionContext) {
     }
     const rHelpProviderOptions = {
         rPath: rPath,
-        cwd: (workspace.workspaceFolders.length > 0 ? workspace.workspaceFolders[0].uri.fsPath : undefined)
+        cwd: (workspace.workspaceFolders !== undefined ? workspace.workspaceFolders[0].uri.fsPath : undefined)
     };
 
     // which helpProvider to use.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ export async function activate(context: ExtensionContext) {
     }
     const rHelpProviderOptions = {
         rPath: rPath,
-        cwd: (workspace.workspaceFolders !== undefined ? workspace.workspaceFolders[0].uri.fsPath : undefined)
+        cwd: ((workspace.workspaceFolders !== undefined && workspace.workspaceFolders.length > 0) ? workspace.workspaceFolders[0].uri.fsPath : undefined)
     };
 
     // which helpProvider to use.


### PR DESCRIPTION
**What problem did you solve?**

Fix checking `workspaceFolders` in the initialization of the help panel.

**(If you do not have screenshot) How can I check this pull request?**

1. No open workspace folders.
2. Open or create an R file.
3. vscode-R should be activated properly.