### PR TITLE
RMarkdown: Add run & navigation commands. More customization. Refactor.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "onCommand:r.runSelectionInActiveTerm",
     "onCommand:r.runCurrentChunk",
     "onCommand:r.runPreviousChunk",
+    "onCommand:r.runNextChunk",
     "onCommand:r.runAboveChunks",
     "onCommand:r.runFromCurrentToBelowChunks",
     "onCommand:r.runBelowChunks",
@@ -394,6 +395,11 @@
         "command": "r.runPreviousChunk"
       },
       {
+        "title": "Run Next Chunk",
+        "category": "R",
+        "command": "r.runNextChunk"
+      },
+      {
         "title": "Run Above Chunks",
         "category": "R",
         "command": "r.runAboveChunks"
@@ -448,6 +454,12 @@
         "command": "r.runPreviousChunk",
         "key": "Ctrl+alt+shift+p",
         "mac": "cmd+alt+shift+p",
+        "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
+        "command": "r.runNextChunk",
+        "key": "Ctrl+alt+n",
+        "mac": "cmd+alt+n",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {

--- a/package.json
+++ b/package.json
@@ -51,12 +51,8 @@
     "onCommand:r.runCurrentAndBelowChunks",
     "onCommand:r.runBelowChunks",
     "onCommand:r.runAllChunks",
-    "onCommand:r.goToBeginningOfChunk",
-    "onCommand:r.goToEndOfChunk",
     "onCommand:r.goToPreviousChunk",
     "onCommand:r.goToNextChunk",
-    "onCommand:r.goToFirstChunk",
-    "onCommand:r.goToLastChunk",
     "onCommand:r.createGitignore",
     "onCommand:r.runCommandWithSelectionOrWord",
     "onCommand:r.runCommandWithEditorPath",
@@ -432,16 +428,6 @@
         "command": "r.runAllChunks"
       },
       {
-        "title": "Go to Beginning of Chunk",
-        "category": "R",
-        "command": "r.goToBeginningOfChunk"
-      },
-      {
-        "title": "Go to End of Chunk",
-        "category": "R",
-        "command": "r.goToEndOfChunk"
-      },
-      {
         "title": "Go to Previous Chunk",
         "category": "R",
         "command": "r.goToPreviousChunk"
@@ -450,16 +436,6 @@
         "title": "Go to Next Chunk",
         "category": "R",
         "command": "r.goToNextChunk"
-      },
-      {
-        "title": "Go to First Chunk",
-        "category": "R",
-        "command": "r.goToFirstChunk"
-      },
-      {
-        "title": "Go to Last Chunk",
-        "category": "R",
-        "command": "r.goToLastChunk"
       },
       {
         "title": "Launch RStudio Addin",
@@ -487,87 +463,15 @@
         "when": "editorTextFocus && editorLangId == 'r'"
       },
       {
-        "command": "r.selectCurrentChunk",
-        "key": "Shift+alt+s",
-        "mac": "Shift+alt+s",
-        "when": "editorTextFocus && editorLangId == 'rmd'"
-      },
-      {
         "command": "r.runCurrentChunk",
         "key": "Ctrl+shift+enter",
         "mac": "cmd+shift+enter",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {
-        "command": "r.runPreviousChunk",
-        "key": "Ctrl+shift+alt+p",
-        "mac": "cmd+shift+alt+p",
-        "when": "editorTextFocus && editorLangId == 'rmd'"
-      },
-      {
-        "command": "r.runNextChunk",
-        "key": "Ctrl+shift+alt+n",
-        "mac": "cmd+shift+alt+n",
-        "when": "editorTextFocus && editorLangId == 'rmd'"
-      },
-      {
         "command": "r.runAboveChunks",
         "key": "Ctrl+alt+p",
         "mac": "cmd+alt+p",
-        "when": "editorTextFocus && editorLangId == 'rmd'"
-      },
-      {
-        "command": "r.runCurrentAndBelowChunks",
-        "key": "Ctrl+alt+n",
-        "mac": "cmd+alt+n",
-        "when": "editorTextFocus && editorLangId == 'rmd'"
-      },
-      {
-        "command": "r.runBelowChunks",
-        "key": "Ctrl+alt+e",
-        "mac": "cmd+alt+e",
-        "when": "editorTextFocus && editorLangId == 'rmd'"
-      },
-      {
-        "command": "r.runAllChunks",
-        "key": "Ctrl+alt+r",
-        "mac": "cmd+alt+r",
-        "when": "editorTextFocus && editorLangId == 'rmd'"
-      },
-      {
-        "command": "r.goToBeginningOfChunk",
-        "key": "Shift+alt+b",
-        "mac": "Shift+alt+b",
-        "when": "editorTextFocus && editorLangId == 'rmd'"
-      },
-      {
-        "command": "r.goToEndOfChunk",
-        "key": "Shift+alt+e",
-        "mac": "Shift+alt+e",
-        "when": "editorTextFocus && editorLangId == 'rmd'"
-      },
-      {
-        "command": "r.goToPreviousChunk",
-        "key": "Shift+alt+p",
-        "mac": "Shift+alt+p",
-        "when": "editorTextFocus && editorLangId == 'rmd'"
-      },
-      {
-        "command": "r.goToNextChunk",
-        "key": "Shift+alt+n",
-        "mac": "Shift+alt+n",
-        "when": "editorTextFocus && editorLangId == 'rmd'"
-      },
-      {
-        "command": "r.goToFirstChunk",
-        "key": "Shift+alt+f",
-        "mac": "Shift+alt+f",
-        "when": "editorTextFocus && editorLangId == 'rmd'"
-      },
-      {
-        "command": "r.goToLastChunk",
-        "key": "Shift+alt+l",
-        "mac": "Shift+alt+l",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {
@@ -662,13 +566,9 @@
           },
           "default": [
             "r.runCurrentChunk",
-            "r.runAboveChunks",
-            "r.runCurrentAndBelowChunks",
-            "r.runAllChunks",
-            "r.goToPreviousChunk",
-            "r.goToNextChunk"
+            "r.runAboveChunks"
           ],
-          "description": "Customize RMarkdown CodeLens, which are inline commands/buttons e.g. 'Run Chunk' shown on the first line of each code chunk. Available commands:\n\nr.selectCurrentChunk\nr.runCurrentChunk\nr.runAboveChunks\nr.runCurrentAndBelowChunks\nr.runBelowChunks\nr.runAllChunks\nr.runPreviousChunk\nr.runNextChunk\nr.goToBeginningOfChunk\nr.goToEndOfChunk\nr.goToPreviousChunk\nr.goToNextChunk\nr.goToFirstChunk\nr.goToLastChunk\n\n----------------------------------\nCustomize both the commands AND its orders (that is, CodeLens respect user-specified orders):"
+          "description": "Customize RMarkdown CodeLens, which are inline commands/buttons e.g. 'Run Chunk' shown on the first line of each code chunk. Available commands:\n\nr.selectCurrentChunk\nr.runCurrentChunk\nr.runAboveChunks\nr.runCurrentAndBelowChunks\nr.runBelowChunks\nr.runAllChunks\nr.runPreviousChunk\nr.runNextChunk\nr.goToPreviousChunk\nr.goToNextChunk\n\n----------------------------------\nCustomize both the commands AND its orders (that is, CodeLens respect user-specified orders):"
         },
         "r.rmarkdown.enableCodeLens": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "onCommand:r.runSelectionInActiveTerm",
     "onCommand:r.runCurrentChunk",
     "onCommand:r.runAboveChunks",
+    "onCommand:r.runFromCurrentToBelowChunks",
     "onCommand:r.createGitignore",
     "onCommand:r.runCommandWithSelectionOrWord",
     "onCommand:r.runCommandWithEditorPath",
@@ -390,6 +391,11 @@
         "command": "r.runAboveChunks"
       },
       {
+        "title": "Run From Current to Below Chunks",
+        "category": "R",
+        "command": "r.runFromCurrentToBelowChunks"
+      },
+      {
         "title": "Launch RStudio Addin",
         "category": "R",
         "command": "r.launchAddinPicker"
@@ -424,6 +430,12 @@
         "command": "r.runAboveChunks",
         "key": "Ctrl+alt+p",
         "mac": "cmd+alt+p",
+        "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
+        "command": "r.runFromCurrentToBelowChunks",
+        "key": "Ctrl+alt+e",
+        "mac": "cmd+alt+e",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "onCommand:r.runFromCurrentToBelowChunks",
     "onCommand:r.runBelowChunks",
     "onCommand:r.runAllChunks",
+    "onCommand:r.goToPreviousChunk",
     "onCommand:r.createGitignore",
     "onCommand:r.runCommandWithSelectionOrWord",
     "onCommand:r.runCommandWithEditorPath",
@@ -420,6 +421,11 @@
         "command": "r.runAllChunks"
       },
       {
+        "title": "Go To Previous Chunk",
+        "category": "R",
+        "command": "r.goToPreviousChunk"
+      },
+      {
         "title": "Launch RStudio Addin",
         "category": "R",
         "command": "r.launchAddinPicker"
@@ -484,6 +490,12 @@
         "command": "r.runAllChunks",
         "key": "Ctrl+alt+r",
         "mac": "cmd+alt+r",
+        "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
+        "command": "r.goToPreviousChunk",
+        "key": "Ctrl+shift+alt+p",
+        "mac": "cmd+shift+alt+p",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {

--- a/package.json
+++ b/package.json
@@ -655,7 +655,7 @@
             "type": "string"
           }
         },
-        "r.rMarkdownCodeLens.option": {
+        "r.rmarkdown.codeLensCommands": {
           "type": "array",
           "items": {
             "type": "string"
@@ -668,17 +668,17 @@
             "r.goToPreviousChunk",
             "r.goToNextChunk"
           ],
-          "description": "Available options:\n\nr.selectCurrentChunk\nr.runCurrentChunk\nr.runAboveChunks\nr.runCurrentAndBelowChunks\nr.runBelowChunks\nr.runAllChunks\nr.runPreviousChunk\nr.runNextChunk\nr.goToBeginningOfChunk\nr.goToEndOfChunk\nr.goToPreviousChunk\nr.goToNextChunk\nr.goToFirstChunk\nr.goToLastChunk\n\n----------------------------------\nCustomize both the options AND its orders (that is, code lens respect user-specified orders):"
+          "description": "Customize RMarkdown CodeLens, which are inline commands/buttons e.g. 'Run Chunk' shown on the first line of each code chunk. Available commands:\n\nr.selectCurrentChunk\nr.runCurrentChunk\nr.runAboveChunks\nr.runCurrentAndBelowChunks\nr.runBelowChunks\nr.runAllChunks\nr.runPreviousChunk\nr.runNextChunk\nr.goToBeginningOfChunk\nr.goToEndOfChunk\nr.goToPreviousChunk\nr.goToNextChunk\nr.goToFirstChunk\nr.goToLastChunk\n\n----------------------------------\nCustomize both the commands AND its orders (that is, CodeLens respect user-specified orders):"
         },
-        "r.rMarkdownCodeLens.enableCodeLens": {
+        "r.rmarkdown.enableCodeLens": {
           "type": "boolean",
           "default": true,
-          "description": "Enable RMarkdown code lens"
+          "description": "Enable RMarkdown CodeLens, which are inline commands/buttons e.g. 'Run Chunk | Run Above' shown on the first line of each code chunk.\n\n- Click the buttons to run commands.\n- Hover on the buttons to show tooltips.\n- CodeLens commands are customizable via settings UI (Rmarkdown: Code Lens commands) or settings.json `r.rmarkdown.codeLensCommands`"
         },
-        "r.rMarkdownCodeLens.chunkBackgroundColor": {
+        "r.rmarkdown.chunkBackgroundColor": {
           "type": "string",
           "default": "rgba(128, 128, 128, 0.1)",
-          "description": "RMarkdown code lens chunk background color in RGBA or RGB value. Defaults to rgba(128, 128, 128, 0.1). Reload VS Code after changing settings. Only works when option `rMarkdownCodeLens.enableCodeLens` is set to true (default).\n\nLearn how to set colors: https://www.w3schools.com/css/css_colors_rgb.asp.\n\nExamples for syntax rgba(<red>, <green>, <blue>, <alpha>):\nrgba(128, 128, 128, 0.1)\nrgba(128, 128, 128, 0.3)\nrgba(255, 165, 0, 0.1)\n\n"
+          "description": "RMarkdown chunk background color in RGBA or RGB value. Defaults to rgba(128, 128, 128, 0.1). Leave it empty to disable it (use default editor background color). Reload VS Code after changing settings.\n\nLearn how to set colors: https://www.w3schools.com/css/css_colors_rgb.asp.\n\nExamples for syntax rgba(<red>, <green>, <blue>, <alpha>):\nrgba(128, 128, 128, 0.1)\nrgba(128, 128, 128, 0.3)\nrgba(255, 165, 0, 0.1)\n\n"
         },
         "r.helpPanel.enableSyntaxHighlighting": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "onCommand:r.runSourcewithEcho",
     "onCommand:r.runSelection",
     "onCommand:r.runSelectionInActiveTerm",
+    "onCommand:r.selectCurrentChunk",
     "onCommand:r.runCurrentChunk",
     "onCommand:r.runPreviousChunk",
     "onCommand:r.runNextChunk",
@@ -50,6 +51,8 @@
     "onCommand:r.runCurrentAndBelowChunks",
     "onCommand:r.runBelowChunks",
     "onCommand:r.runAllChunks",
+    "onCommand:r.goToBeginningOfChunk",
+    "onCommand:r.goToEndOfChunk",
     "onCommand:r.goToPreviousChunk",
     "onCommand:r.goToNextChunk",
     "onCommand:r.goToFirstChunk",
@@ -389,6 +392,11 @@
         "command": "r.runSelectionRetainCursor"
       },
       {
+        "title": "Select Current Chunk",
+        "category": "R",
+        "command": "r.selectCurrentChunk"
+      },
+      {
         "title": "Run Current Chunk",
         "category": "R",
         "command": "r.runCurrentChunk"
@@ -422,6 +430,16 @@
         "title": "Run All Chunks",
         "category": "R",
         "command": "r.runAllChunks"
+      },
+      {
+        "title": "Go to Beginning of Chunk",
+        "category": "R",
+        "command": "r.goToBeginningOfChunk"
+      },
+      {
+        "title": "Go to End of Chunk",
+        "category": "R",
+        "command": "r.goToEndOfChunk"
       },
       {
         "title": "Go to Previous Chunk",
@@ -469,6 +487,12 @@
         "when": "editorTextFocus && editorLangId == 'r'"
       },
       {
+        "command": "r.selectCurrentChunk",
+        "key": "Shift+alt+s",
+        "mac": "Shift+alt+s",
+        "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
         "command": "r.runCurrentChunk",
         "key": "Ctrl+shift+enter",
         "mac": "cmd+shift+enter",
@@ -508,6 +532,18 @@
         "command": "r.runAllChunks",
         "key": "Ctrl+alt+r",
         "mac": "cmd+alt+r",
+        "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
+        "command": "r.goToBeginningOfChunk",
+        "key": "Shift+alt+b",
+        "mac": "Shift+alt+b",
+        "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
+        "command": "r.goToEndOfChunk",
+        "key": "Shift+alt+e",
+        "mac": "Shift+alt+e",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {
@@ -632,7 +668,7 @@
             "r.goToPreviousChunk",
             "r.goToNextChunk"
           ],
-          "description": "Available options:\n\nr.runCurrentChunk\nr.runAboveChunks\nr.runCurrentAndBelowChunks\nr.runBelowChunks\nr.runAllChunks\nr.runPreviousChunk\nr.runNextChunk\nr.goToPreviousChunk\nr.goToNextChunk\nr.goToFirstChunk\nr.goToLastChunk\n\n----------------------------------\nSpecify options:"
+          "description": "Available options:\n\nr.selectCurrentChunk\nr.runCurrentChunk\nr.runAboveChunks\nr.runCurrentAndBelowChunks\nr.runBelowChunks\nr.runAllChunks\nr.goToBeginningOfChunk\nr.goToEndOfChunk\nr.runPreviousChunk\nr.runNextChunk\nr.goToPreviousChunk\nr.goToNextChunk\nr.goToFirstChunk\nr.goToLastChunk\n\n----------------------------------\nSpecify options:"
         },
         "r.helpPanel.enableSyntaxHighlighting": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -47,11 +47,13 @@
     "onCommand:r.runPreviousChunk",
     "onCommand:r.runNextChunk",
     "onCommand:r.runAboveChunks",
-    "onCommand:r.runFromCurrentToBelowChunks",
+    "onCommand:r.runCurrentAndBelowChunks",
     "onCommand:r.runBelowChunks",
     "onCommand:r.runAllChunks",
     "onCommand:r.goToPreviousChunk",
     "onCommand:r.goToNextChunk",
+    "onCommand:r.goToFirstChunk",
+    "onCommand:r.goToLastChunk",
     "onCommand:r.createGitignore",
     "onCommand:r.runCommandWithSelectionOrWord",
     "onCommand:r.runCommandWithEditorPath",
@@ -407,9 +409,9 @@
         "command": "r.runAboveChunks"
       },
       {
-        "title": "Run From Current to Below Chunks",
+        "title": "Run Current and Below Chunks",
         "category": "R",
-        "command": "r.runFromCurrentToBelowChunks"
+        "command": "r.runCurrentAndBelowChunks"
       },
       {
         "title": "Run Below Chunks",
@@ -422,14 +424,24 @@
         "command": "r.runAllChunks"
       },
       {
-        "title": "Go To Previous Chunk",
+        "title": "Go to Previous Chunk",
         "category": "R",
         "command": "r.goToPreviousChunk"
       },
       {
-        "title": "Go To Next Chunk",
+        "title": "Go to Next Chunk",
         "category": "R",
         "command": "r.goToNextChunk"
+      },
+      {
+        "title": "Go to First Chunk",
+        "category": "R",
+        "command": "r.goToFirstChunk"
+      },
+      {
+        "title": "Go to Last Chunk",
+        "category": "R",
+        "command": "r.goToLastChunk"
       },
       {
         "title": "Launch RStudio Addin",
@@ -464,14 +476,14 @@
       },
       {
         "command": "r.runPreviousChunk",
-        "key": "Ctrl+alt+shift+p",
-        "mac": "cmd+alt+shift+p",
+        "key": "Ctrl+shift+alt+p",
+        "mac": "cmd+shift+alt+p",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {
         "command": "r.runNextChunk",
-        "key": "Ctrl+alt+n",
-        "mac": "cmd+alt+n",
+        "key": "Ctrl+shift+alt+n",
+        "mac": "cmd+shift+alt+n",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {
@@ -481,15 +493,15 @@
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {
-        "command": "r.runFromCurrentToBelowChunks",
-        "key": "Ctrl+alt+e",
-        "mac": "cmd+alt+e",
+        "command": "r.runCurrentAndBelowChunks",
+        "key": "Ctrl+alt+n",
+        "mac": "cmd+alt+n",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {
         "command": "r.runBelowChunks",
-        "key": "Ctrl+alt+shift+e",
-        "mac": "cmd+alt+shift+e",
+        "key": "Ctrl+alt+e",
+        "mac": "cmd+alt+e",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {
@@ -500,14 +512,26 @@
       },
       {
         "command": "r.goToPreviousChunk",
-        "key": "Ctrl+shift+alt+p",
-        "mac": "cmd+shift+alt+p",
+        "key": "Shift+alt+p",
+        "mac": "Shift+alt+p",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {
         "command": "r.goToNextChunk",
-        "key": "Ctrl+shift+alt+n",
-        "mac": "cmd+shift+alt+n",
+        "key": "Shift+alt+n",
+        "mac": "Shift+alt+n",
+        "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
+        "command": "r.goToFirstChunk",
+        "key": "Shift+alt+f",
+        "mac": "Shift+alt+f",
+        "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
+        "command": "r.goToLastChunk",
+        "key": "Shift+alt+l",
+        "mac": "Shift+alt+l",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {
@@ -594,6 +618,21 @@
           "items": {
             "type": "string"
           }
+        },
+        "r.rMarkdownCodeLens.option": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "r.runCurrentChunk",
+            "r.runAboveChunks",
+            "r.runCurrentAndBelowChunks",
+            "r.runAllChunks",
+            "r.goToPreviousChunk",
+            "r.goToNextChunk"
+          ],
+          "description": "Available options:\n\nr.runCurrentChunk\nr.runAboveChunks\nr.runCurrentAndBelowChunks\nr.runBelowChunks\nr.runAllChunks\nr.runPreviousChunk\nr.runNextChunk\nr.goToPreviousChunk\nr.goToNextChunk\nr.goToFirstChunk\nr.goToLastChunk\n\n----------------------------------\nSpecify options:"
         },
         "r.helpPanel.enableSyntaxHighlighting": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "onCommand:r.runSelection",
     "onCommand:r.runSelectionInActiveTerm",
     "onCommand:r.runCurrentChunk",
+    "onCommand:r.runPreviousChunk",
     "onCommand:r.runAboveChunks",
     "onCommand:r.runFromCurrentToBelowChunks",
     "onCommand:r.runBelowChunks",
@@ -388,6 +389,11 @@
         "command": "r.runCurrentChunk"
       },
       {
+        "title": "Run Previous Chunk",
+        "category": "R",
+        "command": "r.runPreviousChunk"
+      },
+      {
         "title": "Run Above Chunks",
         "category": "R",
         "command": "r.runAboveChunks"
@@ -436,6 +442,12 @@
         "command": "r.runCurrentChunk",
         "key": "Ctrl+shift+enter",
         "mac": "cmd+shift+enter",
+        "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
+        "command": "r.runPreviousChunk",
+        "key": "Ctrl+alt+shift+p",
+        "mac": "cmd+alt+shift+p",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "onCommand:r.runAboveChunks",
     "onCommand:r.runFromCurrentToBelowChunks",
     "onCommand:r.runBelowChunks",
+    "onCommand:r.runAllChunks",
     "onCommand:r.createGitignore",
     "onCommand:r.runCommandWithSelectionOrWord",
     "onCommand:r.runCommandWithEditorPath",
@@ -402,6 +403,11 @@
         "command": "r.runBelowChunks"
       },
       {
+        "title": "Run All Chunks",
+        "category": "R",
+        "command": "r.runAllChunks"
+      },
+      {
         "title": "Launch RStudio Addin",
         "category": "R",
         "command": "r.launchAddinPicker"
@@ -448,6 +454,12 @@
         "command": "r.runBelowChunks",
         "key": "Ctrl+alt+shift+e",
         "mac": "cmd+alt+shift+e",
+        "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
+        "command": "r.runAllChunks",
+        "key": "Ctrl+alt+r",
+        "mac": "cmd+alt+r",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "onCommand:r.runBelowChunks",
     "onCommand:r.runAllChunks",
     "onCommand:r.goToPreviousChunk",
+    "onCommand:r.goToNextChunk",
     "onCommand:r.createGitignore",
     "onCommand:r.runCommandWithSelectionOrWord",
     "onCommand:r.runCommandWithEditorPath",
@@ -426,6 +427,11 @@
         "command": "r.goToPreviousChunk"
       },
       {
+        "title": "Go To Next Chunk",
+        "category": "R",
+        "command": "r.goToNextChunk"
+      },
+      {
         "title": "Launch RStudio Addin",
         "category": "R",
         "command": "r.launchAddinPicker"
@@ -496,6 +502,12 @@
         "command": "r.goToPreviousChunk",
         "key": "Ctrl+shift+alt+p",
         "mac": "cmd+shift+alt+p",
+        "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
+        "command": "r.goToNextChunk",
+        "key": "Ctrl+shift+alt+n",
+        "mac": "cmd+shift+alt+n",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "onCommand:r.runCurrentChunk",
     "onCommand:r.runAboveChunks",
     "onCommand:r.runFromCurrentToBelowChunks",
+    "onCommand:r.runBelowChunks",
     "onCommand:r.createGitignore",
     "onCommand:r.runCommandWithSelectionOrWord",
     "onCommand:r.runCommandWithEditorPath",
@@ -396,6 +397,11 @@
         "command": "r.runFromCurrentToBelowChunks"
       },
       {
+        "title": "Run Below Chunks",
+        "category": "R",
+        "command": "r.runBelowChunks"
+      },
+      {
         "title": "Launch RStudio Addin",
         "category": "R",
         "command": "r.launchAddinPicker"
@@ -436,6 +442,12 @@
         "command": "r.runFromCurrentToBelowChunks",
         "key": "Ctrl+alt+e",
         "mac": "cmd+alt+e",
+        "when": "editorTextFocus && editorLangId == 'rmd'"
+      },
+      {
+        "command": "r.runBelowChunks",
+        "key": "Ctrl+alt+shift+e",
+        "mac": "cmd+alt+shift+e",
         "when": "editorTextFocus && editorLangId == 'rmd'"
       },
       {

--- a/package.json
+++ b/package.json
@@ -670,6 +670,16 @@
           ],
           "description": "Available options:\n\nr.selectCurrentChunk\nr.runCurrentChunk\nr.runAboveChunks\nr.runCurrentAndBelowChunks\nr.runBelowChunks\nr.runAllChunks\nr.runPreviousChunk\nr.runNextChunk\nr.goToBeginningOfChunk\nr.goToEndOfChunk\nr.goToPreviousChunk\nr.goToNextChunk\nr.goToFirstChunk\nr.goToLastChunk\n\n----------------------------------\nCustomize both the options AND its orders (that is, code lens respect user-specified orders):"
         },
+        "r.rMarkdownCodeLens.enableCodeLens": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable RMarkdown code lens"
+        },
+        "r.rMarkdownCodeLens.chunkBackgroundColor": {
+          "type": "string",
+          "default": "rgba(128, 128, 128, 0.1)",
+          "description": "RMarkdown code lens chunk background color in RGBA or RGB value. Defaults to rgba(128, 128, 128, 0.1). Reload VS Code after changing settings. Only works when option `rMarkdownCodeLens.enableCodeLens` is set to true (default).\n\nLearn how to set colors: https://www.w3schools.com/css/css_colors_rgb.asp.\n\nExamples for syntax rgba(<red>, <green>, <blue>, <alpha>):\nrgba(128, 128, 128, 0.1)\nrgba(128, 128, 128, 0.3)\nrgba(255, 165, 0, 0.1)\n\n"
+        },
         "r.helpPanel.enableSyntaxHighlighting": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -668,7 +668,7 @@
             "r.goToPreviousChunk",
             "r.goToNextChunk"
           ],
-          "description": "Available options:\n\nr.selectCurrentChunk\nr.runCurrentChunk\nr.runAboveChunks\nr.runCurrentAndBelowChunks\nr.runBelowChunks\nr.runAllChunks\nr.goToBeginningOfChunk\nr.goToEndOfChunk\nr.runPreviousChunk\nr.runNextChunk\nr.goToPreviousChunk\nr.goToNextChunk\nr.goToFirstChunk\nr.goToLastChunk\n\n----------------------------------\nSpecify options:"
+          "description": "Available options:\n\nr.selectCurrentChunk\nr.runCurrentChunk\nr.runAboveChunks\nr.runCurrentAndBelowChunks\nr.runBelowChunks\nr.runAllChunks\nr.runPreviousChunk\nr.runNextChunk\nr.goToBeginningOfChunk\nr.goToEndOfChunk\nr.goToPreviousChunk\nr.goToNextChunk\nr.goToFirstChunk\nr.goToLastChunk\n\n----------------------------------\nCustomize both the options AND its orders (that is, code lens respect user-specified orders):"
         },
         "r.helpPanel.enableSyntaxHighlighting": {
           "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { getWordOrSelection, surroundSelection } from './selection';
 import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startRequestWatcher } from './session';
 import { config, ToRStringLiteral, getRpath, getRpathFromSystem } from './util';
 import { launchAddinPicker, trackLastActiveTextEditor } from './rstudioapi';
-import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks, runFromCurrentToBelowChunks, runBelowChunks, runPreviousChunk, runNextChunk, runAllChunks, goToPreviousChunk, goToNextChunk } from './rmarkdown';
+import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks, runCurrentAndBelowChunks, runBelowChunks, runPreviousChunk, runNextChunk, runAllChunks, goToPreviousChunk, goToNextChunk, goToFirstChunk, goToLastChunk } from './rmarkdown';
 
 import * as path from 'path';
 
