### PR TITLE
Add browser WebView command buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -600,6 +600,11 @@
         },
         {
           "command": "editor.action.webvieweditor.showFind",
+          "when": "resourceScheme =~ /webview/ && r.browser.active",
+          "group": "navigation"
+        },
+        {
+          "command": "editor.action.webvieweditor.showFind",
           "when": "resourceScheme =~ /webview/ && r.helpPanel.active",
           "group": "navigation"
         },

--- a/package.json
+++ b/package.json
@@ -292,7 +292,7 @@
       },
       {
         "command": "editor.action.webvieweditor.showFind",
-        "title": "R Help Panel: Find in Topic",
+        "title": "R WebView: Find in text",
         "icon": "$(search)"
       },
       {

--- a/package.json
+++ b/package.json
@@ -279,12 +279,14 @@
       {
         "command": "r.browser.refresh",
         "title": "Refresh",
-        "icon": "$(refresh)"
+        "icon": "$(refresh)",
+        "category": "R"
       },
       {
         "command": "r.browser.openExternal",
         "title": "Open in external browser",
-        "icon": "$(link-external)"
+        "icon": "$(link-external)",
+        "category": "R"
       },
       {
         "command": "r.showHelp",
@@ -292,8 +294,9 @@
       },
       {
         "command": "editor.action.webvieweditor.showFind",
-        "title": "R WebView: Find in text",
-        "icon": "$(search)"
+        "title": "R: Find in WebView",
+        "icon": "$(search)",
+        "category": "R"
       },
       {
         "command": "r.helpPanel.back",

--- a/package.json
+++ b/package.json
@@ -277,6 +277,16 @@
         "icon": "$(folder-opened)"
       },
       {
+        "command": "r.browser.refresh",
+        "title": "Refresh",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "r.browser.openExternal",
+        "title": "Open in external browser",
+        "icon": "$(link-external)"
+      },
+      {
         "command": "r.showHelp",
         "title": "R: Show help"
       },
@@ -576,6 +586,16 @@
         {
           "when": "editorLangId == rmd",
           "command": "r.knitRmd",
+          "group": "navigation"
+        },
+        {
+          "command": "r.browser.refresh",
+          "when": "resourceScheme =~ /webview/ && r.browser.active",
+          "group": "navigation"
+        },
+        {
+          "command": "r.browser.openExternal",
+          "when": "resourceScheme =~ /webview/ && r.browser.active",
           "group": "navigation"
         },
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { previewDataframe, previewEnvironment } from './preview';
 import { createGitignore } from './rGitignore';
 import { createRTerm, deleteTerminal, runChunksInTerm, runSelectionInTerm, runTextInTerm } from './rTerminal';
 import { getWordOrSelection, surroundSelection } from './selection';
-import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startRequestWatcher } from './session';
+import { attachActive, deploySessionWatcher, globalenv, showPlotHistory, startRequestWatcher, refreshBrowser, openExternalBrowser } from './session';
 import { config, ToRStringLiteral, getRpath } from './util';
 import { launchAddinPicker, trackLastActiveTextEditor } from './rstudioapi';
 import { RMarkdownCodeLensProvider, RMarkdownCompletionItemProvider, selectCurrentChunk, runCurrentChunk, runAboveChunks, runCurrentAndBelowChunks, runBelowChunks, runPreviousChunk, runNextChunk, runAllChunks, goToPreviousChunk, goToNextChunk } from './rmarkdown';
@@ -293,6 +293,8 @@ export async function activate(context: ExtensionContext): Promise<RExtension> {
         commands.registerCommand('r.workspaceViewer.clear', clearWorkspace),
         commands.registerCommand('r.workspaceViewer.load', loadWorkspace),
         commands.registerCommand('r.workspaceViewer.save', saveWorkspace),
+        commands.registerCommand('r.browser.refresh', refreshBrowser),
+        commands.registerCommand('r.browser.openExternal', openExternalBrowser),
         window.onDidCloseTerminal(deleteTerminal),
     );
 

--- a/src/rHelpPanel.ts
+++ b/src/rHelpPanel.ts
@@ -411,6 +411,7 @@ export class HelpPanel implements api.HelpPanel {
 				this.panel = undefined;
 				this.webviewScriptUri = undefined;
 				this.webviewStyleUri = undefined;
+				void commands.executeCommand('setContext', 'r.helpPanel.active', false);
 			});
 
 			// sent by javascript added to the help pages, e.g. when a link or mouse button is clicked

--- a/src/session.ts
+++ b/src/session.ts
@@ -216,6 +216,12 @@ async function showBrowser(url: string, title: string, viewer: string | boolean)
             }
             void commands.executeCommand('setContext', 'r.browser.active', e.webviewPanel.active);
         });
