### PR TITLE
Only show R menu items in R view

### DIFF
--- a/package.json
+++ b/package.json
@@ -597,29 +597,35 @@
       "view/item/context": [
         {
           "command": "r.workspaceViewer.view",
-          "group": "inline"
+          "group": "inline",
+          "when": "view == workspaceViewer"
         },
         {
           "command": "r.workspaceViewer.remove",
-          "group": "inline"
+          "group": "inline",
+          "when": "view == workspaceViewer"
         }
       ],
       "view/title": [
         {
           "command": "r.workspaceViewer.load",
-          "group": "navigation@0"
+          "group": "navigation@0",
+          "when": "view == workspaceViewer"
         },
         {
           "command": "r.workspaceViewer.save",
-          "group": "navigation@1"
+          "group": "navigation@1",
+          "when": "view == workspaceViewer"
         },
         {
           "command": "r.workspaceViewer.clear",
-          "group": "navigation@2"
+          "group": "navigation@2",
+          "when": "view == workspaceViewer"
         },
         {
           "command": "r.workspaceViewer.refreshEntry",
-          "group": "navigation@3"
+          "group": "navigation@3",
+          "when": "view == workspaceViewer"
         }
       ]
     },


### PR DESCRIPTION
**What problem did you solve?**
Currently, the R menu items `Load workspace`, `Save workspace` etc. are shown in every view in the side panel.

This PR only shows the R menu items in the R workspace view

**(If you do not have screenshot) How can I check this pull request?**

Check menu items in the title bar and item contexts for non-R-workspace views.