@@ -251,11 +251,13 @@ export async function activate(context: ExtensionContext) {
         commands.registerCommand('r.runPreviousChunk', runPreviousChunk),
         commands.registerCommand('r.runNextChunk', runNextChunk),
         commands.registerCommand('r.runAboveChunks', runAboveChunks),
-        commands.registerCommand('r.runFromCurrentToBelowChunks', runFromCurrentToBelowChunks),
+        commands.registerCommand('r.runCurrentAndBelowChunks', runCurrentAndBelowChunks),
         commands.registerCommand('r.runBelowChunks', runBelowChunks),
         commands.registerCommand('r.runAllChunks', runAllChunks),
         commands.registerCommand('r.goToPreviousChunk', goToPreviousChunk),
         commands.registerCommand('r.goToNextChunk', goToNextChunk),
+        commands.registerCommand('r.goToFirstChunk', goToFirstChunk),
+        commands.registerCommand('r.goToLastChunk', goToLastChunk),
         commands.registerCommand('r.runChunks', runChunksInTerm),
         commands.registerCommand('r.createGitignore', createGitignore),
         commands.registerCommand('r.previewDataframe', previewDataframe),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { getWordOrSelection, surroundSelection } from './selection';
 import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startRequestWatcher } from './session';
 import { config, ToRStringLiteral, getRpath, getRpathFromSystem } from './util';
 import { launchAddinPicker, trackLastActiveTextEditor } from './rstudioapi';
