### PR TITLE
Improve style of help pages

### DIFF
--- a/html/theme.css
+++ b/html/theme.css
@@ -87,9 +87,14 @@ a {
     font-size: 16px;
 } */
 
-body table:nth-child(1)[width="100%"] {
+body table:nth-child(1)[width="100%"] td:nth-child(2){
     display: none;
 }
+
+body table:nth-child(1)[width="100%"] td:nth-child(1){
+    text-align: right;
+}
+
 
 h1, h2 {
     text-align: center;

--- a/html/theme.css
+++ b/html/theme.css
@@ -98,6 +98,7 @@ body table:nth-child(1)[width="100%"] td:nth-child(1){
 
 h1, h2 {
     text-align: center;
+    margin-block-end: 0;
 }
 
 img {

--- a/html/theme.css
+++ b/html/theme.css
@@ -86,3 +86,19 @@ a {
 /* p {
     font-size: 16px;
 } */
+
+body table:nth-child(1)[width="100%"] {
+    display: none;
+}
+
+h1, h2 {
+    text-align: center;
+}
+
+img {
+    display: none;
+}
+
+a ~ div.header {
+    display: none;
+}

--- a/src/rHelpPanel.ts
+++ b/src/rHelpPanel.ts
@@ -524,6 +524,8 @@ export class HelpPanel implements api.HelpPanel {
 
 		if(!helpFile.isModified){
 
+			$('head style').remove();
+
 			if(config().get<boolean>('helpPanel.enableSyntaxHighlighting')){
 				// find all code sections, enclosed by <pre>...</pre>
 				const codeSections = $('pre');


### PR DESCRIPTION
Just some small modifications of the helppanel style:
* All help pages: center headings
* Normal functino help pages: hide (rather useless) header bar 
* All help pages: hide image placeholders
* Manuel Pages: hide page-internal links 
* Manual Pages: suppress mismatching header styles embedded in the html

To test the changes:
Open some help pages, e.g. `base::mean` and `R-Intro` (`F1` -> `R: Show Help` -> `Help Index` -> `An Introduction to R` -> `Preface`)