### PR TITLE
releaseAction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,5 +43,5 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           files: "artifacts/*/*"
           prerelease: false
-          draft: true # Could also be false to publish the release immediately
+          draft: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: release
 
 # runs when a tag v* is pushed
-# creates a release draft with the binaries
+# releases the extension to GitHub and the vscode marketplace
 
 on:
   push:
@@ -45,3 +45,17 @@ jobs:
           prerelease: false
           draft: false
 
+
+  publish:
+    name: Publish
+    timeout-minutes: 30
+    needs: release # doesn't really need these, just to make sure that packaging etc worked
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm install
+      - uses: lannonbr/vsce-action@master
+        with:
+          args: "publish -p $VSCE_TOKEN"
+        env:
+          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}


### PR DESCRIPTION
**What problem did you solve?**
Fix #503. This PR updates the GitHub release action to automatically release the extension to GitHub and the marketplace when a tag matching `v*` is pushed.


**How can I check this pull request?**
This PR is kind of hard to check safely since the action is triggered automatically and produces a release to the marketplace, which can potentially affect all users of the extension. To be safe, I'd suggest keeping a `.vsix` file ready as backup when using the action for the first time.

For the action to publish to the marketlace, an access token is required, more details e.g. [here](https://github.com/marketplace/actions/github-action-for-vsce).