-import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, selectCurrentChunk, runCurrentChunk, runAboveChunks, runCurrentAndBelowChunks, runBelowChunks, runPreviousChunk, runNextChunk, runAllChunks, goToBeginningOfChunk, goToEndOfChunk, goToPreviousChunk, goToNextChunk, goToFirstChunk, goToLastChunk } from './rmarkdown';
+import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, selectCurrentChunk, runCurrentChunk, runAboveChunks, runCurrentAndBelowChunks, runBelowChunks, runPreviousChunk, runNextChunk, runAllChunks, goToPreviousChunk, goToNextChunk } from './rmarkdown';
 
 import * as path from 'path';
 
@@ -255,12 +255,8 @@ export async function activate(context: ExtensionContext) {
         commands.registerCommand('r.runCurrentAndBelowChunks', runCurrentAndBelowChunks),
         commands.registerCommand('r.runBelowChunks', runBelowChunks),
         commands.registerCommand('r.runAllChunks', runAllChunks),
-        commands.registerCommand('r.goToBeginningOfChunk', goToBeginningOfChunk),
-        commands.registerCommand('r.goToEndOfChunk', goToEndOfChunk),
         commands.registerCommand('r.goToPreviousChunk', goToPreviousChunk),
         commands.registerCommand('r.goToNextChunk', goToNextChunk),
-        commands.registerCommand('r.goToFirstChunk', goToFirstChunk),
-        commands.registerCommand('r.goToLastChunk', goToLastChunk),
         commands.registerCommand('r.runChunks', runChunksInTerm),
         commands.registerCommand('r.createGitignore', createGitignore),
         commands.registerCommand('r.previewDataframe', previewDataframe),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { getWordOrSelection, surroundSelection } from './selection';
 import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startRequestWatcher } from './session';
 import { config, ToRStringLiteral, getRpath, getRpathFromSystem } from './util';
 import { launchAddinPicker, trackLastActiveTextEditor } from './rstudioapi';
