### PR TITLE
Rmd fenced block syntax highlighting for julia, python, etc

### DIFF
--- a/syntax/Markdown Redcarpet.json
+++ b/syntax/Markdown Redcarpet.json
@@ -13,6 +13,13 @@
                 {"include" : "#fenced_block_cpp"},
                 {"include" : "#fenced_block_yaml"},
                 {"include" : "#fenced_block"},
+                {"include" : "#fenced_block_julia"},
+                {"include" : "#fenced_block_stan"},
+                {"include" : "#fenced_block_python"},
+                {"include" : "#fenced_block_sql"},
+                {"include" : "#fenced_block_css"},
+                {"include" : "#fenced_block_scss"},
+                {"include" : "#fenced_block_js"},
                 {"include" : "#link-def"},
                 {"include" : "#html"},
                 {"include" : "#paragraph"}
@@ -48,6 +55,62 @@
                     "name" : "meta.embedded.block.yaml",
                     "patterns" : [
                         {"include" : "source.yaml"}
+                    ]
+                },
+                "fenced_block_julia" : {
+                    "begin" : "(^|\\G)([`]{3})\\{*[ ]*(?:julia).*\\}*$",
+                    "end" : "(^|\\G)([`]{3})($|\\z)",
+                    "name" : "meta.embedded.block.julia",
+                    "patterns" : [
+                        {"include" : "source.julia"}
+                    ]
+                },
+                "fenced_block_stan" : {
+                    "begin" : "(^|\\G)([`]{3})\\{*[ ]*(?:stan).*\\}*$",
+                    "end" : "(^|\\G)([`]{3})($|\\z)",
+                    "name" : "meta.embedded.block.stan",
+                    "patterns" : [
+                        {"include" : "source.stan"}
+                    ]
+                },
+                "fenced_block_python" : {
+                    "begin" : "(^|\\G)([`]{3})\\{*[ ]*(?:python).*\\}*$",
+                    "end" : "(^|\\G)([`]{3})($|\\z)",
+                    "name" : "meta.embedded.block.python",
+                    "patterns" : [
+                        {"include" : "source.python"}
+                    ]
+                },
+                "fenced_block_sql" : {
+                    "begin" : "(^|\\G)([`]{3})\\{*[ ]*(?:sql).*\\}*$",
+                    "end" : "(^|\\G)([`]{3})($|\\z)",
+                    "name" : "meta.embedded.block.sql",
+                    "patterns" : [
+                        {"include" : "source.sql"}
+                    ]
+                },
+                "fenced_block_css" : {
+                    "begin" : "(^|\\G)([`]{3})\\{*[ ]*(?:css).*\\}*$",
+                    "end" : "(^|\\G)([`]{3})($|\\z)",
+                    "name" : "meta.embedded.block.css",
+                    "patterns" : [
+                        {"include" : "source.css"}
+                    ]
+                },
+                "fenced_block_scss" : {
+                    "begin" : "(^|\\G)([`]{3})\\{*[ ]*(?:scss).*\\}*$",
+                    "end" : "(^|\\G)([`]{3})($|\\z)",
+                    "name" : "meta.embedded.block.css.scss",
+                    "patterns" : [
+                        {"include" : "source.css.scss"}
+                    ]
+                },
+                "fenced_block_js" : {
+                    "begin" : "(^|\\G)([`]{3})\\{*[ ]*(?:js).*\\}*$",
+                    "end" : "(^|\\G)([`]{3})($|\\z)",
+                    "name" : "meta.embedded.block.js",
+                    "patterns" : [
+                        {"include" : "source.js"}
                     ]
                 }
             }


### PR DESCRIPTION
**What problem did you solve?**
Add Rmd fenced block syntax highlighting for common languages in Rmd
- Julia
- Stan
- Python
- SQL
- CSS
- SCSS
- JS

Although there are a total of 42 supported languages, I think we can keep VSCode-R lean by just supporting additional languages above, which should cover almost all use cases. New language can be added upon user request.

```r
❯ names(knitr::knit_engines$get())

 [1] "awk"       "bash"      "coffee"    "gawk"      "groovy"
 [6] "haskell"   "lein"      "mysql"     "node"      "octave"
[11] "perl"      "psql"      "Rscript"   "ruby"      "sas"
[16] "scala"     "sed"       "sh"        "stata"     "zsh"
[21] "highlight" "Rcpp"      "tikz"      "dot"       "c"
[26] "cc"        "fortran"   "fortran95" "asy"       "cat"
[31] "asis"      "stan"      "block"     "block2"    "js"
[36] "css"       "sql"       "go"        "python"    "julia"
[41] "sass"      "scss"
```

# Before PR

![1](https://user-images.githubusercontent.com/54139483/99940851-1ccbfa00-2dc1-11eb-983b-102a21e7b814.png)

# After PR

_(Kindly ignore the minor different colors of my Julia's starting code block because I customize it in my theme extension. They all should have the same colors on your machine e.g. white color as shown here)_

![2](https://user-images.githubusercontent.com/54139483/99940871-26edf880-2dc1-11eb-93dd-209460c1cce1.png)
 