+        panel.onDidDispose(() => {
+            activeBrowserPanel = undefined;
+            activeBrowserUri = undefined;
+            activeBrowserExternalUri = undefined;
+            void commands.executeCommand('setContext', 'r.browser.active', false);
+        });
         panel.webview.html = getBrowserHtml(externalUri);
     }
     console.info('[showBrowser] Done');

--- a/src/session.ts
+++ b/src/session.ts
@@ -7,7 +7,6 @@
 import fs = require('fs-extra');
 import os = require('os');
 import path = require('path');
-import { URL } from 'url';
 import { commands, StatusBarItem, Uri, ViewColumn, Webview, window, workspace, env, WebviewPanelOnDidChangeViewStateEvent, WebviewPanel } from 'vscode';
 
 import { runTextInTerm } from './rTerminal';

--- a/src/session.ts
+++ b/src/session.ts
@@ -200,6 +200,7 @@ async function showBrowser(url: string, title: string, viewer: string | boolean)
                 viewColumn: ViewColumn[String(viewer)],
             },
             {
+                enableFindWidget: true,
                 enableScripts: true,
                 retainContextWhenHidden: true,
             });

--- a/src/session.ts
+++ b/src/session.ts
@@ -39,6 +39,7 @@ let globalEnvWatcher: FSWatcher;
 let plotWatcher: FSWatcher;
 let activeBrowserPanel: WebviewPanel;
 let activeBrowserUri: Uri;
+let activeBrowserExternalUri: Uri;
 
 export function deploySessionWatcher(extensionPath: string): void {
     console.info(`[deploySessionWatcher] extensionPath: ${extensionPath}`);
@@ -205,10 +206,12 @@ async function showBrowser(url: string, title: string, viewer: string | boolean)
         panel.onDidChangeViewState((e: WebviewPanelOnDidChangeViewStateEvent) => {
             if (e.webviewPanel.active) {
                 activeBrowserPanel = panel;
-                activeBrowserUri = externalUri;
+                activeBrowserUri = uri;
+                activeBrowserExternalUri = externalUri;
             } else {
                 activeBrowserPanel = undefined;
                 activeBrowserUri = undefined;
+                activeBrowserExternalUri = undefined;
             }
             void commands.executeCommand('setContext', 'r.browser.active', e.webviewPanel.active);
         });
@@ -243,7 +246,7 @@ export function refreshBrowser():void {
     console.log('[refreshBrowser]');
     if (activeBrowserPanel) {
         activeBrowserPanel.webview.html = '';
-        activeBrowserPanel.webview.html = getBrowserHtml(activeBrowserUri);
+        activeBrowserPanel.webview.html = getBrowserHtml(activeBrowserExternalUri);
     }
 }
 


### PR DESCRIPTION
**What problem did you solve?**

This PR adds the following buttons to WebViews created by `browser`.

* Refresh: useful If the browser WebView is loaded too early (e.g. https://github.com/microsoft/vscode/issues/112297) or not properly loaded, or  the user wants to reload the page for some reason.
* Open in external browser: useful if the WebView cannot show the page properly (most likely due to some WebView limitations).
* Find: find text in WebView. This is identical to the "R Help Panel: Find in Topic" command. Therefore I rename this command so that it sounds more general.

Also, this PR uses `vscode.env.asExternalUri` introduced at <https://code.visualstudio.com/api/advanced-topics/remote-extensions#forwarding-localhost> instead of [port mapping](https://code.visualstudio.com/api/advanced-topics/remote-extensions#option-2-use-a-port-mapping). Now the port forwarding should work smoothly under remote development when a browser WebView is created without relying on explicit port mapping (currently not working, see https://github.com/microsoft/vscode/issues/102449) and auto port forwarding (currently not working smoothly, see https://github.com/microsoft/vscode/issues/112297).

**(If you have)Screenshot**

<img width="651" alt="image" src="https://user-images.githubusercontent.com/4662568/102004732-3cb26600-3d4e-11eb-9218-42d94c63ce9f.png">

**(If you do not have screenshot) How can I check this pull request?**

1. Create a R terminal with session watcher attached.
2. Run `shiny::runExample("01_hello")` and a WebView is created
3. Focus on the WebView, and the two commands should appear on the right side of the tab.
4. Click "Refresh", and the WebView is reloaded.
5. Click "Open in external browser", and the user web browser is launched to show the web page.
6. Click "Find", and the find widget should work.

"Open in external browser" should also work under remote development as it will automatically setup the port forwarding from remote to local. To test, just repeat the above steps under remote development and the behavior should be exactly the same.