-import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks, runFromCurrentToBelowChunks, runBelowChunks, runPreviousChunk, runNextChunk, runAllChunks, goToPreviousChunk } from './rmarkdown';
+import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks, runFromCurrentToBelowChunks, runBelowChunks, runPreviousChunk, runNextChunk, runAllChunks, goToPreviousChunk, goToNextChunk } from './rmarkdown';
 
 import * as path from 'path';
 
@@ -255,6 +255,7 @@ export async function activate(context: ExtensionContext) {
         commands.registerCommand('r.runBelowChunks', runBelowChunks),
         commands.registerCommand('r.runAllChunks', runAllChunks),
         commands.registerCommand('r.goToPreviousChunk', goToPreviousChunk),
+        commands.registerCommand('r.goToNextChunk', goToNextChunk),
         commands.registerCommand('r.runChunks', runChunksInTerm),
         commands.registerCommand('r.createGitignore', createGitignore),
         commands.registerCommand('r.previewDataframe', previewDataframe),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { getWordOrSelection, surroundSelection } from './selection';
 import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startRequestWatcher } from './session';
 import { config, ToRStringLiteral, getRpath, getRpathFromSystem } from './util';
 import { launchAddinPicker, trackLastActiveTextEditor } from './rstudioapi';
-import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks, runFromCurrentToBelowChunks, runBelowChunks, runPreviousChunk, runAllChunks } from './rmarkdown';
+import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks, runFromCurrentToBelowChunks, runBelowChunks, runPreviousChunk, runNextChunk, runAllChunks } from './rmarkdown';
 
 import * as path from 'path';
 
@@ -249,6 +249,7 @@ export async function activate(context: ExtensionContext) {
         commands.registerCommand('r.runSelectionRetainCursor', runSelectionRetainCursor),
         commands.registerCommand('r.runCurrentChunk', runCurrentChunk),
         commands.registerCommand('r.runPreviousChunk', runPreviousChunk),
+        commands.registerCommand('r.runNextChunk', runNextChunk),
         commands.registerCommand('r.runAboveChunks', runAboveChunks),
         commands.registerCommand('r.runFromCurrentToBelowChunks', runFromCurrentToBelowChunks),
         commands.registerCommand('r.runBelowChunks', runBelowChunks),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { getWordOrSelection, surroundSelection } from './selection';
 import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startRequestWatcher } from './session';
 import { config, ToRStringLiteral, getRpath, getRpathFromSystem } from './util';
 import { launchAddinPicker, trackLastActiveTextEditor } from './rstudioapi';
-import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks, runFromCurrentToBelowChunks } from './rmarkdown';
+import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks, runFromCurrentToBelowChunks, runBelowChunks } from './rmarkdown';
 
 import * as path from 'path';
 
@@ -250,6 +250,7 @@ export async function activate(context: ExtensionContext) {
         commands.registerCommand('r.runCurrentChunk', runCurrentChunk),
         commands.registerCommand('r.runAboveChunks', runAboveChunks),
         commands.registerCommand('r.runFromCurrentToBelowChunks', runFromCurrentToBelowChunks),
+        commands.registerCommand('r.runBelowChunks', runBelowChunks),
         commands.registerCommand('r.runChunks', runChunksInTerm),
         commands.registerCommand('r.createGitignore', createGitignore),
         commands.registerCommand('r.previewDataframe', previewDataframe),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { getWordOrSelection, surroundSelection } from './selection';
 import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startRequestWatcher } from './session';
 import { config, ToRStringLiteral, getRpath, getRpathFromSystem } from './util';
 import { launchAddinPicker, trackLastActiveTextEditor } from './rstudioapi';
-import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks } from './rmarkdown';
+import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks, runFromCurrentToBelowChunks } from './rmarkdown';
 
 import * as path from 'path';
 
@@ -97,9 +97,9 @@ export async function activate(context: ExtensionContext) {
     context.subscriptions.push(commands.registerCommand('r.helpPanel.forward', () =>{
         rHelpPanel.goForward();
     }));
-    
 
-    
+
+
 
     // Use the console to output diagnostic information (console.log) and errors (console.error)
     // This line of code will only be executed once when your extension is activated
@@ -249,6 +249,7 @@ export async function activate(context: ExtensionContext) {
         commands.registerCommand('r.runSelectionRetainCursor', runSelectionRetainCursor),
         commands.registerCommand('r.runCurrentChunk', runCurrentChunk),
         commands.registerCommand('r.runAboveChunks', runAboveChunks),
+        commands.registerCommand('r.runFromCurrentToBelowChunks', runFromCurrentToBelowChunks),
         commands.registerCommand('r.runChunks', runChunksInTerm),
         commands.registerCommand('r.createGitignore', createGitignore),
         commands.registerCommand('r.previewDataframe', previewDataframe),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { getWordOrSelection, surroundSelection } from './selection';
 import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startRequestWatcher } from './session';
 import { config, ToRStringLiteral, getRpath, getRpathFromSystem } from './util';
 import { launchAddinPicker, trackLastActiveTextEditor } from './rstudioapi';
-import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks, runFromCurrentToBelowChunks, runBelowChunks, runPreviousChunk, runNextChunk, runAllChunks } from './rmarkdown';
+import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks, runFromCurrentToBelowChunks, runBelowChunks, runPreviousChunk, runNextChunk, runAllChunks, goToPreviousChunk } from './rmarkdown';
 
 import * as path from 'path';
 
@@ -254,6 +254,7 @@ export async function activate(context: ExtensionContext) {
         commands.registerCommand('r.runFromCurrentToBelowChunks', runFromCurrentToBelowChunks),
         commands.registerCommand('r.runBelowChunks', runBelowChunks),
         commands.registerCommand('r.runAllChunks', runAllChunks),
+        commands.registerCommand('r.goToPreviousChunk', goToPreviousChunk),
         commands.registerCommand('r.runChunks', runChunksInTerm),
         commands.registerCommand('r.createGitignore', createGitignore),
         commands.registerCommand('r.previewDataframe', previewDataframe),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { getWordOrSelection, surroundSelection } from './selection';
 import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startRequestWatcher } from './session';
 import { config, ToRStringLiteral, getRpath, getRpathFromSystem } from './util';
 import { launchAddinPicker, trackLastActiveTextEditor } from './rstudioapi';
-import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks, runFromCurrentToBelowChunks, runBelowChunks, runAllChunks } from './rmarkdown';
+import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks, runFromCurrentToBelowChunks, runBelowChunks, runPreviousChunk, runAllChunks } from './rmarkdown';
 
 import * as path from 'path';
 
@@ -248,6 +248,7 @@ export async function activate(context: ExtensionContext) {
         commands.registerCommand('r.runFromLineToEnd', runFromLineToEnd),
         commands.registerCommand('r.runSelectionRetainCursor', runSelectionRetainCursor),
         commands.registerCommand('r.runCurrentChunk', runCurrentChunk),
+        commands.registerCommand('r.runPreviousChunk', runPreviousChunk),
         commands.registerCommand('r.runAboveChunks', runAboveChunks),
         commands.registerCommand('r.runFromCurrentToBelowChunks', runFromCurrentToBelowChunks),
         commands.registerCommand('r.runBelowChunks', runBelowChunks),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { getWordOrSelection, surroundSelection } from './selection';
 import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startRequestWatcher } from './session';
 import { config, ToRStringLiteral, getRpath, getRpathFromSystem } from './util';
 import { launchAddinPicker, trackLastActiveTextEditor } from './rstudioapi';
-import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks, runCurrentAndBelowChunks, runBelowChunks, runPreviousChunk, runNextChunk, runAllChunks, goToPreviousChunk, goToNextChunk, goToFirstChunk, goToLastChunk } from './rmarkdown';
+import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, selectCurrentChunk, runCurrentChunk, runAboveChunks, runCurrentAndBelowChunks, runBelowChunks, runPreviousChunk, runNextChunk, runAllChunks, goToBeginningOfChunk, goToEndOfChunk, goToPreviousChunk, goToNextChunk, goToFirstChunk, goToLastChunk } from './rmarkdown';
 
 import * as path from 'path';
 
@@ -247,6 +247,7 @@ export async function activate(context: ExtensionContext) {
         commands.registerCommand('r.runFromBeginningToLine', runFromBeginningToLine),
         commands.registerCommand('r.runFromLineToEnd', runFromLineToEnd),
         commands.registerCommand('r.runSelectionRetainCursor', runSelectionRetainCursor),
+        commands.registerCommand('r.selectCurrentChunk', selectCurrentChunk),
         commands.registerCommand('r.runCurrentChunk', runCurrentChunk),
         commands.registerCommand('r.runPreviousChunk', runPreviousChunk),
         commands.registerCommand('r.runNextChunk', runNextChunk),
@@ -254,6 +255,8 @@ export async function activate(context: ExtensionContext) {
         commands.registerCommand('r.runCurrentAndBelowChunks', runCurrentAndBelowChunks),
         commands.registerCommand('r.runBelowChunks', runBelowChunks),
         commands.registerCommand('r.runAllChunks', runAllChunks),
+        commands.registerCommand('r.goToBeginningOfChunk', goToBeginningOfChunk),
+        commands.registerCommand('r.goToEndOfChunk', goToEndOfChunk),
         commands.registerCommand('r.goToPreviousChunk', goToPreviousChunk),
         commands.registerCommand('r.goToNextChunk', goToNextChunk),
         commands.registerCommand('r.goToFirstChunk', goToFirstChunk),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { getWordOrSelection, surroundSelection } from './selection';
 import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startRequestWatcher } from './session';
 import { config, ToRStringLiteral, getRpath, getRpathFromSystem } from './util';
 import { launchAddinPicker, trackLastActiveTextEditor } from './rstudioapi';
-import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks, runFromCurrentToBelowChunks, runBelowChunks } from './rmarkdown';
+import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, runCurrentChunk, runAboveChunks, runFromCurrentToBelowChunks, runBelowChunks, runAllChunks } from './rmarkdown';
 
 import * as path from 'path';
 
