### PR TITLE
Conditionally show view

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
           "id": "workspaceViewer",
           "name": "Workspace",
           "icon": "./images/Rlogo.svg",
-          "contextualTitle": "R"
+          "contextualTitle": "R",
+          "when": "r.WorkspaceViewer:show"
         }
       ]
     },
@@ -729,7 +730,7 @@
         "r.sessionWatcher": {
           "type": "boolean",
           "default": false,
-          "description": "Enable R session watcher (experimental). Restart required to take effect."
+          "description": "Enable R session watcher (experimental). Required for workspace viewer. Restart required to take effect."
         },
         "r.rtermSendDelay": {
           "type": "integer",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,15 +56,6 @@ export async function activate(context: ExtensionContext): Promise<RExtension> {
         rWorkspace
     );
 
-    // creates a custom context value for the workspace view
-    // only shows view when session watcher is enabled
-    const sessionBool = workspace.getConfiguration('r')['sessionWatcher'];
-    if (sessionBool === true) {
-        void commands.executeCommand('setContext', 'r.WorkspaceViewer:show', true);
-    } else {
-        void commands.executeCommand('setContext', 'r.WorkspaceViewer:show', false);
-    }
-
     // used to export an interface to the help panel
     // used e.g. by vscode-r-debugger to show the help panel from within debug sessions
     const rExtension = new RExtension();
@@ -311,7 +302,8 @@ export async function activate(context: ExtensionContext): Promise<RExtension> {
     const rmdCompletionProvider = new RMarkdownCompletionItemProvider();
     languages.registerCompletionItemProvider('rmd', rmdCompletionProvider, ' ', ',');
 
-    if (config().get<boolean>('sessionWatcher')) {
+    const enabledSessionWatcher = config().get<boolean>('sessionWatcher');
+    if (enabledSessionWatcher) {
         console.info('Initialize session watcher');
         languages.registerHoverProvider('r', {
             provideHover(document, position, ) {
@@ -370,6 +362,10 @@ export async function activate(context: ExtensionContext): Promise<RExtension> {
                 return items;
             },
         },                                       '', '$', '@', '"', '\'');
+
+        // creates a custom context value for the workspace view
+        // only shows view when session watcher is enabled
+        void commands.executeCommand('setContext', 'r.WorkspaceViewer:show', enabledSessionWatcher);
 
         console.info('Create sessionStatusBarItem');
         const sessionStatusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 1000);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,6 +56,15 @@ export async function activate(context: ExtensionContext): Promise<RExtension> {
         rWorkspace
     );
 
+    // creates a custom context value for the workspace view
+    // only shows view when session watcher is enabled
+    const sessionBool = workspace.getConfiguration('r')['sessionWatcher'];
+    if (sessionBool === true) {
+        void commands.executeCommand('setContext', 'r.WorkspaceViewer:show', true);
+    } else {
+        void commands.executeCommand('setContext', 'r.WorkspaceViewer:show', false);
+    }
+
     // used to export an interface to the help panel
     // used e.g. by vscode-r-debugger to show the help panel from within debug sessions
     const rExtension = new RExtension();


### PR DESCRIPTION
Only show workspace view when session watcher is enabled

**What problem did you solve?**

Workspace viewer only functions when session watcher is enabled. Currently, the workspace viewer is displayed even when non-functional because the session watcher is not enabled.

**How can I check this pull request?**
If session watcher is enabled, the workspace viewer should be visible. When session watcher is disabled, workspace viewer should not be shown.
