### PR TITLE
Improve Help Panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,10 @@ node_modules
 *.vsix
 dist
 .vscode-test
+
+*.temp
+*.tmp
+tmp.*
+temp.*
+tmp
+temp

--- a/package-lock.json
+++ b/package-lock.json
@@ -3187,6 +3187,11 @@
         "is-number": "^7.0.0"
       }
     },
+    "tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
+    },
     "ts-loader": {
       "version": "8.0.11",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.11.tgz",

--- a/package.json
+++ b/package.json
@@ -619,6 +619,7 @@
     "jquery.json-viewer": "^1.4.0",
     "popper.js": "^1.16.1",
     "showdown": "^1.9.1",
+    "tree-kill": "^1.2.2",
     "winreg": "^1.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -217,6 +217,10 @@
         "title": "R: Show help"
       },
       {
+        "command": "r.searchHelp",
+        "title": "R: Search help"
+      },
+      {
         "command": "r.helpPanel.back",
         "title": "R Help Panel: Go Back",
         "icon": "$(arrow-left)"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,6 @@ import { HelpPanel, HelpPanelOptions, HelpProvider, RHelpProviderOptions } from 
 import { RHelpClient } from './rHelpProviderBuiltin';
 import { RHelp } from './rHelpProviderCustom';
 import { RExtensionImplementation as RExtension } from './apiImplementation';
-import { resolveCliPathFromVSCodeExecutablePath } from 'vscode-test';
 
 const wordPattern = /(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\<\>\/\s]+)/g;
 
@@ -63,11 +62,15 @@ export async function activate(context: ExtensionContext) {
     const helpProviderType = config().get<'custom'|'Rserver'>('helpPanel.helpProvider');
 
     // launch help provider (provides the html for requested entries)
-    let helpProvider: HelpProvider;
-    if(helpProviderType === 'custom'){
-        helpProvider = new RHelp(rHelpProviderOptions);
-    } else {
-        helpProvider = new RHelpClient(rHelpProviderOptions);
+    let helpProvider: HelpProvider = undefined;
+    try{
+        if(helpProviderType === 'custom'){
+            helpProvider = new RHelp(rHelpProviderOptions);
+        } else {
+            helpProvider = new RHelpClient(rHelpProviderOptions);
+        }
+    } catch(e) {
+        window.showErrorMessage(`Help Panel not available: ${e.message}`);
     }
 
     // launch the help panel (displays the html provided by helpProvider)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,6 +89,10 @@ export async function activate(context: ExtensionContext) {
         rHelpPanel.showHelpForInput();
     }));
 
+    context.subscriptions.push(commands.registerCommand('r.searchHelp', () => {
+        rHelpPanel.searchHelp();
+    }));
+
     context.subscriptions.push(commands.registerCommand('r.showDoc', () => {
         rHelpPanel.showHelpForFunctionName('index.html', 'doc');
     }));

