### PR TITLE
Disable alwaysShow for addin items

### DIFF
--- a/src/rstudioapi.ts
+++ b/src/rstudioapi.ts
@@ -291,7 +291,7 @@ export async function getAddinPickerItems(): Promise<AddinItem[]> {
 
     const addinItems = addins.map((x) => {
       return {
-        alwaysShow: true,
+        alwaysShow: false,
         description: `{${x.package}}`,
         label: x.name,
         detail: x.description,


### PR DESCRIPTION
**What problem did you solve?**

Closes #489 

This PR sets `alwaysShow: false` to addin items so that it is easier for user to find the wanted addin command on type.

**(If you have)Screenshot**

![image](https://user-images.githubusercontent.com/4662568/101722129-86981380-3ae4-11eb-9383-bf6cae8c0b3c.png)


**(If you do not have screenshot) How can I check this pull request?**

1. Attach an R session
2. Launch RStudio Addin
3. type a package name
4. Only matched items will show in the list
