### PR TITLE
Fixes #443

### DIFF
--- a/src/lineCache.ts
+++ b/src/lineCache.ts
@@ -40,10 +40,30 @@ export class LineCache {
     }
 }
 
-function cleanLine(text: string) {
-    const cleaned = text.replace(/\s*\#.*/, '');
+function isQuote(c: string) {
+    return c === '"' || c === '\'' || c === '`';
+}
 
-    return (cleaned);
+function isComment(c: string) {
+    return c === '#';
+}
+
+function cleanLine(text: string) {
+    let cleaned = '';
+    let withinQuotes = null;
+    for (let i = 0; i < text.length; i++) {
+        const c = text[i];
+        if (isQuote(c)) {
+            withinQuotes = (withinQuotes === c) ? null : c;
+        }
+        if (isComment(c) && !withinQuotes) {
+            break;
+        }
+
+        cleaned += c;
+    }
+
+    return (cleaned.trimEnd());
 }
 
 function doesLineEndInOperator(text: string) {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -600,4 +600,19 @@ suite('Extension Tests', () => {
         assert.equal(extendSelection(2, f, doc.length).endLine, 2);
     });
 
+    test('Selecting multi-line expression with comment char in quotes', () => {
+        const doc = `
+        "a" %>%
+        paste("#") %>%
+        paste("'#") %>%
+        paste("'") %>%
+        print() # } #
+        `.split('\n');
+        function f(i) { return (doc[i]); }
+        assert.equal(extendSelection(1, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(1, f, doc.length).endLine, 5);
+        assert.equal(extendSelection(2, f, doc.length).startLine, 0);
+        assert.equal(extendSelection(2, f, doc.length).endLine, 5);
+    });
+
 });


### PR DESCRIPTION
The Ctrl+Enter shortcut does not work properly when a non-comment line in a function contains the "#" character.

The problem was that the cleanLine removes everything until the #, the new regex does a lookbehind and lookahead and does not match # within quotes.