### PR TITLE
Publish development build to vscode marketplace

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+webpack.config.js
+html/*.js
+scripts/*.js
+node_modules

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
   test:
     strategy:
+      fail-fast: false # continue other tests if one os fails
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -4,7 +4,7 @@ name: pre-release
 
 on:
   push:
-    branches: ["master"]
+    branches: ["devbuild*"]
 
 env:
   FILE_OUT: r-latest.vsix
@@ -44,10 +44,22 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: latest
-          commitish: master
           name: Development Build
           body: Contains the vsix-file from the latest push to master.
           prerelease: true
           files: "artifacts/*/*"
           gzip: false
           allow_override: true
+
+  publish:
+    name: Publish Devbuild
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: node scripts/prepareDevbuild.js
+      - run: npm install
+      - uses: lannonbr/vsce-action@master
+        with:
+          args: "publish -p $VSCE_TOKEN_DEV_BUILD"
+        env:
+          VSCE_TOKEN_DEV_BUILD: ${{ secrets.VSCE_TOKEN_DEV_BUILD }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -4,7 +4,7 @@ name: pre-release
 
 on:
   push:
-    branches: ["devbuild*"]
+    branches: ["master"]
 
 env:
   FILE_OUT: r-latest.vsix

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,6 +12,7 @@ html/*.ts
 node_modules
 out/
 out/test/**
+scripts/**
 src/
 src/**
 test/**

--- a/README-dev-build-note.md
+++ b/README-dev-build-note.md
@@ -1,0 +1,5 @@
+# Dev Build
+
+This is a development build!
+
+

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "publisher": "Ikuyadeu",
   "icon": "images/Rlogo.png",
+  "preview": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/Ikuyadeu/vscode-R"

--- a/scripts/prepareDevbuild.js
+++ b/scripts/prepareDevbuild.js
@@ -1,0 +1,24 @@
+"use strict";
+exports.__esModule = true;
+var fs = require("fs");
+// file names
+var README = './README.md';
+var README_NOTE = './README-dev-build-note.md';
+var PACKAGE = './package.json';
+// parse package.json
+var json = JSON.parse(fs.readFileSync(PACKAGE, 'utf-8'));
+// construct version from year.month.monthMinutes
+var date = new Date();
+var monthMinutes = (date.getDate() - 1) * 24 * 60 + date.getHours() * 60 + date.getMinutes();
+var version = date.getFullYear() + "." + (date.getMonth() + 1) + "." + monthMinutes;
+// modify json and write back to package.json
+json.version = version;
+json.name = 'r-dev';
+json.displayName = 'R - Development Build';
+json.preview = true;
+fs.writeFileSync(PACKAGE, JSON.stringify(json, undefined, 4));
+// add note to readme
+var readme = fs.readFileSync(README, 'utf-8');
+var readmeNote = fs.readFileSync(README_NOTE, 'utf-8');
+var newReadme = readmeNote + "\n" + readme;
+fs.writeFileSync(README, newReadme);

--- a/scripts/prepareDevbuild.ts
+++ b/scripts/prepareDevbuild.ts
@@ -1,0 +1,41 @@
+
+import * as fs from 'fs';
+
+// items of package.json that are modified
+interface packageInfo {
+    version?: string,
+    name?: string,
+    displayName?: string,
+    preview?: boolean
+}
+
+// file names
+const README = './README.md';
+const README_NOTE = './README-dev-build-note.md';
+const PACKAGE = './package.json';
+
+// parse package.json
+const json = <packageInfo>JSON.parse(fs.readFileSync(PACKAGE, 'utf-8'));
+
+// construct version from year.month.monthMinutes
+const date = new Date();
+const monthMinutes = (date.getDate() - 1) * 24 * 60 + date.getHours() * 60 + date.getMinutes();
+const version = `${date.getFullYear()}.${date.getMonth() + 1}.${monthMinutes}`;
+
+// modify json and write back to package.json
+json.version = version;
+json.name = 'r-dev';
+json.displayName = 'R - Development Build';
+json.preview = true;
+
+fs.writeFileSync(PACKAGE, JSON.stringify(json, undefined, 4));
+
+
+// add note to readme
+const readme = fs.readFileSync(README, 'utf-8');
+const readmeNote = fs.readFileSync(README_NOTE, 'utf-8');
+const newReadme = `${readmeNote}\n${readme}`;
+
+fs.writeFileSync(README, newReadme);
+
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "exclude": [
         "node_modules",
         ".vscode-test",
-        "html/*"
+        "html",
+        "scripts"
     ]
 }


### PR DESCRIPTION
As suggested in [#505](https://github.com/Ikuyadeu/vscode-R/pull/505#issuecomment-751349854), this PR modifies the current pre-release action to publish to the vscode marketplace as well.

This development build differs from the normal build in the following points:
* The name of the extension is changed to `r-dev`
* The displayName is changed to `R - Development Build`
* The version is changed to match the template `YEAR.MONTH.MONTH_MINUTES`, since it's not possible to publish the same version twice and the dev build shouldn't interfere with the normal versioning
* The content of `./README-dev-build-note.md` is added to the top of the normal README (the content of this note is just a dummy so far)
* The extension is flagged as preview

A development build can give users the chance to try out new features and give feedback without having to manuallly install and update the extension from .vsix files.