--- a/src/rHelpPanel.ts
+++ b/src/rHelpPanel.ts
@@ -88,7 +88,6 @@ export class HelpPanel {
 
 	constructor(rHelp: HelpProvider, options: HelpPanelOptions){
 		this.helpProvider = rHelp;
-		console.log(options.webviewScriptPath);
 		this.webviewScriptFile = vscode.Uri.file(options.webviewScriptPath);
 		this.webviewStyleFile = vscode.Uri.file(options.webviewStylePath);
 	}
@@ -130,20 +129,22 @@ export class HelpPanel {
 
 	// shows help for package and function name
 	public showHelpForFunctionName(fncName: string, pkgName: string){
+		this.checkHelpProvider();
+
 		let helpFile: HelpFile|Promise<HelpFile>;
 
 		if(pkgName === 'doc'){
 			if(this.helpProvider.getHelpFileForDoc){
 				helpFile = this.helpProvider.getHelpFileForDoc(fncName);
 			} else{
-				const requestPath = `doc/html/${fncName}`;
+				const requestPath = `/doc/html/${fncName}`;
 				helpFile = this.helpProvider.getHelpFileFromRequestPath(requestPath);
 			}
 		} else{
 			if(this.helpProvider.getHelpFileForFunction){
 				helpFile = this.helpProvider.getHelpFileForFunction(pkgName, fncName);
 			} else{
-				const requestPath = `library/${pkgName}/html/${fncName}.html`;
+				const requestPath = `/library/${pkgName}/html/${fncName}.html`;
 				helpFile = this.helpProvider.getHelpFileFromRequestPath(requestPath);
 			}
 		}
@@ -153,6 +154,7 @@ export class HelpPanel {
 
 	// shows help for request path as used by R's internal help server
 	public showHelpForPath(requestPath: string, viewer?: string|any){
+		this.checkHelpProvider();
 
 		if(typeof viewer === 'string'){
 			this.viewColumn = vscode.ViewColumn[String(viewer)];
@@ -370,6 +372,14 @@ export class HelpPanel {
 
 		// return the html of the modified page:
 		return helpFile;
+	}
+
+	// Helper function that rhwos an error if no vvalid help provider is available
+	private checkHelpProvider(){
+		if(!this.helpProvider){
+			vscode.window.showErrorMessage('Help provider not available!');
+			throw new Error('Help provider not available!');
+		}
 	}
 }
 

--- a/src/rHelpPanel.ts
+++ b/src/rHelpPanel.ts
@@ -117,7 +117,7 @@ export class HelpPanel {
 		this.checkHelpProvider();
 
 		const qpOptions: vscode.QuickPickOptions = {
-			matchOnDescription: true
+			matchOnDescription: true,
 		};
 
 		const packages = await this.getParsedIndexFile(`/doc/html/packages.html`);
@@ -126,20 +126,25 @@ export class HelpPanel {
 
 		if(packages && packages.length>0){
 			packages.unshift({
-				label: `$(home)`,
+				label: '$(home)',
 				description: 'Help Index',
 				pkgName: 'doc'
 			},{
-				label: `$(search)`,
+				label: '$(search)',
 				description: 'Search the help system using `??`',
 				pkgName: '??'
 			},{
-				label:`$(refresh)`,
+				label:'$(refresh)',
 				description: 'Clear cached index files',
 				pkgName: '__refresh'
 			});
-			const qp = await vscode.window.showQuickPick(packages, qpOptions);
-			pkgName = (qp.pkgName || '').replace(/\.html$/, '') || qp.label;
+			const qp = await vscode.window.showQuickPick(packages, {
+				matchOnDescription: true,
+				placeHolder: 'Please select a package'
+			});
+			if(qp){
+				pkgName = (qp.pkgName || '').replace(/\.html$/, '') || qp.label;
+			}
 		} else{
 			const defaultPkg = 'doc';
 			pkgName = await vscode.window.showInputBox({
@@ -168,7 +173,7 @@ export class HelpPanel {
 			const functions = await this.getParsedIndexFile(`/library/${pkgName}/html/00Index.html`);
 			if(functions){
 				functions.unshift({
-					label: `$(list-unordered)`,
+					label: '$(list-unordered)',
 					href: '00Index',
 					description: 'Package Index'
 				});
@@ -180,8 +185,13 @@ export class HelpPanel {
 					[functions[0], functions[1]] = [functions[1], functions[0]];
 				}
 
-				const qp = await vscode.window.showQuickPick(functions, qpOptions);
-				fncName = (qp.href || '').replace(/\.html$/, '') || qp.label;
+				const qp = await vscode.window.showQuickPick(functions, {
+					matchOnDescription: true,
+					placeHolder: 'Please select a documentation entry'
+				});
+				if(qp){
+					fncName = (qp.href || '').replace(/\.html$/, '') || qp.label;
+				}
 			} else{
 				const defaultFnc = (pkgName==='doc' ? 'index.html' : '00Index');
 				fncName = await vscode.window.showInputBox({

--- a/src/rHelpPanel.ts
+++ b/src/rHelpPanel.ts
@@ -25,6 +25,9 @@ export interface HelpProvider {
 	getHelpFileForDoc?(fncName: string): null|HelpFile|Promise<HelpFile>;
 	getHelpFileForFunction?(pkgName: string, fncName: string): null|HelpFile|Promise<HelpFile>;
 
+	// called to refresh (cached) underlying package info
+	refresh?(): void;
+
 	// called to e.g. close servers, delete files
 	dispose?(): void;
 }
@@ -148,6 +151,9 @@ export class HelpPanel {
 		if(!pkgName){
 			return false;
 		} else if(pkgName === '__refresh'){
+			if(this.helpProvider.refresh){
+				this.helpProvider.refresh();
+			}
 			this.cachedIndexFiles.clear();
 			return this.showHelpForInput();
 		}

--- a/src/rHelpPanel.ts
+++ b/src/rHelpPanel.ts
@@ -133,6 +133,10 @@ export class HelpPanel {
 				label: `$(search)`,
 				description: 'Search the help system using `??`',
 				pkgName: '??'
+			},{
+				label:`$(refresh)`,
+				description: 'Clear cached index files',
+				pkgName: '__refresh'
 			});
 			const qp = await vscode.window.showQuickPick(packages, qpOptions);
 			pkgName = (qp.pkgName || '').replace(/\.html$/, '') || qp.label;
@@ -145,6 +149,9 @@ export class HelpPanel {
 		}
 
 		if(!pkgName){
+			return false;
+		} else if(pkgName === '__refresh'){
+			this.cachedIndexFiles.clear();
 			return false;
 		}
 

--- a/src/rHelpPanel.ts
+++ b/src/rHelpPanel.ts
@@ -25,9 +25,6 @@ export interface HelpProvider {
 	getHelpFileForDoc?(fncName: string): null|HelpFile|Promise<HelpFile>;
 	getHelpFileForFunction?(pkgName: string, fncName: string): null|HelpFile|Promise<HelpFile>;
 
-	// optional function that list installed packages and documented items from package
-	getInstalledPackages?(): vscode.QuickPickItem[] | undefined;
-
 	// called to e.g. close servers, delete files
 	dispose?(): void;
 }

--- a/src/rHelpPanel.ts
+++ b/src/rHelpPanel.ts
@@ -169,6 +169,13 @@ export class HelpPanel {
 					href: '00Index',
 					description: 'Package Index'
 				});
+
+				if(functions.length>1 && functions[1].label === `${pkgName}-package`){
+					functions[1].href ||= functions[1].label;
+					functions[1].label = `$(home)`;
+					[functions[0], functions[1]] = [functions[1], functions[0]];
+				}
+
 				const qp = await vscode.window.showQuickPick(functions, qpOptions);
 				fncName = (qp.href || '').replace(/\.html$/, '') || qp.label;
 			} else{

--- a/src/rHelpPanel.ts
+++ b/src/rHelpPanel.ts
@@ -171,6 +171,7 @@ export class HelpPanel {
 				});
 
 				if(functions.length>1 && functions[1].label === `${pkgName}-package`){
+					functions[1] = {...functions[1]};
 					functions[1].href ||= functions[1].label;
 					functions[1].label = `$(home)`;
 					[functions[0], functions[1]] = [functions[1], functions[0]];

--- a/src/rHelpPanel.ts
+++ b/src/rHelpPanel.ts
@@ -152,7 +152,7 @@ export class HelpPanel {
 			return false;
 		} else if(pkgName === '__refresh'){
 			this.cachedIndexFiles.clear();
-			return false;
+			return this.showHelpForInput();
 		}
 
 		let fncName: string = undefined;

--- a/src/rHelpProviderBuiltin.ts
+++ b/src/rHelpProviderBuiltin.ts
@@ -10,7 +10,7 @@ import * as rHelpPanel from './rHelpPanel';
 const kill = require('tree-kill');
 
 export interface RHelpClientOptions extends rHelpPanel.RHelpProviderOptions {
-	// path of the R executable. Could be left out (with limited functionality)
+	// path of the R executable
     rPath: string;
 }
 
@@ -70,9 +70,13 @@ export class RHelpClient implements rHelpPanel.HelpProvider {
         return port;
     }
 
-    public async getHelpFileFromRequestPath(requestPath: string){
+	public async getHelpFileFromRequestPath(requestPath: string): Promise<null|rHelpPanel.HelpFile> {
         // make sure the server is actually running
         this.port = await this.port;
+
+        if(!this.port || typeof this.port !== 'number'){
+            return null;
+        }
 
         // remove leading '/'
         while(requestPath.startsWith('/')){

--- a/src/rHelpProviderBuiltin.ts
+++ b/src/rHelpProviderBuiltin.ts
@@ -7,6 +7,8 @@ import * as http from 'http';
 
 import * as rHelpPanel from './rHelpPanel';
 
+const kill = require('tree-kill');
+
 export interface RHelpClientOptions extends rHelpPanel.RHelpProviderOptions {
 	// path of the R executable. Could be left out (with limited functionality)
     rPath: string;
@@ -18,13 +20,20 @@ export class RHelpClient implements rHelpPanel.HelpProvider {
     private cp: cp.ChildProcess;
     private port: number|Promise<number>;
     private readonly rPath: string;
+    private readonly cwd?: string;
 
     public constructor(options: RHelpClientOptions){
         this.rPath = options.rPath || 'R';
-        this.port = this.launchRHelpServer(options.cwd); // is a promise for now!
+        this.cwd = options.cwd;
+        this.port = this.launchRHelpServer(); // is a promise for now!
     }
 
-    public async launchRHelpServer(cwd?: string){
+    public refresh(){
+        kill(this.cp.pid); // more reliable than cp.kill (?)
+        this.port = this.launchRHelpServer();
+    }
+
+    public async launchRHelpServer(){
 		const lim = '---vsc---';
 		const re = new RegExp(`.*${lim}(.*)${lim}.*`, 'ms');
 
@@ -34,7 +43,7 @@ export class RHelpClient implements rHelpPanel.HelpProvider {
             `"cat('${lim}', tools::startDynamicHelp(), '${lim}', sep=''); while(TRUE) Sys.sleep(1)" ` 
         );
         const cpOptions = {
-            cwd: cwd
+            cwd: this.cwd
         };
         this.cp = cp.exec(cmd, cpOptions);
 

--- a/src/rHelpProviderCustom.ts
+++ b/src/rHelpProviderCustom.ts
@@ -64,6 +64,8 @@ export class RHelp implements rHelpPanel.HelpProvider {
 	readonly homePath: string;
 	// temp directory used to extract .Rd file to
 	readonly tempDir: string;
+	// list of installed packages
+	readonly installedPackges?: string[];
 
 	constructor(options: RHelpOptions = {}) {
 		this.rPath = options.rPath || 'R';
@@ -103,6 +105,12 @@ export class RHelp implements rHelpPanel.HelpProvider {
 			// not good... throw error?
 			this.libPaths = [];
 		}
+
+		if(this.rPath){
+			const cmd = `${this.rPath} --silent --no-save --no-restore  --no-echo -e "cat('${lim}', paste(installed.packages(), collapse='\\n'), '${lim}', sep='')"`;
+			const packagesString = cp.execSync(cmd, cpOptions).toString().replace(re, '$1');
+			this.installedPackges = packagesString.replace(/\r/g, '').split('\n');
+		}
 	}
 
 	public dispose() {
@@ -111,7 +119,13 @@ export class RHelp implements rHelpPanel.HelpProvider {
 			recursive: true
 		};
 		fs.rmdir(this.tempDir, options, () => null);
-    }
+	}
+	
+	public getInstalledPackages() {
+		return this.installedPackges.map(pkg => {
+			return {label: pkg};
+		});
+	}
 
 	// main public interface
     public getHelpFileFromRequestPath(requestPath: string, prevFileLocation?: HelpFileLocation): HelpFile|null {

--- a/src/rHelpProviderCustom.ts
+++ b/src/rHelpProviderCustom.ts
@@ -249,16 +249,6 @@ export class RHelp implements rHelpPanel.HelpProvider {
             return null;
         }
 
-        // // convert the .Rd file to .html
-        // const cmd2 = `${this.rPath} CMD Rdconv --type=html ${rdFileName}`;
-        // let htmlContent: string = '';
-        // try{
-        //     htmlContent = cp.execSync(cmd2, options);
-        // } catch(e){
-        //     console.log('Failed to convert .Rd to .html');
-        //     return null;
-		// }
-		
         // convert the .Rd file to .html
 		const cmd3a = `"tools::Rd2HTML('${rdFileName}', Links=tools::findHTMLlinks())"`;
 		const cmd3 = `${this.rPath} -e ${cmd3a} --vanilla --silent --slave`;
@@ -270,13 +260,7 @@ export class RHelp implements rHelpPanel.HelpProvider {
             return null;
 		}
 
-
-		// try to remove temporary .Rd file
-		try {
-			fs.rmdirSync(rdFileName);
-		} catch (e) {
-			console.log('Failed to remove temp file. (Still working though)');
-		}
+		fs.unlink(rdFileName, (e) => {});
 
 		return htmlContent;
 	}

--- a/src/rHelpProviderCustom.ts
+++ b/src/rHelpProviderCustom.ts
@@ -86,7 +86,7 @@ export class RHelp implements rHelpPanel.HelpProvider {
 			this.homePath = options.homePath;
 		} else if(this.rPath){
 			// use R.home() in R
-			const cmd = `${this.rPath} --silent --no-save --no-restore  --no-echo -e "cat('${lim}', R.home(), '${lim}', sep='')"`;
+			const cmd = `${this.rPath} --silent --no-save --no-restore  --slave -e "cat('${lim}', R.home(), '${lim}', sep='')"`;
 			this.homePath = cp.execSync(cmd, cpOptions).toString().replace(re, '$1');
 		} else {
 			this.homePath = '';
@@ -98,7 +98,7 @@ export class RHelp implements rHelpPanel.HelpProvider {
 			this.libPaths = options.libPaths;
 		} else if (this.rPath) {
 			// use .libPaths() in R
-			const cmd = `${this.rPath} --silent --no-save --no-restore  --no-echo -e "cat('${lim}', paste(.libPaths(), collapse='\\n'), '${lim}', sep='')"`;
+			const cmd = `${this.rPath} --silent --no-save --no-restore  --slave -e "cat('${lim}', paste(.libPaths(), collapse='\\n'), '${lim}', sep='')"`;
 			const libPathString = cp.execSync(cmd, cpOptions).toString().replace(re, '$1');
 			this.libPaths = libPathString.replace(/\r/g, '').split('\n');
 		} else {
@@ -107,7 +107,7 @@ export class RHelp implements rHelpPanel.HelpProvider {
 		}
 
 		if(this.rPath){
-			const cmd = `${this.rPath} --silent --no-save --no-restore  --no-echo -e "cat('${lim}', paste(installed.packages(), collapse='\\n'), '${lim}', sep='')"`;
+			const cmd = `${this.rPath} --silent --no-save --no-restore  --slave -e "cat('${lim}', paste(installed.packages(), collapse='\\n'), '${lim}', sep='')"`;
 			const packagesString = cp.execSync(cmd, cpOptions).toString().replace(re, '$1');
 			this.installedPackges = packagesString.replace(/\r/g, '').split('\n');
 		}
@@ -255,7 +255,7 @@ export class RHelp implements rHelpPanel.HelpProvider {
 		const rdFileName = path.join(os.tmpdir(), fncName + '.Rd').replace(/\\/g, '/');
 
         // produce the .Rd file of a function:
-		const cmd1 = `${this.rPath} -e ${cmd1a} -e ${cmd1b} --vanilla --silent --no-echo > ${rdFileName}`;
+		const cmd1 = `${this.rPath} -e ${cmd1a} -e ${cmd1b} --vanilla --silent --slave > ${rdFileName}`;
         try{
             const out1 = cp.execSync(cmd1, options);
         } catch(e){
@@ -275,7 +275,7 @@ export class RHelp implements rHelpPanel.HelpProvider {
 		
         // convert the .Rd file to .html
 		const cmd3a = `"tools::Rd2HTML('${rdFileName}', Links=tools::findHTMLlinks())"`;
-		const cmd3 = `${this.rPath} -e ${cmd3a} --vanilla --silent --no-echo`;
+		const cmd3 = `${this.rPath} -e ${cmd3a} --vanilla --silent --slave`;
         let htmlContent: string = '';
         try{
             htmlContent = cp.execSync(cmd3, options);

--- a/src/rHelpProviderCustom.ts
+++ b/src/rHelpProviderCustom.ts
@@ -64,8 +64,6 @@ export class RHelp implements rHelpPanel.HelpProvider {
 	readonly homePath: string;
 	// temp directory used to extract .Rd file to
 	readonly tempDir: string;
-	// list of installed packages
-	readonly installedPackges?: string[];
 
 	constructor(options: RHelpOptions = {}) {
 		this.rPath = options.rPath || 'R';
@@ -105,12 +103,6 @@ export class RHelp implements rHelpPanel.HelpProvider {
 			// not good... throw error?
 			this.libPaths = [];
 		}
-
-		if(this.rPath){
-			const cmd = `${this.rPath} --silent --no-save --no-restore  --slave -e "cat('${lim}', paste(installed.packages(), collapse='\\n'), '${lim}', sep='')"`;
-			const packagesString = cp.execSync(cmd, cpOptions).toString().replace(re, '$1');
-			this.installedPackges = packagesString.replace(/\r/g, '').split('\n');
-		}
 	}
 
 	public dispose() {
@@ -119,12 +111,6 @@ export class RHelp implements rHelpPanel.HelpProvider {
 			recursive: true
 		};
 		fs.rmdir(this.tempDir, options, () => null);
-	}
-	
-	public getInstalledPackages() {
-		return this.installedPackges.map(pkg => {
-			return {label: pkg};
-		});
 	}
 
 	// main public interface

--- a/src/rHelpProviderCustom.ts
+++ b/src/rHelpProviderCustom.ts
@@ -98,7 +98,7 @@ export class RHelp implements rHelpPanel.HelpProvider {
 			// use .libPaths() in R
 			const cmd = `${this.rPath} --silent --no-save --no-restore  --no-echo -e "cat('${lim}', paste(.libPaths(), collapse='\\n'), '${lim}', sep='')"`;
 			const libPathString = cp.execSync(cmd, cpOptions).toString().replace(re, '$1');
-			this.libPaths = libPathString.replace('\r', '').split('\n');
+			this.libPaths = libPathString.replace(/\r/g, '').split('\n');
 		} else {
 			// not good... throw error?
 			this.libPaths = [];


### PR DESCRIPTION
Improve the help panel and fix https://github.com/Ikuyadeu/vscode-R/issues/471:
- [x] Remove use of `isFALSE`
- [x] Fix some bugs that caused the entire extension to crash, if the help panel path was invalid
- [x] Parse package index to suggest package names when calling `R: Show Help`
- [x] Parse index files of packages to suggest documented functions from a selected package
- [x] Implement `??` functionality
    - [x] Accessible with command `R: Search Help` or by selecting search icon after command `R: Show Help`
    - [x] Make accessible from R session
- [ ] Improve performance:
    - [x] Cache installed packages/functions in package per session
    - [ ] Keep cache between sessions?
    - [x] Add option to clear cached index files
- [ ] Implement `?` functionality (from vscode command palette)
- [x] Identify and highlight package pages like e.g. `base/html/base-package.html`
- [ ] ...