### PR TITLE
Fix bug that would leave background R processes running

### DIFF
--- a/src/rHelpProviderBuiltin.ts
+++ b/src/rHelpProviderBuiltin.ts
@@ -133,7 +133,7 @@ export class RHelpClient implements rHelpPanel.HelpProvider {
 
     dispose(){
         if(this.cp){
-            this.cp.kill();
+            kill(this.cp.pid);
         }
     }
 }


### PR DESCRIPTION
Fix a command that would not properly kill background R processes started by the help panel.