### PR TITLE
Add pre-release

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,48 @@
+name: pre-release
+
+# creates a pre-release with the .vsix 
+
+on:
+  push:
+    branches: ["master"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm install
+      - uses: lannonbr/vsce-action@master
+        with:
+          args: "package"
+      - name: Identify output file # can be retrieved as steps.filenames.outputs.file_out
+        id: filenames
+        run: echo "::set-output name=file_out::$(ls | grep "^.*\.vsix$" | head -1)"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ steps.filenames.outputs.file_out }}
+          path: ${{ steps.filenames.outputs.file_out }}
+
+  pre-release:
+    name: Pre-Release
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: "artifacts/"
+      - name: Get version from tag
+        id: get_version
+        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\/v/}
+      - name: Create release
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          title: "Development Build"
+          automatic_release_tag: "latest"
+          files: "artifacts/*/*"
+          prerelease: true
+          draft: false 
+


### PR DESCRIPTION
This PR adds a GitHub action that releases a development build marked as pre-release on every push to master.

At [vscode-r-debugger](https://github.com/ManuelHentschel/VSCode-R-Debugger/releases) and [vscDebugger](https://github.com/ManuelHentschel/vscDebugger/releases) the action seems to be working nicely.

This would make it possible to download and test the latest master version, without having to navigate to the correct build action and downloading the artifacts.