### PR TITLE
Enable find widget in WebViews

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -246,6 +246,7 @@ async function showWebView(file: string, title: string, viewer: string | boolean
             },
             {
                 enableScripts: true,
+                enableFindWidget: true,
                 retainContextWhenHidden: true,
                 localResourceRoots: [Uri.file(dir)],
             });
@@ -269,6 +270,7 @@ async function showDataView(source: string, type: string, title: string, file: s
             },
             {
                 enableScripts: true,
+                enableFindWidget: true,
                 retainContextWhenHidden: true,
                 localResourceRoots: [Uri.file(resDir)],
             });
@@ -282,6 +284,7 @@ async function showDataView(source: string, type: string, title: string, file: s
             },
             {
                 enableScripts: true,
+                enableFindWidget: true,
                 retainContextWhenHidden: true,
                 localResourceRoots: [Uri.file(resDir)],
             });


### PR DESCRIPTION
**What problem did you solve?**

Inspired by #488, this PR uses `enableFindWidget` for all non-http web views.

**(If you have)Screenshot**

![image](https://user-images.githubusercontent.com/4662568/101721404-db3a8f00-3ae2-11eb-87a2-aaf8ad376812.png)

![image](https://user-images.githubusercontent.com/4662568/101721375-c78f2880-3ae2-11eb-836a-021bcee74a7c.png)

**(If you do not have screenshot) How can I check this pull request?**

```r
View(mtcars)
View(list(a = 1, b = 2))
DT::datatable(mtcars)
```

The find widget should work in each WebView created by the above lines.