@@ -251,6 +251,7 @@ export async function activate(context: ExtensionContext) {
         commands.registerCommand('r.runAboveChunks', runAboveChunks),
         commands.registerCommand('r.runFromCurrentToBelowChunks', runFromCurrentToBelowChunks),
         commands.registerCommand('r.runBelowChunks', runBelowChunks),
+        commands.registerCommand('r.runAllChunks', runAllChunks),
         commands.registerCommand('r.runChunks', runChunksInTerm),
         commands.registerCommand('r.createGitignore', createGitignore),
         commands.registerCommand('r.previewDataframe', previewDataframe),

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -213,11 +213,33 @@ export async function runFromCurrentToBelowChunks() {
   let chunkLanguage: string = undefined;
   let chunkOptions: string = undefined;
 
-  // Find the chunk start line of the current chunk
-  let line: number = selection.start.line;
-  while (!isChunkStartLine(lines[line])) {
-    line--;
+  // Find 'chunk start line' of the 'current' chunk, covering cases for within and outside of chunk. When the cursor is outside the chunk, the 'current' chunk is next chunk below the cursor.
+
+  let line = selection.start.line;
+  let chunkStartLineAtOrAbove = line;
+  let chunkEndLineAbove = line;
+
+  while (chunkStartLineAtOrAbove >= 0 && !isChunkStartLine(lines[chunkStartLineAtOrAbove])) {
+    chunkStartLineAtOrAbove--;
   }
+
+  while (chunkEndLineAbove >= 0 && !isChunkEndLine(lines[chunkEndLineAbove])) {
+    chunkEndLineAbove--;
+  }
+
+  // Case: Cursor is within chunk
+  if (chunkEndLineAbove < chunkStartLineAtOrAbove) {
+    line = chunkStartLineAtOrAbove;
+  } else {
+  // Cases: Cursor is above the first chunk, at the first chunk or outside of chunk. Find the 'chunk start line' of the next chunk below the cursor.
+    let chunkStartLineBelow = line;
+    while (!isChunkStartLine(lines[chunkStartLineBelow])) {
+      chunkStartLineBelow++;
+    }
+    line = chunkStartLineBelow;
+  }
+
+  // Start finding and run codes from the current to all the chunks below
 
   while (line < lines.length) {
     if (chunkStartLine === undefined) {

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -510,6 +510,40 @@ export async function goToPreviousChunk() {
   line++;  // Move cursor 1 line below 'chunk start line'
   window.activeTextEditor.selection = new vscode.Selection(line, 0, line, 0);
 }
+
+export async function goToNextChunk() {
+  const selection = window.activeTextEditor.selection;
+  const currentDocument = window.activeTextEditor.document;
+  const lines = currentDocument.getText().split(/\r?\n/);
+
+  // Find 'chunk start line' of the 'current' chunk, covering cases for within and outside of chunk. When the cursor is outside the chunk, the 'current' chunk is next chunk below the cursor.
+
+  let line = selection.start.line;
+  let chunkStartLineBelow = line + 1;
+  // TODO `+ 1` to cover edge case when cursor is at 'chunk start line'
+  let chunkEndLineAtOrBelow = line;
+
+  while (chunkStartLineBelow <= lines.length && !isChunkStartLine(lines[chunkStartLineBelow])) {
+    chunkStartLineBelow++;
+  }
+
+  while (chunkEndLineAtOrBelow <= lines.length && !isChunkEndLine(lines[chunkEndLineAtOrBelow])) {
+    chunkEndLineAtOrBelow++;
+  }
+
+  // Case: Cursor is within chunk
+  if (chunkEndLineAtOrBelow < chunkStartLineBelow) {
+    line = chunkStartLineBelow;
+  } else {
+  // Case: Cursor is outside of chunk
+    // Find the next 'chunk start line'
+    chunkStartLineBelow++;
+    while (chunkStartLineBelow <= lines.length && !isChunkStartLine(lines[chunkStartLineBelow])) {
+      chunkStartLineBelow++;
+    }
+    line = chunkStartLineBelow;
+  }
+
   line++;  // Move cursor 1 line below 'chunk start line'
   window.activeTextEditor.selection = new vscode.Selection(line, 0, line, 0);
 }

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -217,7 +217,8 @@ export async function runFromCurrentToBelowChunks() {
 
   let line = selection.start.line;
   let chunkStartLineAtOrAbove = line;
-  let chunkEndLineAbove = line;
+  // `- 1` to cover edge case when cursor is at 'chunk end line'
+  let chunkEndLineAbove = line - 1;
 
   while (chunkStartLineAtOrAbove >= 0 && !isChunkStartLine(lines[chunkStartLineAtOrAbove])) {
     chunkStartLineAtOrAbove--;

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -1,10 +1,9 @@
 import {
   CancellationToken, CodeLens, CodeLensProvider,
   CompletionItem, CompletionItemProvider,
-  Event, EventEmitter, Position, Range, TextDocument, TextEditorDecorationType, window
+  Event, EventEmitter, Position, Range, TextDocument, TextEditorDecorationType, window, Selection
 } from 'vscode';
 import { runChunksInTerm } from './rTerminal';
-import * as vscode from 'vscode';
 import { config } from './util';
 
 function isChunkStartLine(text: string) {
@@ -378,7 +377,7 @@ export async function runAllChunks(
 function goToChunk(chunk: RMarkdownChunk) {
   // Move cursor 1 line below 'chunk start line'
   const line = chunk.startLine + 1;
-  window.activeTextEditor.selection = new vscode.Selection(line, 0, line, 0);
+  window.activeTextEditor.selection = new Selection(line, 0, line, 0);
 }
 
 export async function goToPreviousChunk(
@@ -405,7 +404,7 @@ export async function selectCurrentChunk(
   const currentChunk = getCurrentChunk__CursorWithinChunk(chunks, line);
   const lines = editor.document.getText().split(/\r?\n/);
 
-  editor.selection = new vscode.Selection(
+  editor.selection = new Selection(
     currentChunk.startLine, 0,
     currentChunk.endLine, lines[currentChunk.endLine].length
   );

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -45,7 +45,7 @@ export class RMarkdownCodeLensProvider implements CodeLensProvider {
   constructor() {
     this.decoration = window.createTextEditorDecorationType({
       isWholeLine: true,
-      backgroundColor: config().get('rMarkdownCodeLens.chunkBackgroundColor'),
+      backgroundColor: config().get('rmarkdown.chunkBackgroundColor'),
     });
   }
 
@@ -53,109 +53,108 @@ export class RMarkdownCodeLensProvider implements CodeLensProvider {
     this.codeLenses = [];
     const chunks = getChunks(document);
     const chunkRanges: Range[] = [];
-    const rmdCodeLensOpt: string[] = config().get('rMarkdownCodeLens.option');
+    const rmdCodeLensCommands: string[] = config().get('rmarkdown.codeLensCommands');
 
-    // Enable/disable both code lens and chunk background color (set by `editor.setDecorations`)
-    if (!config().get<boolean>('rMarkdownCodeLens.enableCodeLens')) {
-      return null;
-    }
-
+    // Iterate through all code chunks for getting chunk information for both CodeLens and chunk background color (set by `editor.setDecorations`)
     for (let i = 1 ; i <= chunks.length ; i++) {
       const chunk = chunks.filter(e => e.id === i)[0];
       const chunkRange = chunk.chunkRange;
       const line = chunk.startLine;
       chunkRanges.push(chunkRange);
 
-      if (chunk.language === 'r') {
-        if (token.isCancellationRequested) {
-          break;
+      // Enable/disable only CodeLens, without affecting chunk background color.
+      if (config().get<boolean>('rmarkdown.enableCodeLens')) {
+        if (chunk.language === 'r') {
+          if (token.isCancellationRequested) {
+            break;
+          }
+          this.codeLenses.push(
+            new CodeLens(chunkRange, {
+              title: 'Run Chunk',
+              tooltip: 'Run current chunk',
+              command: 'r.runCurrentChunk',
+              arguments: [chunks, line]
+            }),
+            new CodeLens(chunkRange, {
+              title: 'Run Above',
+              tooltip: 'Run all chunks above',
+              command: 'r.runAboveChunks',
+              arguments: [chunks, line]
+            }),
+            new CodeLens(chunkRange, {
+              title: 'Run Current & Below',
+              tooltip: 'Run current and all chunks below',
+              command: 'r.runCurrentAndBelowChunks',
+              arguments: [chunks, line]
+            }),
+            new CodeLens(chunkRange, {
+              title: 'Run Below',
+              tooltip: 'Run all chunks below',
+              command: 'r.runBelowChunks',
+              arguments: [chunks, line]
+            }),
+            new CodeLens(chunkRange, {
+              title: 'Run Previous',
+              tooltip: 'Run previous chunk',
+              command: 'r.runPreviousChunk',
+              arguments: [chunks, line]
+            }),
+            new CodeLens(chunkRange, {
+              title: 'Run Next',
+              tooltip: 'Run next chunk',
+              command: 'r.runNextChunk',
+              arguments: [chunks, line]
+            }),
+            new CodeLens(chunkRange, {
+              title: 'Run All',
+              tooltip: 'Run all chunks',
+              command: 'r.runAllChunks',
+              arguments: [chunks]
+            }),
+            new CodeLens(chunkRange, {
+              title: 'Go Beginning',
+              tooltip: 'Go to beginning of chunk',
+              command: 'r.goToBeginningOfChunk',
+              arguments: [chunks, line]
+            }),
+            new CodeLens(chunkRange, {
+              title: 'Go End',
+              tooltip: 'Go to end of chunk',
+              command: 'r.goToEndOfChunk',
+              arguments: [chunks, line]
+            }),
+            new CodeLens(chunkRange, {
+              title: 'Go Previous',
+              tooltip: 'Go to previous chunk',
+              command: 'r.goToPreviousChunk',
+              arguments: [chunks, line]
+            }),
+            new CodeLens(chunkRange, {
+              title: 'Go Next',
+              tooltip: 'Go to next chunk',
+              command: 'r.goToNextChunk',
+              arguments: [chunks, line]
+            }),
+            new CodeLens(chunkRange, {
+              title: 'Go First',
+              tooltip: 'Go to first chunk',
+              command: 'r.goToFirstChunk',
+              arguments: [chunks]
+            }),
+            new CodeLens(chunkRange, {
+              title: 'Go Last',
+              tooltip: 'Go to last chunk',
+              command: 'r.goToLastChunk',
+              arguments: [chunks]
+            }),
+            new CodeLens(chunkRange, {
+              title: 'Select Chunk',
+              tooltip: 'Select current chunk',
+              command: 'r.selectCurrentChunk',
+              arguments: [chunks, line]
+            }),
+          );
         }
-        this.codeLenses.push(
-          new CodeLens(chunkRange, {
-            title: 'Run Chunk',
-            tooltip: 'Run current chunk',
-            command: 'r.runCurrentChunk',
-            arguments: [chunks, line]
-          }),
-          new CodeLens(chunkRange, {
-            title: 'Run Above',
-            tooltip: 'Run all chunks above',
-            command: 'r.runAboveChunks',
-            arguments: [chunks, line]
-          }),
-          new CodeLens(chunkRange, {
-            title: 'Run Current & Below',
-            tooltip: 'Run current and all chunks below',
-            command: 'r.runCurrentAndBelowChunks',
-            arguments: [chunks, line]
-          }),
-          new CodeLens(chunkRange, {
-            title: 'Run Below',
-            tooltip: 'Run all chunks below',
-            command: 'r.runBelowChunks',
-            arguments: [chunks, line]
-          }),
-          new CodeLens(chunkRange, {
-            title: 'Run Previous',
-            tooltip: 'Run previous chunk',
-            command: 'r.runPreviousChunk',
-            arguments: [chunks, line]
-          }),
-          new CodeLens(chunkRange, {
-            title: 'Run Next',
-            tooltip: 'Run next chunk',
-            command: 'r.runNextChunk',
-            arguments: [chunks, line]
-          }),
-          new CodeLens(chunkRange, {
-            title: 'Run All',
-            tooltip: 'Run all chunks',
-            command: 'r.runAllChunks',
-            arguments: [chunks]
-          }),
-          new CodeLens(chunkRange, {
-            title: 'Go Beginning',
-            tooltip: 'Go to beginning of chunk',
-            command: 'r.goToBeginningOfChunk',
-            arguments: [chunks, line]
-          }),
-          new CodeLens(chunkRange, {
-            title: 'Go End',
-            tooltip: 'Go to end of chunk',
-            command: 'r.goToEndOfChunk',
-            arguments: [chunks, line]
-          }),
-          new CodeLens(chunkRange, {
-            title: 'Go Previous',
-            tooltip: 'Go to previous chunk',
-            command: 'r.goToPreviousChunk',
-            arguments: [chunks, line]
-          }),
-          new CodeLens(chunkRange, {
-            title: 'Go Next',
-            tooltip: 'Go to next chunk',
-            command: 'r.goToNextChunk',
-            arguments: [chunks, line]
-          }),
-          new CodeLens(chunkRange, {
-            title: 'Go First',
-            tooltip: 'Go to first chunk',
-            command: 'r.goToFirstChunk',
-            arguments: [chunks]
-          }),
-          new CodeLens(chunkRange, {
-            title: 'Go Last',
-            tooltip: 'Go to last chunk',
-            command: 'r.goToLastChunk',
-            arguments: [chunks]
-          }),
-          new CodeLens(chunkRange, {
-            title: 'Select Chunk',
-            tooltip: 'Select current chunk',
-            command: 'r.selectCurrentChunk',
-            arguments: [chunks, line]
-          }),
-        );
       }
     }
 
@@ -168,10 +167,10 @@ export class RMarkdownCodeLensProvider implements CodeLensProvider {
     // For default options, both options and sort order are based on options specified in package.json.
     // For user-specified options, both options and sort order are based on options specified in settings UI or settings.json.
     return this.codeLenses.
-      filter(e => rmdCodeLensOpt.includes(e.command.command)).
+      filter(e => rmdCodeLensCommands.includes(e.command.command)).
       sort(function(a, b) {
-        const sorted = rmdCodeLensOpt.indexOf(a.command.command) -
-                       rmdCodeLensOpt.indexOf(b.command.command);
+        const sorted = rmdCodeLensCommands.indexOf(a.command.command) -
+                       rmdCodeLensCommands.indexOf(b.command.command);
         return sorted;
       });
   }

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -284,34 +284,34 @@ function getNextChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk {
   return nextChunk;
 }
 
-export async function runCurrentChunk(
-  chunks: RMarkdownChunk[] = getChunks(window.activeTextEditor.document),
-  line: number = window.activeTextEditor.selection.start.line) {
+// Helpers
+function _getChunks() {
+  return getChunks(window.activeTextEditor.document);
+}
+function _getStartLine() {
+  return window.activeTextEditor.selection.start.line;
+}
 
+export async function runCurrentChunk(chunks: RMarkdownChunk[] = _getChunks(),
+                                      line: number = _getStartLine()) {
   const currentChunk = getCurrentChunk(chunks, line);
   runChunksInTerm([currentChunk.codeRange]);
 }
 
-export async function runPreviousChunk(
-  chunks: RMarkdownChunk[] = getChunks(window.activeTextEditor.document),
-  line: number = window.activeTextEditor.selection.start.line) {
-
+export async function runPreviousChunk(chunks: RMarkdownChunk[] = _getChunks(),
+                                       line: number = _getStartLine()) {
   const previousChunk = getPreviousChunk(chunks, line);
   runChunksInTerm([previousChunk.codeRange]);
 }
 
-export async function runNextChunk(
-  chunks: RMarkdownChunk[] = getChunks(window.activeTextEditor.document),
-  line: number = window.activeTextEditor.selection.start.line) {
-
+export async function runNextChunk(chunks: RMarkdownChunk[] = _getChunks(),
+                                   line: number = _getStartLine()) {
   const nextChunk = getNextChunk(chunks, line);
   runChunksInTerm([nextChunk.codeRange]);
 }
 
-export async function runAboveChunks(
-  chunks: RMarkdownChunk[] = getChunks(window.activeTextEditor.document),
-  line: number = window.activeTextEditor.selection.start.line) {
-
+export async function runAboveChunks(chunks: RMarkdownChunk[] = _getChunks(),
+                                     line: number = _getStartLine()) {
   const previousChunk = getPreviousChunk(chunks, line);
   const firstChunkId = 1;
   const previousChunkId = previousChunk.id;
@@ -325,9 +325,8 @@ export async function runAboveChunks(
   runChunksInTerm(codeRanges);
 }
 
-export async function runBelowChunks(
-  chunks: RMarkdownChunk[] = getChunks(window.activeTextEditor.document),
-  line: number = window.activeTextEditor.selection.start.line) {
+export async function runBelowChunks(chunks: RMarkdownChunk[] = _getChunks(),
+                                     line: number = _getStartLine()) {
 
   const nextChunk = getNextChunk(chunks, line);
   const nextChunkId = nextChunk.id;
@@ -343,9 +342,7 @@ export async function runBelowChunks(
 }
 
 export async function runCurrentAndBelowChunks(
-  chunks: RMarkdownChunk[] = getChunks(window.activeTextEditor.document),
-  line: number = window.activeTextEditor.selection.start.line) {
-
+  chunks: RMarkdownChunk[] = _getChunks(), line: number = _getStartLine()) {
   const currentChunk = getCurrentChunk(chunks, line);
   const currentChunkId = currentChunk.id;
   const lastChunkId = chunks.length;
@@ -359,8 +356,7 @@ export async function runCurrentAndBelowChunks(
   runChunksInTerm(codeRanges);
 }
 
-export async function runAllChunks(
-  chunks: RMarkdownChunk[] = getChunks(window.activeTextEditor.document)) {
+export async function runAllChunks(chunks: RMarkdownChunk[] = _getChunks()) {
 
   const firstChunkId = 1;
   const lastChunkId = chunks.length;
@@ -380,26 +376,20 @@ function goToChunk(chunk: RMarkdownChunk) {
   window.activeTextEditor.selection = new Selection(line, 0, line, 0);
 }
 
-export async function goToPreviousChunk(
-  chunks: RMarkdownChunk[] = getChunks(window.activeTextEditor.document),
-  line: number = window.activeTextEditor.selection.start.line) {
-
+export async function goToPreviousChunk(chunks: RMarkdownChunk[] = _getChunks(),
+                                        line: number = _getStartLine()) {
   const previousChunk = getPreviousChunk(chunks, line);
   goToChunk(previousChunk);
 }
 
-export async function goToNextChunk(
-  chunks: RMarkdownChunk[] = getChunks(window.activeTextEditor.document),
-  line: number = window.activeTextEditor.selection.start.line) {
-
+export async function goToNextChunk(chunks: RMarkdownChunk[] = _getChunks(),
+                                    line: number = _getStartLine()) {
   const nextChunk = getNextChunk(chunks, line);
   goToChunk(nextChunk);
 }
 
 export async function selectCurrentChunk(
-  chunks: RMarkdownChunk[] = getChunks(window.activeTextEditor.document),
-  line: number = window.activeTextEditor.selection.start.line) {
-
+  chunks: RMarkdownChunk[] = _getChunks(), line: number = _getStartLine()) {
   const editor = window.activeTextEditor;
   const currentChunk = getCurrentChunk__CursorWithinChunk(chunks, line);
   const lines = editor.document.getText().split(/\r?\n/);

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -45,7 +45,7 @@ export class RMarkdownCodeLensProvider implements CodeLensProvider {
   constructor() {
     this.decoration = window.createTextEditorDecorationType({
       isWholeLine: true,
-      backgroundColor: 'rgba(128, 128, 128, 0.1)',
+      backgroundColor: config().get('rMarkdownCodeLens.chunkBackgroundColor'),
     });
   }
 
@@ -55,6 +55,10 @@ export class RMarkdownCodeLensProvider implements CodeLensProvider {
     const chunkRanges: Range[] = [];
     const rmdCodeLensOpt: string[] = config().get('rMarkdownCodeLens.option');
 
+    // Enable/disable both code lens and chunk background color (set by `editor.setDecorations`)
+    if (!config().get<boolean>('rMarkdownCodeLens.enableCodeLens')) {
+      return null;
+    }
 
     for (let i = 1 ; i <= chunks.length ; i++) {
       const chunk = chunks.filter(e => e.id === i)[0];

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -452,10 +452,11 @@ export async function selectCurrentChunk(
   chunks: RMarkdownChunk[] = getChunks(window.activeTextEditor.document),
   line: number = window.activeTextEditor.selection.start.line) {
 
+  const editor = window.activeTextEditor;
   const currentChunk = getCurrentChunk__CursorWithinChunk(chunks, line);
-  const lines = window.activeTextEditor.document.getText().split(/\r?\n/);
+  const lines = editor.document.getText().split(/\r?\n/);
 
-  window.activeTextEditor.selection = new vscode.Selection(
+  editor.selection = new vscode.Selection(
     currentChunk.startLine, 0,
     currentChunk.endLine, lines[currentChunk.endLine].length
   );

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -295,14 +295,16 @@ function getCurrentChunk__CursorWithinChunk(chunks: RMarkdownChunk[], line: numb
 
 function getPreviousChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk {
   const currentChunk = getCurrentChunk(chunks, line);
-  const previousChunkId = currentChunk.id - 1;
+  // When cursor is below the last 'chunk end line', the definition of the previous chunk is the last chunk
+  const previousChunkId = currentChunk.endLine < line ? currentChunk.id : currentChunk.id - 1;
   const previousChunk = chunks.filter(i => i.id === previousChunkId)[0];
   return previousChunk;
 }
 
 function getNextChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk {
   const currentChunk = getCurrentChunk(chunks, line);
-  const nextChunkId = currentChunk.id + 1;
+  // When cursor is above the first 'chunk start line', the definition of the next chunk is the first chunk
+  const nextChunkId = line < currentChunk.startLine ? currentChunk.id : currentChunk.id + 1;
   const nextChunk = chunks.filter(i => i.id === nextChunkId)[0];
   return nextChunk;
 }

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -321,6 +321,44 @@ export async function runBelowChunks() {
   runChunksInTerm(codeRanges);
 }
 
+
+export async function runAllChunks() {
+  const currentDocument = window.activeTextEditor.document;
+  const lines = currentDocument.getText().split(/\r?\n/);
+  const codeRanges: Range[] = [];
+
+  let line = 0;
+  let chunkStartLine: number = undefined;
+  let chunkLanguage: string = undefined;
+  let chunkOptions: string = undefined;
+
+  while (line < lines.length) {
+    if (chunkStartLine === undefined) {
+      if (isChunkStartLine(lines[line])) {
+        chunkStartLine = line;
+        chunkLanguage = getChunkLanguage(lines[line]);
+        chunkOptions = getChunkOptions(lines[line]);
+      }
+    } else {
+      if (isChunkEndLine(lines[line])) {
+        if (chunkLanguage === 'r') {
+          if (getChunkEval(chunkOptions)) {
+            const codeRange = new Range(
+              new Position(chunkStartLine + 1, 0),
+              new Position(line - 1, lines[line - 1].length)
+            );
+
+            codeRanges.push(codeRange);
+          }
+        }
+
+        chunkStartLine = undefined;
+      }
+    }
+    line++;
+  }
+  runChunksInTerm(codeRanges);
+}
 export class RMarkdownCompletionItemProvider implements CompletionItemProvider {
 
   // obtained from R code

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -62,74 +62,72 @@ export class RMarkdownCodeLensProvider implements CodeLensProvider {
       chunkRanges.push(chunkRange);
 
       // Enable/disable only CodeLens, without affecting chunk background color.
-      if (config().get<boolean>('rmarkdown.enableCodeLens')) {
-        if (chunk.language === 'r') {
-          if (token.isCancellationRequested) {
-            break;
-          }
-          this.codeLenses.push(
-            new CodeLens(chunkRange, {
-              title: 'Run Chunk',
-              tooltip: 'Run current chunk',
-              command: 'r.runCurrentChunk',
-              arguments: [chunks, line]
-            }),
-            new CodeLens(chunkRange, {
-              title: 'Run Above',
-              tooltip: 'Run all chunks above',
-              command: 'r.runAboveChunks',
-              arguments: [chunks, line]
-            }),
-            new CodeLens(chunkRange, {
-              title: 'Run Current & Below',
-              tooltip: 'Run current and all chunks below',
-              command: 'r.runCurrentAndBelowChunks',
-              arguments: [chunks, line]
-            }),
-            new CodeLens(chunkRange, {
-              title: 'Run Below',
-              tooltip: 'Run all chunks below',
-              command: 'r.runBelowChunks',
-              arguments: [chunks, line]
-            }),
-            new CodeLens(chunkRange, {
-              title: 'Run Previous',
-              tooltip: 'Run previous chunk',
-              command: 'r.runPreviousChunk',
-              arguments: [chunks, line]
-            }),
-            new CodeLens(chunkRange, {
-              title: 'Run Next',
-              tooltip: 'Run next chunk',
-              command: 'r.runNextChunk',
-              arguments: [chunks, line]
-            }),
-            new CodeLens(chunkRange, {
-              title: 'Run All',
-              tooltip: 'Run all chunks',
-              command: 'r.runAllChunks',
-              arguments: [chunks]
-            }),
-            new CodeLens(chunkRange, {
-              title: 'Go Previous',
-              tooltip: 'Go to previous chunk',
-              command: 'r.goToPreviousChunk',
-              arguments: [chunks, line]
-            }),
-            new CodeLens(chunkRange, {
-              title: 'Go Next',
-              tooltip: 'Go to next chunk',
-              command: 'r.goToNextChunk',
-              arguments: [chunks, line]
-            }),
-            new CodeLens(chunkRange, {
-              title: 'Select Chunk',
-              tooltip: 'Select current chunk',
-              command: 'r.selectCurrentChunk',
-              arguments: [chunks, line]
-            }),
-          );
+      if (config().get<boolean>('rmarkdown.enableCodeLens') && chunk.language === 'r') {
+        if (token.isCancellationRequested) {
+          break;
         }
+        this.codeLenses.push(
+          new CodeLens(chunkRange, {
+            title: 'Run Chunk',
+            tooltip: 'Run current chunk',
+            command: 'r.runCurrentChunk',
+            arguments: [chunks, line]
+          }),
+          new CodeLens(chunkRange, {
+            title: 'Run Above',
+            tooltip: 'Run all chunks above',
+            command: 'r.runAboveChunks',
+            arguments: [chunks, line]
+          }),
+          new CodeLens(chunkRange, {
+            title: 'Run Current & Below',
+            tooltip: 'Run current and all chunks below',
+            command: 'r.runCurrentAndBelowChunks',
+            arguments: [chunks, line]
+          }),
+          new CodeLens(chunkRange, {
+            title: 'Run Below',
+            tooltip: 'Run all chunks below',
+            command: 'r.runBelowChunks',
+            arguments: [chunks, line]
+          }),
+          new CodeLens(chunkRange, {
+            title: 'Run Previous',
+            tooltip: 'Run previous chunk',
+            command: 'r.runPreviousChunk',
+            arguments: [chunks, line]
+          }),
+          new CodeLens(chunkRange, {
+            title: 'Run Next',
+            tooltip: 'Run next chunk',
+            command: 'r.runNextChunk',
+            arguments: [chunks, line]
+          }),
+          new CodeLens(chunkRange, {
+            title: 'Run All',
+            tooltip: 'Run all chunks',
+            command: 'r.runAllChunks',
+            arguments: [chunks]
+          }),
+          new CodeLens(chunkRange, {
+            title: 'Go Previous',
+            tooltip: 'Go to previous chunk',
+            command: 'r.goToPreviousChunk',
+            arguments: [chunks, line]
+          }),
+          new CodeLens(chunkRange, {
+            title: 'Go Next',
+            tooltip: 'Go to next chunk',
+            command: 'r.goToNextChunk',
+            arguments: [chunks, line]
+          }),
+          new CodeLens(chunkRange, {
+            title: 'Select Chunk',
+            tooltip: 'Select current chunk',
+            command: 'r.selectCurrentChunk',
+            arguments: [chunks, line]
+          }),
+        );
       }
     }
 

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -251,20 +251,16 @@ function getCurrentChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk
 }
 
 // Alternative `getCurrentChunk` for cases:
-// - commands (e.g. `goToBeginningOfChunk`) only make sense when cursor is within chunk
+// - commands (e.g. `selectCurrentChunk`) only make sense when cursor is within chunk
 // - when cursor is outside of chunk, no response is triggered for chunk navigation commands (e.g. `goToPreviousChunk`) and chunk running commands (e.g. `runAboveChunks`)
 function getCurrentChunk__CursorWithinChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk {
-  let id = 0;
+  const ids = chunks.map(e => e.id);
 
-  while (id <= chunks.length - 1) {
-    const chunk = chunks[id];
-    const chunkStartLine = chunk.startLine;
-    const chunkEndLine = chunk.endLine;
-
-    if (chunkStartLine <= line && line <= chunkEndLine) {
+  for (const id of ids) {
+    const chunk = chunks.filter(e => e.id === id)[0];
+    if (chunk.startLine <= line && line <= chunk.endLine) {
       return chunk;
     }
-    id++;
   }
 }
 

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -161,7 +161,15 @@ export class RMarkdownCodeLensProvider implements CodeLensProvider {
       }
     }
 
-    return this.codeLenses.filter(e => rmdCodeLensOpt.includes(e.command.command));
+    // For default options, both options and sort order are based on options specified in package.json.
+    // For user-specified options, both options and sort order are based on options specified in settings UI or settings.json.
+    return this.codeLenses.
+      filter(e => rmdCodeLensOpt.includes(e.command.command)).
+      sort(function(a, b) {
+        const sorted = rmdCodeLensOpt.indexOf(a.command.command) -
+                       rmdCodeLensOpt.indexOf(b.command.command);
+        return sorted;
+      });
   }
   public resolveCodeLens(codeLens: CodeLens, token: CancellationToken) {
     return codeLens;

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -112,18 +112,6 @@ export class RMarkdownCodeLensProvider implements CodeLensProvider {
               arguments: [chunks]
             }),
             new CodeLens(chunkRange, {
-              title: 'Go Beginning',
-              tooltip: 'Go to beginning of chunk',
-              command: 'r.goToBeginningOfChunk',
-              arguments: [chunks, line]
-            }),
-            new CodeLens(chunkRange, {
-              title: 'Go End',
-              tooltip: 'Go to end of chunk',
-              command: 'r.goToEndOfChunk',
-              arguments: [chunks, line]
-            }),
-            new CodeLens(chunkRange, {
               title: 'Go Previous',
               tooltip: 'Go to previous chunk',
               command: 'r.goToPreviousChunk',
@@ -134,18 +122,6 @@ export class RMarkdownCodeLensProvider implements CodeLensProvider {
               tooltip: 'Go to next chunk',
               command: 'r.goToNextChunk',
               arguments: [chunks, line]
-            }),
-            new CodeLens(chunkRange, {
-              title: 'Go First',
-              tooltip: 'Go to first chunk',
-              command: 'r.goToFirstChunk',
-              arguments: [chunks]
-            }),
-            new CodeLens(chunkRange, {
-              title: 'Go Last',
-              tooltip: 'Go to last chunk',
-              command: 'r.goToLastChunk',
-              arguments: [chunks]
             }),
             new CodeLens(chunkRange, {
               title: 'Select Chunk',
@@ -405,24 +381,6 @@ function goToChunk(chunk: RMarkdownChunk) {
   window.activeTextEditor.selection = new vscode.Selection(line, 0, line, 0);
 }
 
-export async function goToBeginningOfChunk(
-  chunks: RMarkdownChunk[] = getChunks(window.activeTextEditor.document),
-  line: number = window.activeTextEditor.selection.start.line) {
-
-  const currentChunk = getCurrentChunk__CursorWithinChunk(chunks, line);
-  goToChunk(currentChunk);
-}
-
-export async function goToEndOfChunk(
-  chunks: RMarkdownChunk[] = getChunks(window.activeTextEditor.document),
-  line: number = window.activeTextEditor.selection.start.line) {
-
-  const currentChunk = getCurrentChunk__CursorWithinChunk(chunks, line);
-  // Move cursor 1 line above 'chunk end line'
-  line = currentChunk.endLine - 1;
-  window.activeTextEditor.selection = new vscode.Selection(line, 0, line, 0);
-}
-
 export async function goToPreviousChunk(
   chunks: RMarkdownChunk[] = getChunks(window.activeTextEditor.document),
   line: number = window.activeTextEditor.selection.start.line) {
@@ -437,20 +395,6 @@ export async function goToNextChunk(
 
   const nextChunk = getNextChunk(chunks, line);
   goToChunk(nextChunk);
-}
-
-export async function goToFirstChunk(
-  chunks: RMarkdownChunk[] = getChunks(window.activeTextEditor.document)) {
-
-  const firstChunk = chunks[0];
-  goToChunk(firstChunk);
-}
-
-export async function goToLastChunk(
-  chunks: RMarkdownChunk[] = getChunks(window.activeTextEditor.document)) {
-
-  const lastChunk = chunks[chunks.length - 1];
-  goToChunk(lastChunk);
 }
 
 export async function selectCurrentChunk(


### PR DESCRIPTION
This is my first time playing around with Typescript/javascript. So please review the codes in details thanks! 😅 😂 🤣

__What problem did you solve?__

- Add and refactor RMarkdown navigation and run commands for both extension and RMarkdown code lens.
- User-specified RMarkdown code lens commands and its orders (that is, code lens respect user-specified orders) via settings UI (RMarkdown Code Lens: Option) or settings.json (`r.rMarkdownCodeLens.option`). See below.
- More customizations
    - Enable/disable RMarkdown CodeLens, which are inline commands/buttons e.g. 'Run Chunk | Run Above' shown on the first line of each code chunk.
    - Customize chunk background color
- User-friendly options message for new users (see below)

Also closes #262

| Command|                      Keybinding|         Notes|
| ----------------------------| ------------------| --------------|
| `r.selectCurrentChunk`|       shift+alt+s| e.g. for delete/copy/cut
| `r.runCurrentChunk`|          ctrl+shift+enter| (previously implemented)
| `r.runAboveChunks`|           ctrl+alt+p|       (previously implemented)
| `r.runCurrentAndBelowChunks`| ctrl+alt+n|
| `r.runBelowChunks`|           ctrl+alt+e|
| `r.runPreviousChunk`|         ctrl+shift+alt+p|
| `r.runNextChunk`|             ctrl+shift+alt+n|
| `r.runAllChunks`|             ctrl+alt+r|
| `r.goToBeginningOfChunk`|     shift+alt+b|
| `r.goToEndOfChunk`|           shift+alt+e|
| `r.goToPreviousChunk`|        shift+alt+p|
| `r.goToNextChunk`|            shift+alt+n|
| `r.goToFirstChunk`|           shift+alt+l|
| `r.goToLastChunk`|            shift+alt+n|

Animation for both
- __Add and refactor RMarkdown navigation and run commands.__
- __User-specified RMarkdown code lens options and its orders (that is, code lens respect user-specified orders)__

(__Click to enlarge__)

![rmarkdown](https://user-images.githubusercontent.com/54139483/100451050-d9e48c00-310a-11eb-9f67-fab876e984fd.gif)


Images for __User-specified RMarkdown code lens commands and its orders (that is, code lens respect user-specified orders)__

![1212](https://user-images.githubusercontent.com/54139483/100493524-b31a6a00-318b-11eb-8073-be16d9141e70.png)
![zz1](https://user-images.githubusercontent.com/54139483/100493525-b44b9700-318b-11eb-88f4-11e2ded4d9d7.png)
![zz2](https://user-images.githubusercontent.com/54139483/100493527-b57cc400-318b-11eb-8847-f6e80bf3f4ae.png)






Customize __options and order (code lens respect user-specified orders)__ via settings UI (RMarkdown Code Lens: Option) or settings.json (`r.rMarkdownCodeLens.option`).

```json
{
  "r.rmarkdown.codeLensCommands": [
    "r.runCurrentChunk",
    "r.runAboveChunks",
    "r.runCurrentAndBelowChunks",
    "goToPreviousChunk",
    "goToNextChunk",
    "selectAllChunk",
    // more...
  ]
}
```

## More customizations

- Enable/disable RMarkdown CodeLens, which are inline commands/buttons e.g. 'Run Chunk | Run Above' shown on the first line of each code chunk.
- Customize chunk background color

User-friendly message for new users

![a3](https://user-images.githubusercontent.com/54139483/100492784-c9bcc300-3183-11eb-81d8-1ef20464dd11.png)

### Enable RMarkdown CodeLens (default)

`"r.rmarkdown.enableCodeLens": true` (default)

![a4](https://user-images.githubusercontent.com/54139483/100492836-6c754180-3184-11eb-84fe-2fba5f34663d.png)


### Disable RMarkdown CodeLens

`"r.rmarkdown.enableCodeLens": false`

- Disable only RMarkdown CodeLens, leaving other CodeLens (e.g. Git lens) enabled.
- Chunk background color is also enabled by default

![hahaz](https://user-images.githubusercontent.com/54139483/100493789-b6632500-318e-11eb-9350-b8cd586d0b84.png)





### Customize chunk background colors

`r.rmarkdown.chunkBackgroundColor: "rgba(128, 128, 128, 0.1)",`

![c1](https://user-images.githubusercontent.com/54139483/100492880-12c14700-3185-11eb-8f46-85d2a114953e.png)

`r.rmarkdown.chunkBackgroundColor: "rgba(255, 165, 0, 0.1)",`

![c2](https://user-images.githubusercontent.com/54139483/100492884-18b72800-3185-11eb-9cd2-5fe999209223.png)


Disable background color
`r.rmarkdown.chunkBackgroundColor: "",`

![c3](https://user-images.githubusercontent.com/54139483/100492892-2e2c5200-3185-11eb-8ca6-b2babaf163d3.png)


# Use cases for both  `r.runFromCurrentToBelowChunks` & `r.runBelowChunks`

1. Edit current chunk, `r.runCurrentChunk` for checking values/etc and, when done, `r.runBelowChunks` from the next chunk **(excluding the current chunk)** to all chunks below
2. After checking that the overall codes are working beautifully, edit current chunk and `r.runFromCurrentToBelowChunks` from the **current chunk** to all chunks below

![use_cases](https://user-images.githubusercontent.com/54139483/100093213-524d1200-2eab-11eb-941a-637d6d8add6e.gif)


# Design decisions & known bugs

By design, these commands work for both cases when the cursor is
- within the chunk (including both 'chunk start line' and 'chunk end line')
- outside the chunk

### Case 'within the chunk'

Works as expected

### Case cursor outside of chunk

The reason for including cases for 'outside the chunk' is to make it work for
- Navigation commands: `goToPreviousChunk`, `goToNextChunk`, `goToFirstChunk`, `goToLastChunk`, which is very convenient especially for large Rmd files with many chunks and a lot of text in between chunks.
- Less useful, but still useful for run commands (e.g. e.g. `runCurrentAndBelowChunks`) and to make the behaviour consistent with navigation commands

As a result, when the cursor is outside the chunk, the definition of the 'current chunk' and 'next chunk' become blur, that is, there are no 'correct' definitions, simply because there is no definition of 'current chunk'. To make it makes more sense, when cursor is outside the chunk, for the reason that navigation commands (e.g. `goToNextChunk`) is more useful than run commands (e.g. `runCurrentAndBelowChunks`), by design, the definition of the 'current chunk' and 'next chunk' are the same--the very next chunk. That is, e.g.

- `goToNextChunk`, `runCurrentChunk` and `runNextChunk` trigger the very next chunk
- both `runCurrentAndBelowChunks` and `runBelowChunks` trigger from the very next chunk to the last chunk
- so on...

Compared to the case where
- current chunk is the next chunk
- next chunk is the next next chunk
- then, for `goToNextChunk` will jump to next next chunk when cursor is outside the chunk, which doesn't make much sense. And it also doesn't make sense to make another command for `goToCurrentChunk` just for this trade-off.

So it's a trade-off for its design. I think the overall benefits e.g. `goToNextChunk`, `goToFirstChunk` outweigh the minor 'unexpected' behaviours when the cursor is outside the chunk, especially for large Rmd files with many chunks and a lot of text in between the chunks. Code navigation is often the most time consuming part. e.g.
- after writing a lot of text in between the chunk, with just a keybinding __shift+alt+p__ `goToPreviousChunk` often saves a lot of time

Lastly, a known bug is when the cursor is below the very last chunk,
- Commands like `goToFirstChunk`, `goToLastChunk`, `runAllChunks` work as expected (in all cases) becauses these commands doesn't require the 'current line' as argument so the cursor position doesn't affect it at all.
- But I couldn't make it work for `goToPreviousChunk`, `runPreviousChunk` and `runAboveChunks`  I thought the bugs is in internal function `getCurrentChunk` but I spent some time on it there is still some bug. I will come back and work in near future if that's okay. The bug is just weird.

-------------------------------------------------------------

Tested on Windows WSL remote extension