### PR TITLE
Keep promises and active bindings in globalenv

### DIFF
--- a/R/.lintr
+++ b/R/.lintr
@@ -1,1 +1,5 @@
-linters: with_defaults(cyclocomp_linter = NULL, object_name_linter = NULL, object_usage_linter = NULL)
+linters: with_defaults(
+  line_length_linter(120),
+  cyclocomp_linter = NULL,
+  object_name_linter = NULL,
+  object_usage_linter = NULL)

--- a/R/init.R
+++ b/R/init.R
@@ -73,6 +73,7 @@ if (interactive() &&
       inspect_env <- function(env) {
         all_names <- ls(env)
         is_promise <- rlang::env_binding_are_lazy(env, all_names)
+        is_active <- rlang::env_binding_are_active(env, all_names)
         objs <- lapply(all_names, function(name) {
           if (is_promise[[name]]) {
             info <- list(
@@ -80,6 +81,13 @@ if (interactive() &&
               type = unbox("promise"),
               length = unbox(0L),
               str = unbox("<promise>")
+            )
+          } else if (is_active[[name]]) {
+            info <- list(
+              class = "active_binding",
+              type = unbox("active_binding"),
+              length = unbox(0L),
+              str = unbox("<active-binding>")
             )
           } else {
             obj <- env[[name]]

--- a/R/init.R
+++ b/R/init.R
@@ -1,652 +1,661 @@
-if (interactive() &&
-  Sys.getenv("RSTUDIO") == "" &&
-  Sys.getenv("TERM_PROGRAM") == "vscode") {
-  if (requireNamespace("jsonlite", quietly = TRUE) &&
-      requireNamespace("rlang", quietly = TRUE)) local({
-    # cleanup previous version
-    removeTaskCallback("vscode-R")
-    options(vscodeR = NULL)
+local({
+  if (interactive() &&
+    Sys.getenv("RSTUDIO") == "" &&
+    Sys.getenv("TERM_PROGRAM") == "vscode") {
 
-    .vsc.name <- "tools:vscode"
-    if (.vsc.name %in% search()) {
-      detach(.vsc.name, character.only = TRUE)
-    }
+    required_packages <- c("jsonlite", "rlang")
+    missing_packages <- required_packages[
+      !vapply(required_packages, requireNamespace,
+        logical(1L), quietly = TRUE)
+    ]
 
-    .vsc <- local({
-      pid <- Sys.getpid()
-      wd <- getwd()
-      tempdir <- tempdir()
-      homedir <- Sys.getenv(
-        if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"
+    if (length(missing_packages)) {
+      message(
+        "VSCode R Session Watcher requires ",
+        toString(missing_packages), ". ",
+        "Please install manually in order to use VSCode-R."
       )
-      dir_extension <- file.path(homedir, ".vscode-R")
-      request_file <- file.path(dir_extension, "request.log")
-      request_lock_file <- file.path(dir_extension, "request.lock")
+    } else local({
+       # cleanup previous version
+      removeTaskCallback("vscode-R")
+      options(vscodeR = NULL)
 
-      if (is.null(getOption("help_type"))) {
-        options(help_type = "html")
+      .vsc.name <- "tools:vscode"
+      if (.vsc.name %in% search()) {
+        detach(.vsc.name, character.only = TRUE)
       }
 
-      get_timestamp <- function() {
-        format.default(Sys.time(), nsmall = 6)
-      }
-
-      unbox <- jsonlite::unbox
-
-      request <- function(command, ...) {
-        obj <- list(
-          time = Sys.time(),
-          pid = pid,
-          wd = wd,
-          command = command,
-          ...
+      .vsc <- local({
+        pid <- Sys.getpid()
+        wd <- getwd()
+        tempdir <- tempdir()
+        homedir <- Sys.getenv(
+          if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"
         )
-        jsonlite::write_json(obj, request_file,
-          auto_unbox = TRUE, null = "null", force = TRUE)
-        cat(get_timestamp(), file = request_lock_file)
-      }
+        dir_extension <- file.path(homedir, ".vscode-R")
+        request_file <- file.path(dir_extension, "request.log")
+        request_lock_file <- file.path(dir_extension, "request.lock")
 
-      capture_str <- function(object) {
-        utils::capture.output(
-          utils::str(object, max.level = 0, give.attr = FALSE)
-        )
-      }
-
-      rebind <- function(sym, value, ns) {
-        if (is.character(ns)) {
-          Recall(sym, value, getNamespace(ns))
-          pkg <- paste0("package:", ns)
-          if (pkg %in% search()) {
-            Recall(sym, value, as.environment(pkg))
-          }
-        } else if (is.environment(ns)) {
-          if (bindingIsLocked(sym, ns)) {
-            unlockBinding(sym, ns)
-            on.exit(lockBinding(sym, ns))
-          }
-          assign(sym, value, ns)
-        } else {
-          stop("ns must be a string or environment")
+        if (is.null(getOption("help_type"))) {
+          options(help_type = "html")
         }
-      }
 
-      inspect_env <- function(env) {
-        all_names <- ls(env)
-        is_promise <- rlang::env_binding_are_lazy(env, all_names)
-        is_active <- rlang::env_binding_are_active(env, all_names)
-        objs <- lapply(all_names, function(name) {
-          if (is_promise[[name]]) {
-            info <- list(
-              class = "promise",
-              type = unbox("promise"),
-              length = unbox(0L),
-              str = unbox("<promise>")
-            )
-          } else if (is_active[[name]]) {
-            info <- list(
-              class = "active_binding",
-              type = unbox("active_binding"),
-              length = unbox(0L),
-              str = unbox("<active-binding>")
-            )
+        get_timestamp <- function() {
+          format.default(Sys.time(), nsmall = 6)
+        }
+
+        unbox <- jsonlite::unbox
+
+        request <- function(command, ...) {
+          obj <- list(
+            time = Sys.time(),
+            pid = pid,
+            wd = wd,
+            command = command,
+            ...
+          )
+          jsonlite::write_json(obj, request_file,
+            auto_unbox = TRUE, null = "null", force = TRUE)
+          cat(get_timestamp(), file = request_lock_file)
+        }
+
+        capture_str <- function(object) {
+          utils::capture.output(
+            utils::str(object, max.level = 0, give.attr = FALSE)
+          )
+        }
+
+        rebind <- function(sym, value, ns) {
+          if (is.character(ns)) {
+            Recall(sym, value, getNamespace(ns))
+            pkg <- paste0("package:", ns)
+            if (pkg %in% search()) {
+              Recall(sym, value, as.environment(pkg))
+            }
+          } else if (is.environment(ns)) {
+            if (bindingIsLocked(sym, ns)) {
+              unlockBinding(sym, ns)
+              on.exit(lockBinding(sym, ns))
+            }
+            assign(sym, value, ns)
           } else {
-            obj <- env[[name]]
-            str <- capture_str(obj)[[1L]]
-            info <- list(
-              class = class(obj),
-              type = unbox(typeof(obj)),
-              length = unbox(length(obj)),
-              str = unbox(trimws(str))
+            stop("ns must be a string or environment")
+          }
+        }
+
+        inspect_env <- function(env) {
+          all_names <- ls(env)
+          is_promise <- rlang::env_binding_are_lazy(env, all_names)
+          is_active <- rlang::env_binding_are_active(env, all_names)
+          objs <- lapply(all_names, function(name) {
+            if (is_promise[[name]]) {
+              info <- list(
+                class = "promise",
+                type = unbox("promise"),
+                length = unbox(0L),
+                str = unbox("<promise>")
+              )
+            } else if (is_active[[name]]) {
+              info <- list(
+                class = "active_binding",
+                type = unbox("active_binding"),
+                length = unbox(0L),
+                str = unbox("<active-binding>")
+              )
+            } else {
+              obj <- env[[name]]
+              str <- capture_str(obj)[[1L]]
+              info <- list(
+                class = class(obj),
+                type = unbox(typeof(obj)),
+                length = unbox(length(obj)),
+                str = unbox(trimws(str))
+              )
+              if ((is.list(obj) ||
+                is.environment(obj)) &&
+                !is.null(names(obj))) {
+                info$names <- names(obj)
+              }
+              if (isS4(obj)) {
+                info$slots <- slotNames(obj)
+              }
+              if (is.list(obj) &&
+                !is.null(dim(obj))) {
+                info$dim <- dim(obj)
+              }
+            }
+            info
+          })
+          names(objs) <- all_names
+          objs
+        }
+
+        dir_session <- file.path(tempdir, "vscode-R")
+        dir.create(dir_session, showWarnings = FALSE, recursive = TRUE)
+
+        removeTaskCallback("vsc.globalenv")
+        show_globalenv <- isTRUE(getOption("vsc.globalenv", TRUE))
+        if (show_globalenv) {
+          globalenv_file <- file.path(dir_session, "globalenv.json")
+          globalenv_lock_file <- file.path(dir_session, "globalenv.lock")
+          file.create(globalenv_lock_file, showWarnings = FALSE)
+
+          update_globalenv <- function(...) {
+            tryCatch({
+              objs <- inspect_env(.GlobalEnv)
+              jsonlite::write_json(objs, globalenv_file, pretty = FALSE)
+              cat(get_timestamp(), file = globalenv_lock_file)
+            }, error = message)
+            TRUE
+          }
+
+          update_globalenv()
+          addTaskCallback(update_globalenv, name = "vsc.globalenv")
+        }
+
+        removeTaskCallback("vsc.plot")
+        show_plot <- !identical(getOption("vsc.plot", "Two"), FALSE)
+        if (show_plot) {
+          dir_plot_history <- file.path(dir_session, "images")
+          dir.create(dir_plot_history, showWarnings = FALSE, recursive = TRUE)
+          plot_file <- file.path(dir_session, "plot.png")
+          plot_lock_file <- file.path(dir_session, "plot.lock")
+          file.create(plot_file, plot_lock_file, showWarnings = FALSE)
+
+          plot_history_file <- NULL
+          plot_updated <- FALSE
+          null_dev_id <- c(pdf = 2L)
+          null_dev_size <- c(7 + pi, 7 + pi)
+
+          check_null_dev <- function() {
+            identical(dev.cur(), null_dev_id) &&
+              identical(dev.size(), null_dev_size)
+          }
+
+          new_plot <- function() {
+            if (check_null_dev()) {
+              plot_history_file <<- file.path(dir_plot_history,
+                format(Sys.time(), "%Y%m%d-%H%M%OS6.png"))
+              plot_updated <<- TRUE
+            }
+          }
+
+          options(
+            device = function(...) {
+              pdf(NULL,
+                width = null_dev_size[[1L]],
+                height = null_dev_size[[2L]],
+                bg = "white")
+              dev.control(displaylist = "enable")
+            }
+          )
+
+          update_plot <- function(...) {
+            tryCatch({
+              if (plot_updated && check_null_dev()) {
+                plot_updated <<- FALSE
+                record <- recordPlot()
+                if (length(record[[1L]])) {
+                  dev_args <- getOption("vsc.dev.args")
+                  do.call(png, c(list(filename = plot_file), dev_args))
+                  on.exit({
+                    dev.off()
+                    cat(get_timestamp(), file = plot_lock_file)
+                    if (!is.null(plot_history_file)) {
+                      file.copy(plot_file, plot_history_file, overwrite = TRUE)
+                    }
+                  })
+                  replayPlot(record)
+                }
+              }
+            }, error = message)
+            TRUE
+          }
+
+          setHook("plot.new", new_plot, "replace")
+          setHook("grid.newpage", new_plot, "replace")
+
+          rebind(".External.graphics", function(...) {
+            out <- .Primitive(".External.graphics")(...)
+            if (check_null_dev()) {
+              plot_updated <<- TRUE
+            }
+            out
+          }, "base")
+
+          update_plot()
+          addTaskCallback(update_plot, name = "vsc.plot")
+        }
+
+        show_view <- !identical(getOption("vsc.view", "Two"), FALSE)
+        if (show_view) {
+          dataview_data_type <- function(x) {
+            if (is.numeric(x)) {
+              if (is.null(attr(x, "class"))) {
+                "num"
+              } else {
+                "num-fmt"
+              }
+            } else if (inherits(x, "Date")) {
+              "date"
+            } else {
+              "string"
+            }
+          }
+
+          dataview_table <- function(data) {
+            if (is.data.frame(data)) {
+              nrow <- nrow(data)
+              colnames <- colnames(data)
+              if (is.null(colnames)) {
+                colnames <- sprintf("(X%d)", seq_len(ncol(data)))
+              } else {
+                colnames <- trimws(colnames)
+              }
+              if (.row_names_info(data) > 0L) {
+                rownames <- rownames(data)
+                rownames(data) <- NULL
+              } else {
+                rownames <- seq_len(nrow)
+              }
+              data <- c(list(" " = rownames), .subset(data))
+              colnames <- c(" ", colnames)
+              types <- vapply(data, dataview_data_type,
+                character(1L), USE.NAMES = FALSE)
+              data <- vapply(data, function(x) {
+                trimws(format(x))
+              }, character(nrow), USE.NAMES = FALSE)
+              dim(data) <- c(length(rownames), length(colnames))
+            } else if (is.matrix(data)) {
+              if (is.factor(data)) {
+                data <- format(data)
+              }
+              types <- rep(dataview_data_type(data), ncol(data))
+              colnames <- colnames(data)
+              colnames(data) <- NULL
+              if (is.null(colnames)) {
+                colnames <- sprintf("(X%d)", seq_len(ncol(data)))
+              } else {
+                colnames <- trimws(colnames)
+              }
+              rownames <- rownames(data)
+              rownames(data) <- NULL
+              data <- trimws(format(data))
+              if (is.null(rownames)) {
+                types <- c("num", types)
+                rownames <- seq_len(nrow(data))
+              } else {
+                types <- c("string", types)
+                rownames <- trimws(rownames)
+              }
+              dim(data) <- c(length(rownames), length(colnames))
+              colnames <- c(" ", colnames)
+              data <- cbind(rownames, data)
+            } else {
+              stop("data must be data.frame or matrix")
+            }
+            columns <- .mapply(function(title, type) {
+              class <- if (type == "string") "text-left" else "text-right"
+              list(title = unbox(title),
+                className = unbox(class),
+                type = unbox(type))
+            }, list(colnames, types), NULL)
+            list(columns = columns, data = data)
+          }
+
+          show_dataview <- function(x, title,
+                                    viewer = getOption("vsc.view", "Two")) {
+            if (missing(title)) {
+              sub <- substitute(x)
+              title <- deparse(sub, nlines = 1)
+            }
+            if (is.environment(x)) {
+              x <- eapply(x, function(obj) {
+                data.frame(
+                  class = paste0(class(obj), collapse = ", "),
+                  type = typeof(obj),
+                  length = length(obj),
+                  size = as.integer(object.size(obj)),
+                  value = trimws(capture_str(obj)),
+                  stringsAsFactors = FALSE,
+                  check.names = FALSE
+                )
+              }, all.names = FALSE, USE.NAMES = TRUE)
+              if (length(x)) {
+                x <- do.call(rbind, x)
+              } else {
+                x <- data.frame(
+                  class = character(),
+                  type = character(),
+                  length = integer(),
+                  size = integer(),
+                  value = character(),
+                  stringsAsFactors = FALSE,
+                  check.names = FALSE
+                )
+              }
+            }
+            if (is.data.frame(x) || is.matrix(x)) {
+              data <- dataview_table(x)
+              file <- tempfile(tmpdir = tempdir, fileext = ".json")
+              jsonlite::write_json(data, file, matrix = "rowmajor")
+              request("dataview", source = "table", type = "json",
+                title = title, file = file, viewer = viewer)
+            } else if (is.list(x)) {
+              tryCatch({
+                file <- tempfile(tmpdir = tempdir, fileext = ".json")
+                jsonlite::write_json(x, file, auto_unbox = TRUE)
+                request("dataview", source = "list", type = "json",
+                  title = title, file = file, viewer = viewer)
+              }, error = function(e) {
+                file <- file.path(tempdir, paste0(make.names(title), ".txt"))
+                text <- utils::capture.output(print(x))
+                writeLines(text, file)
+                request("dataview", source = "object", type = "txt",
+                  title = title, file = file, viewer = viewer)
+              })
+            } else {
+              file <- file.path(tempdir, paste0(make.names(title), ".R"))
+              if (is.primitive(x)) {
+                code <- utils::capture.output(print(x))
+              } else {
+                code <- deparse(x)
+              }
+              writeLines(code, file)
+              request("dataview", source = "object", type = "R",
+                title = title, file = file, viewer = viewer)
+            }
+          }
+
+          rebind("View", show_dataview, "utils")
+        }
+
+        attach <- function() {
+          if (rstudioapi_enabled()) {
+            rstudioapi_util_env$update_addin_registry(addin_registry)
+          }
+          request("attach",
+            tempdir = tempdir,
+            plot = getOption("vsc.plot", "Two"))
+        }
+
+        path_to_uri <- function(path) {
+          if (length(path) == 0) {
+            return(character())
+          }
+          path <- path.expand(path)
+          if (.Platform$OS.type == "windows") {
+            prefix <- "file:///"
+            path <- gsub("\\", "/", path, fixed = TRUE)
+          } else {
+            prefix <- "file://"
+          }
+          paste0(prefix, utils::URLencode(path))
+        }
+
+        request_browser <- function(url, title, ..., viewer) {
+          # Printing URL with specific port triggers
+          # auto port-forwarding under remote development
+          message("Browsing ", url)
+          request("browser", url = url, title = title, ..., viewer = viewer)
+        }
+
+        show_browser <- function(url, title = url, ...,
+                                 viewer = getOption("vsc.browser", "Active")) {
+          if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
+            request_browser(url = url, title = title, ..., viewer = viewer)
+          } else if (grepl("^https?\\://", url)) {
+            message(
+              "VSCode WebView only supports showing local http content.\n",
+              "Opening in external browser..."
             )
-            if ((is.list(obj) ||
-              is.environment(obj)) &&
-              !is.null(names(obj))) {
-              info$names <- names(obj)
+            request_browser(url = url, title = title, ..., viewer = FALSE)
+          } else if (file.exists(url)) {
+            url <- normalizePath(url, "/", mustWork = TRUE)
+            if (grepl("\\.html?$", url, ignore.case = TRUE)) {
+              message(
+                "VSCode WebView has restricted access to local file.\n",
+                "Opening in external browser..."
+              )
+              request_browser(url = path_to_uri(url),
+                title = title, ..., viewer = FALSE)
+            } else {
+              request("dataview", source = "object", type = "txt",
+                title = title, file = url, viewer = viewer)
             }
-            if (isS4(obj)) {
-              info$slots <- slotNames(obj)
-            }
-            if (is.list(obj) &&
-              !is.null(dim(obj))) {
-              info$dim <- dim(obj)
-            }
+          } else {
+            stop("File not exists")
           }
-          info
-        })
-        names(objs) <- all_names
-        objs
-      }
-
-      dir_session <- file.path(tempdir, "vscode-R")
-      dir.create(dir_session, showWarnings = FALSE, recursive = TRUE)
-
-      removeTaskCallback("vsc.globalenv")
-      show_globalenv <- isTRUE(getOption("vsc.globalenv", TRUE))
-      if (show_globalenv) {
-        globalenv_file <- file.path(dir_session, "globalenv.json")
-        globalenv_lock_file <- file.path(dir_session, "globalenv.lock")
-        file.create(globalenv_lock_file, showWarnings = FALSE)
-
-        update_globalenv <- function(...) {
-          tryCatch({
-            objs <- inspect_env(.GlobalEnv)
-            jsonlite::write_json(objs, globalenv_file, pretty = FALSE)
-            cat(get_timestamp(), file = globalenv_lock_file)
-          }, error = message)
-          TRUE
         }
 
-        update_globalenv()
-        addTaskCallback(update_globalenv, name = "vsc.globalenv")
-      }
-
-      removeTaskCallback("vsc.plot")
-      show_plot <- !identical(getOption("vsc.plot", "Two"), FALSE)
-      if (show_plot) {
-        dir_plot_history <- file.path(dir_session, "images")
-        dir.create(dir_plot_history, showWarnings = FALSE, recursive = TRUE)
-        plot_file <- file.path(dir_session, "plot.png")
-        plot_lock_file <- file.path(dir_session, "plot.lock")
-        file.create(plot_file, plot_lock_file, showWarnings = FALSE)
-
-        plot_history_file <- NULL
-        plot_updated <- FALSE
-        null_dev_id <- c(pdf = 2L)
-        null_dev_size <- c(7 + pi, 7 + pi)
-
-        check_null_dev <- function() {
-          identical(dev.cur(), null_dev_id) &&
-            identical(dev.size(), null_dev_size)
+        show_webview <- function(url, title, ..., viewer) {
+          if (!is.character(url)) {
+            real_url <- NULL
+            temp_viewer <- function(url, ...) {
+              real_url <<- url
+            }
+            op <- options(viewer = temp_viewer, page_viewer = temp_viewer)
+            on.exit(options(op))
+            print(url)
+            if (is.character(real_url)) {
+              url <- real_url
+            } else {
+              stop("Invalid object")
+            }
+          }
+          if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
+            request_browser(url = url, title = title, ..., viewer = viewer)
+          } else if (grepl("^https?\\://", url)) {
+            message(
+              "VSCode WebView only supports showing local http content.\n",
+              "Opening in external browser..."
+            )
+            request_browser(url = url, title = title, ..., viewer = FALSE)
+          } else if (file.exists(url)) {
+            file <- normalizePath(url, "/", mustWork = TRUE)
+            request("webview", file = file, title = title, viewer = viewer, ...)
+          } else {
+            stop("File not exists")
+          }
         }
 
-        new_plot <- function() {
-          if (check_null_dev()) {
-            plot_history_file <<- file.path(dir_plot_history,
-              format(Sys.time(), "%Y%m%d-%H%M%OS6.png"))
-            plot_updated <<- TRUE
+        show_viewer <- function(url, title = NULL, ...,
+                                viewer = getOption("vsc.viewer", "Two")) {
+          if (is.null(title)) {
+            expr <- substitute(url)
+            if (is.character(url)) {
+              title <- "Viewer"
+            } else {
+              title <- deparse(expr, nlines = 1)
+            }
           }
+          show_webview(url = url, title = title, ..., viewer = viewer)
+        }
+
+        show_page_viewer <- function(url, title = NULL, ...,
+                                     viewer = getOption("vsc.page_viewer", "Active")) {
+          if (is.null(title)) {
+            expr <- substitute(url)
+            if (is.character(url)) {
+              title <- "Page Viewer"
+            } else {
+              title <- deparse(expr, nlines = 1)
+            }
+          }
+          show_webview(url = url, title = title, ..., viewer = viewer)
         }
 
         options(
-          device = function(...) {
-            pdf(NULL,
-              width = null_dev_size[[1L]],
-              height = null_dev_size[[2L]],
-              bg = "white")
-            dev.control(displaylist = "enable")
-          }
+          browser = show_browser,
+          viewer = show_viewer,
+          page_viewer = show_page_viewer
         )
 
-        update_plot <- function(...) {
-          tryCatch({
-            if (plot_updated && check_null_dev()) {
-              plot_updated <<- FALSE
-              record <- recordPlot()
-              if (length(record[[1L]])) {
-                dev_args <- getOption("vsc.dev.args")
-                do.call(png, c(list(filename = plot_file), dev_args))
-                on.exit({
-                  dev.off()
-                  cat(get_timestamp(), file = plot_lock_file)
-                  if (!is.null(plot_history_file)) {
-                    file.copy(plot_file, plot_history_file, overwrite = TRUE)
-                  }
-                })
-                replayPlot(record)
-              }
-            }
-          }, error = message)
-          TRUE
+        # rstudioapi
+        rstudioapi_enabled <- function() {
+          isTRUE(getOption("vsc.rstudioapi"))
         }
 
-        setHook("plot.new", new_plot, "replace")
-        setHook("grid.newpage", new_plot, "replace")
-
-        rebind(".External.graphics", function(...) {
-          out <- .Primitive(".External.graphics")(...)
-          if (check_null_dev()) {
-            plot_updated <<- TRUE
-          }
-          out
-        }, "base")
-
-        update_plot()
-        addTaskCallback(update_plot, name = "vsc.plot")
-      }
-
-      show_view <- !identical(getOption("vsc.view", "Two"), FALSE)
-      if (show_view) {
-        dataview_data_type <- function(x) {
-          if (is.numeric(x)) {
-            if (is.null(attr(x, "class"))) {
-              "num"
-            } else {
-              "num-fmt"
-            }
-          } else if (inherits(x, "Date")) {
-            "date"
-          } else {
-            "string"
-          }
-        }
-
-        dataview_table <- function(data) {
-          if (is.data.frame(data)) {
-            nrow <- nrow(data)
-            colnames <- colnames(data)
-            if (is.null(colnames)) {
-              colnames <- sprintf("(X%d)", seq_len(ncol(data)))
-            } else {
-              colnames <- trimws(colnames)
-            }
-            if (.row_names_info(data) > 0L) {
-              rownames <- rownames(data)
-              rownames(data) <- NULL
-            } else {
-              rownames <- seq_len(nrow)
-            }
-            data <- c(list(" " = rownames), .subset(data))
-            colnames <- c(" ", colnames)
-            types <- vapply(data, dataview_data_type,
-              character(1L), USE.NAMES = FALSE)
-            data <- vapply(data, function(x) {
-              trimws(format(x))
-            }, character(nrow), USE.NAMES = FALSE)
-            dim(data) <- c(length(rownames), length(colnames))
-          } else if (is.matrix(data)) {
-            if (is.factor(data)) {
-              data <- format(data)
-            }
-            types <- rep(dataview_data_type(data), ncol(data))
-            colnames <- colnames(data)
-            colnames(data) <- NULL
-            if (is.null(colnames)) {
-              colnames <- sprintf("(X%d)", seq_len(ncol(data)))
-            } else {
-              colnames <- trimws(colnames)
-            }
-            rownames <- rownames(data)
-            rownames(data) <- NULL
-            data <- trimws(format(data))
-            if (is.null(rownames)) {
-              types <- c("num", types)
-              rownames <- seq_len(nrow(data))
-            } else {
-              types <- c("string", types)
-              rownames <- trimws(rownames)
-            }
-            dim(data) <- c(length(rownames), length(colnames))
-            colnames <- c(" ", colnames)
-            data <- cbind(rownames, data)
-          } else {
-            stop("data must be data.frame or matrix")
-          }
-          columns <- .mapply(function(title, type) {
-            class <- if (type == "string") "text-left" else "text-right"
-            list(title = unbox(title),
-              className = unbox(class),
-              type = unbox(type))
-          }, list(colnames, types), NULL)
-          list(columns = columns, data = data)
-        }
-
-        show_dataview <- function(x, title,
-          viewer = getOption("vsc.view", "Two")) {
-          if (missing(title)) {
-            sub <- substitute(x)
-            title <- deparse(sub, nlines = 1)
-          }
-          if (is.environment(x)) {
-            x <- eapply(x, function(obj) {
-              data.frame(
-                class = paste0(class(obj), collapse = ", "),
-                type = typeof(obj),
-                length = length(obj),
-                size = as.integer(object.size(obj)),
-                value = trimws(capture_str(obj)),
-                stringsAsFactors = FALSE,
-                check.names = FALSE
-              )
-            }, all.names = FALSE, USE.NAMES = TRUE)
-            if (length(x)) {
-              x <- do.call(rbind, x)
-            } else {
-              x <- data.frame(
-                class = character(),
-                type = character(),
-                length = integer(),
-                size = integer(),
-                value = character(),
-                stringsAsFactors = FALSE,
-                check.names = FALSE
-              )
-            }
-          }
-          if (is.data.frame(x) || is.matrix(x)) {
-            data <- dataview_table(x)
-            file <- tempfile(tmpdir = tempdir, fileext = ".json")
-            jsonlite::write_json(data, file, matrix = "rowmajor")
-            request("dataview", source = "table", type = "json",
-              title = title, file = file, viewer = viewer)
-          } else if (is.list(x)) {
-            tryCatch({
-              file <- tempfile(tmpdir = tempdir, fileext = ".json")
-              jsonlite::write_json(x, file, auto_unbox = TRUE)
-              request("dataview", source = "list", type = "json",
-                title = title, file = file, viewer = viewer)
-            }, error = function(e) {
-              file <- file.path(tempdir, paste0(make.names(title), ".txt"))
-              text <- utils::capture.output(print(x))
-              writeLines(text, file)
-              request("dataview", source = "object", type = "txt",
-                title = title, file = file, viewer = viewer)
-            })
-          } else {
-            file <- file.path(tempdir, paste0(make.names(title), ".R"))
-            if (is.primitive(x)) {
-              code <- utils::capture.output(print(x))
-            } else {
-              code <- deparse(x)
-            }
-            writeLines(code, file)
-            request("dataview", source = "object", type = "R",
-              title = title, file = file, viewer = viewer)
-          }
-        }
-
-        rebind("View", show_dataview, "utils")
-      }
-
-      attach <- function() {
         if (rstudioapi_enabled()) {
-          rstudioapi_util_env$update_addin_registry(addin_registry)
-        }
-        request("attach",
-          tempdir = tempdir,
-          plot = getOption("vsc.plot", "Two"))
-      }
+          response_timeout <- 5
+          response_lock_file <- file.path(dir_session, "response.lock")
+          response_file <- file.path(dir_session, "response.log")
+          file.create(response_lock_file, showWarnings = FALSE)
+          file.create(response_file, showWarnings = FALSE)
+          addin_registry <- file.path(dir_session, "addins.json")
+          # This is created in attach()
 
-      path_to_uri <- function(path) {
-        if (length(path) == 0) {
-          return(character())
-        }
-        path <- path.expand(path)
-        if (.Platform$OS.type == "windows") {
-          prefix <- "file:///"
-          path <- gsub("\\", "/", path, fixed = TRUE)
-        } else {
-          prefix <- "file://"
-        }
-        paste0(prefix, utils::URLencode(path))
-      }
+          get_response_timestamp <- function() {
+            readLines(response_lock_file)
+          }
+          # initialise the reponse timestamp to empty string
+          response_time_stamp <- ""
 
-      request_browser <- function(url, title, ..., viewer) {
-        # Printing URL with specific port triggers
-        # auto port-forwarding under remote development
-        message("Browsing ", url)
-        request("browser", url = url, title = title, ..., viewer = viewer)
-      }
+          get_response_lock <- function() {
+            lock_time_stamp <- get_response_timestamp()
+            if (isTRUE(lock_time_stamp != response_time_stamp)) {
+              response_time_stamp <<- lock_time_stamp
+              TRUE
+            } else {
+              FALSE
+            }
+          }
 
-      show_browser <- function(url, title = url, ...,
-        viewer = getOption("vsc.browser", "Active")) {
-        if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
-          request_browser(url = url, title = title, ..., viewer = viewer)
-        } else if (grepl("^https?\\://", url)) {
-          message(
-            "VSCode WebView only supports showing local http content.\n",
-            "Opening in external browser..."
+          request_response <- function(command, ...) {
+            request(command, ..., sd = dir_session)
+            wait_start <- Sys.time()
+            while (!get_response_lock()) {
+              if ((Sys.time() - wait_start) > response_timeout) {
+                stop(
+                  "Did not receive a response from VSCode-R API within ",
+                  response_timeout, " seconds."
+                )
+              }
+              Sys.sleep(0.1)
+            }
+            jsonlite::read_json(response_file)
+          }
+
+          rstudioapi_util_env <- new.env()
+          rstudioapi_env <- new.env(parent = rstudioapi_util_env)
+          source(file.path(dir_extension, "rstudioapi_util.R"),
+            local = rstudioapi_util_env,
           )
-          request_browser(url = url, title = title, ..., viewer = FALSE)
-        } else if (file.exists(url)) {
-          url <- normalizePath(url, "/", mustWork = TRUE)
-          if (grepl("\\.html?$", url, ignore.case = TRUE)) {
-            message(
-              "VSCode WebView has restricted access to local file.\n",
-              "Opening in external browser..."
+          source(file.path(dir_extension, "rstudioapi.R"),
+            local = rstudioapi_env
+          )
+          setHook(
+            packageEvent("rstudioapi", "onLoad"),
+            function(...) {
+              rstudioapi_util_env$rstudioapi_patch_hook(rstudioapi_env)
+            }
+          )
+        }
+
+        print.help_files_with_topic <- function(h, ...) {
+          viewer <- getOption("vsc.helpPanel", "Two")
+          if (!identical(FALSE, viewer) && length(h) >= 1 && is.character(h)) {
+            file <- h[1]
+            path <- dirname(file)
+            dirpath <- dirname(path)
+            pkgname <- basename(dirpath)
+            requestPath <- paste0(
+              "/library/",
+              pkgname,
+              "/html/",
+              basename(file),
+              ".html"
             )
-            request_browser(url = path_to_uri(url),
-              title = title, ..., viewer = FALSE)
+            request(command = "help", requestPath = requestPath, viewer = viewer)
           } else {
-            request("dataview", source = "object", type = "txt",
-              title = title, file = url, viewer = viewer)
+            utils:::print.help_files_with_topic(h, ...)
           }
-        } else {
-          stop("File not exists")
-        }
-      }
-
-      show_webview <- function(url, title, ..., viewer) {
-        if (!is.character(url)) {
-          real_url <- NULL
-          temp_viewer <- function(url, ...) {
-            real_url <<- url
-          }
-          op <- options(viewer = temp_viewer, page_viewer = temp_viewer)
-          on.exit(options(op))
-          print(url)
-          if (is.character(real_url)) {
-            url <- real_url
-          } else {
-            stop("Invalid object")
-          }
-        }
-        if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
-          request_browser(url = url, title = title, ..., viewer = viewer)
-        } else if (grepl("^https?\\://", url)) {
-          message(
-            "VSCode WebView only supports showing local http content.\n",
-            "Opening in external browser..."
-          )
-          request_browser(url = url, title = title, ..., viewer = FALSE)
-        } else if (file.exists(url)) {
-          file <- normalizePath(url, "/", mustWork = TRUE)
-          request("webview", file = file, title = title, viewer = viewer, ...)
-        } else {
-          stop("File not exists")
-        }
-      }
-
-      show_viewer <- function(url, title = NULL, ...,
-        viewer = getOption("vsc.viewer", "Two")) {
-        if (is.null(title)) {
-          expr <- substitute(url)
-          if (is.character(url)) {
-            title <- "Viewer"
-          } else {
-            title <- deparse(expr, nlines = 1)
-          }
-        }
-        show_webview(url = url, title = title, ..., viewer = viewer)
-      }
-
-      show_page_viewer <- function(url, title = NULL, ...,
-        viewer = getOption("vsc.page_viewer", "Active")) {
-        if (is.null(title)) {
-          expr <- substitute(url)
-          if (is.character(url)) {
-            title <- "Page Viewer"
-          } else {
-            title <- deparse(expr, nlines = 1)
-          }
-        }
-        show_webview(url = url, title = title, ..., viewer = viewer)
-      }
-
-      options(
-        browser = show_browser,
-        viewer = show_viewer,
-        page_viewer = show_page_viewer
-      )
-
-      # rstudioapi
-      rstudioapi_enabled <- function() {
-        isTRUE(getOption("vsc.rstudioapi"))
-      }
-
-      if (rstudioapi_enabled()) {
-        response_timeout <- 5
-        response_lock_file <- file.path(dir_session, "response.lock")
-        response_file <- file.path(dir_session, "response.log")
-        file.create(response_lock_file, showWarnings = FALSE)
-        file.create(response_file, showWarnings = FALSE)
-        addin_registry <- file.path(dir_session, "addins.json")
-        # This is created in attach()
-
-        get_response_timestamp <- function() {
-          readLines(response_lock_file)
-        }
-        # initialise the reponse timestamp to empty string
-        response_time_stamp <- ""
-
-        get_response_lock <- function() {
-          lock_time_stamp <- get_response_timestamp()
-          if (isTRUE(lock_time_stamp != response_time_stamp)) {
-            response_time_stamp <<- lock_time_stamp
-            TRUE
-          } else {
-            FALSE
-          }
+          invisible(h)
         }
 
-        request_response <- function(command, ...) {
-          request(command, ..., sd = dir_session)
-          wait_start <- Sys.time()
-          while (!get_response_lock()) {
-            if ((Sys.time() - wait_start) > response_timeout) {
-              stop(
-                "Did not receive a response from VSCode-R API within ",
-                response_timeout, " seconds."
-              )
-            }
-            Sys.sleep(0.1)
-          }
-          jsonlite::read_json(response_file)
-        }
-
-        rstudioapi_util_env <- new.env()
-        rstudioapi_env <- new.env(parent = rstudioapi_util_env)
-        source(file.path(dir_extension, "rstudioapi_util.R"),
-          local = rstudioapi_util_env,
-        )
-        source(file.path(dir_extension, "rstudioapi.R"),
-          local = rstudioapi_env
-        )
-        setHook(
-          packageEvent("rstudioapi", "onLoad"),
-          function(...) {
-            rstudioapi_util_env$rstudioapi_patch_hook(rstudioapi_env)
-          }
-        )
-      }
-
-      print.help_files_with_topic <- function(h, ...) {
-        viewer <- getOption("vsc.helpPanel", "Two")
-        if (!identical(FALSE, viewer) && length(h) >= 1 && is.character(h)) {
-          file <- h[1]
-          path <- dirname(file)
-          dirpath <- dirname(path)
-          pkgname <- basename(dirpath)
-          requestPath <- paste0(
-            "/library/",
-            pkgname,
-            "/html/",
-            basename(file),
-            ".html"
-          )
-          request(command = "help", requestPath = requestPath, viewer = viewer)
-        } else{
-          utils:::print.help_files_with_topic(h, ...)
-        }
-        invisible(h)
-      }
-
-      print.hsearch <- function(x, ...) {
-        viewer <- getOption("vsc.helpPanel", "Two")
-        if (!identical(FALSE, viewer) && length(x) >= 1) {
-          requestPath <- paste0(
-            "/doc/html/Search?pattern=",
-            tools:::escapeAmpersand(x$pattern),
-            paste0("&fields.", x$fields, "=1",
-              collapse = ""
-            ),
-            if (!is.null(x$agrep)) paste0("&agrep=", x$agrep),
-            if (!x$ignore.case) "&ignore.case=0",
-            if (!identical(
-              x$types,
-              getOption("help.search.types")
-            )) {
-              paste0("&types.", x$types, "=1",
+        print.hsearch <- function(x, ...) {
+          viewer <- getOption("vsc.helpPanel", "Two")
+          if (!identical(FALSE, viewer) && length(x) >= 1) {
+            requestPath <- paste0(
+              "/doc/html/Search?pattern=",
+              tools:::escapeAmpersand(x$pattern),
+              paste0("&fields.", x$fields, "=1",
                 collapse = ""
-              )
-            },
-            if (!is.null(x$package)) {
-              paste0(
-                "&package=",
-                paste(x$package, collapse = ";")
-              )
-            },
-            if (!identical(x$lib.loc, .libPaths())) {
-              paste0(
-                "&lib.loc=",
-                paste(x$lib.loc, collapse = ";")
-              )
-            }
-          )
-          request(command = "help", requestPath = requestPath, viewer = viewer)
-        } else{
-          utils:::print.hsearch(x, ...)
-        }
-        invisible(x)
-      }
-
-      environment()
-    })
-
-    if (!identical(getOption("vsc.helpPanel", "Two"), FALSE)) {
-      .First.sys <- function() {
-        # first load utils in order to overwrite its print method for help files
-        base::.First.sys()
-
-        # a copy of .S3method(), since this function is new in R 4.0
-        .S3method <- function(generic, class, method) {
-          if (missing(method)) {
-            method <- paste(generic, class, sep = ".")
+              ),
+              if (!is.null(x$agrep)) paste0("&agrep=", x$agrep),
+              if (!x$ignore.case) "&ignore.case=0",
+              if (!identical(
+                x$types,
+                getOption("help.search.types")
+              )) {
+                paste0("&types.", x$types, "=1",
+                  collapse = ""
+                )
+              },
+              if (!is.null(x$package)) {
+                paste0(
+                  "&package=",
+                  paste(x$package, collapse = ";")
+                )
+              },
+              if (!identical(x$lib.loc, .libPaths())) {
+                paste0(
+                  "&lib.loc=",
+                  paste(x$lib.loc, collapse = ";")
+                )
+              }
+            )
+            request(command = "help", requestPath = requestPath, viewer = viewer)
+          } else {
+            utils:::print.hsearch(x, ...)
           }
-          method <- match.fun(method)
-          registerS3method(generic, class, method, envir = parent.frame())
-          invisible(NULL)
+          invisible(x)
         }
 
-        suppressWarnings({
-          .S3method(
-            "print",
-            "help_files_with_topic",
-            .vsc$print.help_files_with_topic
-          )
-          .S3method(
-            "print",
-            "hsearch",
-            .vsc$print.hsearch
-          )
-        })
+        environment()
+      })
 
-        rm(".First.sys", envir = parent.env(environment()))
+      if (!identical(getOption("vsc.helpPanel", "Two"), FALSE)) {
+        .First.sys <- function() {
+          # first load utils in order to overwrite its print method for help files
+          base::.First.sys()
+
+          # a copy of .S3method(), since this function is new in R 4.0
+          .S3method <- function(generic, class, method) {
+            if (missing(method)) {
+              method <- paste(generic, class, sep = ".")
+            }
+            method <- match.fun(method)
+            registerS3method(generic, class, method, envir = parent.frame())
+            invisible(NULL)
+          }
+
+          suppressWarnings({
+            .S3method(
+              "print",
+              "help_files_with_topic",
+              .vsc$print.help_files_with_topic
+            )
+            .S3method(
+              "print",
+              "hsearch",
+              .vsc$print.hsearch
+            )
+          })
+
+          rm(".First.sys", envir = parent.env(environment()))
+        }
       }
-    }
 
-    .vsc.attach <- .vsc$attach
-    .vsc.view <- .vsc$show_dataview
-    .vsc.browser <- .vsc$show_browser
-    .vsc.viewer <- .vsc$show_viewer
-    .vsc.page_viewer <- .vsc$show_page_viewer
+      .vsc.attach <- .vsc$attach
+      .vsc.view <- .vsc$show_dataview
+      .vsc.browser <- .vsc$show_browser
+      .vsc.viewer <- .vsc$show_viewer
+      .vsc.page_viewer <- .vsc$show_page_viewer
 
-    attach(environment(), name = .vsc.name, warn.conflicts = FALSE)
+      attach(environment(), name = .vsc.name, warn.conflicts = FALSE)
 
-    .vsc.attach()
-  }) else {
-    message(
-      "VSCode R Session Watcher requires jsonlite.\n",
-      "Please install it with install.packages(\"jsonlite\")."
-    )
+      .vsc.attach()
+    })
   }
-}
+})

--- a/R/init.R
+++ b/R/init.R
@@ -1,7 +1,6 @@
-local({
-  if (interactive() &&
+if (interactive() &&
     Sys.getenv("RSTUDIO") == "" &&
-    Sys.getenv("TERM_PROGRAM") == "vscode") {
+    Sys.getenv("TERM_PROGRAM") == "vscode") local({
 
     required_packages <- c("jsonlite", "rlang")
     missing_packages <- required_packages[
@@ -684,5 +683,5 @@ local({
 
       .vsc.attach()
     })
-  }
-})
+  })
+  

--- a/R/init.R
+++ b/R/init.R
@@ -1,687 +1,686 @@
 if (interactive() &&
-    Sys.getenv("RSTUDIO") == "" &&
-    Sys.getenv("TERM_PROGRAM") == "vscode") local({
+  Sys.getenv("RSTUDIO") == "" &&
+  Sys.getenv("TERM_PROGRAM") == "vscode") local({
 
-    required_packages <- c("jsonlite", "rlang")
-    missing_packages <- required_packages[
-      !vapply(required_packages, requireNamespace,
-        logical(1L), quietly = TRUE)
-    ]
+  required_packages <- c("jsonlite", "rlang")
+  missing_packages <- required_packages[
+    !vapply(required_packages, requireNamespace,
+      logical(1L), quietly = TRUE)
+  ]
 
-    if (length(missing_packages)) {
-      message(
-        "VSCode R Session Watcher requires ",
-        toString(missing_packages), ". ",
-        "Please install manually in order to use VSCode-R."
+  if (length(missing_packages)) {
+    message(
+      "VSCode R Session Watcher requires ",
+      toString(missing_packages), ". ",
+      "Please install manually in order to use VSCode-R."
+    )
+  } else local({
+    # cleanup previous version
+    removeTaskCallback("vscode-R")
+    options(vscodeR = NULL)
+
+    .vsc.name <- "tools:vscode"
+    if (.vsc.name %in% search()) {
+      detach(.vsc.name, character.only = TRUE)
+    }
+
+    .vsc <- local({
+      pid <- Sys.getpid()
+      wd <- getwd()
+      tempdir <- tempdir()
+      homedir <- Sys.getenv(
+        if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"
       )
-    } else local({
-       # cleanup previous version
-      removeTaskCallback("vscode-R")
-      options(vscodeR = NULL)
+      dir_extension <- file.path(homedir, ".vscode-R")
+      request_file <- file.path(dir_extension, "request.log")
+      request_lock_file <- file.path(dir_extension, "request.lock")
 
-      .vsc.name <- "tools:vscode"
-      if (.vsc.name %in% search()) {
-        detach(.vsc.name, character.only = TRUE)
+      if (is.null(getOption("help_type"))) {
+        options(help_type = "html")
       }
 
-      .vsc <- local({
-        pid <- Sys.getpid()
-        wd <- getwd()
-        tempdir <- tempdir()
-        homedir <- Sys.getenv(
-          if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"
+      get_timestamp <- function() {
+        format.default(Sys.time(), nsmall = 6)
+      }
+
+      unbox <- jsonlite::unbox
+
+      request <- function(command, ...) {
+        obj <- list(
+          time = Sys.time(),
+          pid = pid,
+          wd = wd,
+          command = command,
+          ...
         )
-        dir_extension <- file.path(homedir, ".vscode-R")
-        request_file <- file.path(dir_extension, "request.log")
-        request_lock_file <- file.path(dir_extension, "request.lock")
+        jsonlite::write_json(obj, request_file,
+          auto_unbox = TRUE, null = "null", force = TRUE)
+        cat(get_timestamp(), file = request_lock_file)
+      }
 
-        if (is.null(getOption("help_type"))) {
-          options(help_type = "html")
+      capture_str <- function(object) {
+        utils::capture.output(
+          utils::str(object, max.level = 0, give.attr = FALSE)
+        )
+      }
+
+      rebind <- function(sym, value, ns) {
+        if (is.character(ns)) {
+          Recall(sym, value, getNamespace(ns))
+          pkg <- paste0("package:", ns)
+          if (pkg %in% search()) {
+            Recall(sym, value, as.environment(pkg))
+          }
+        } else if (is.environment(ns)) {
+          if (bindingIsLocked(sym, ns)) {
+            unlockBinding(sym, ns)
+            on.exit(lockBinding(sym, ns))
+          }
+          assign(sym, value, ns)
+        } else {
+          stop("ns must be a string or environment")
         }
+      }
 
-        get_timestamp <- function() {
-          format.default(Sys.time(), nsmall = 6)
-        }
-
-        unbox <- jsonlite::unbox
-
-        request <- function(command, ...) {
-          obj <- list(
-            time = Sys.time(),
-            pid = pid,
-            wd = wd,
-            command = command,
-            ...
-          )
-          jsonlite::write_json(obj, request_file,
-            auto_unbox = TRUE, null = "null", force = TRUE)
-          cat(get_timestamp(), file = request_lock_file)
-        }
-
-        capture_str <- function(object) {
-          utils::capture.output(
-            utils::str(object, max.level = 0, give.attr = FALSE)
-          )
-        }
-
-        rebind <- function(sym, value, ns) {
-          if (is.character(ns)) {
-            Recall(sym, value, getNamespace(ns))
-            pkg <- paste0("package:", ns)
-            if (pkg %in% search()) {
-              Recall(sym, value, as.environment(pkg))
-            }
-          } else if (is.environment(ns)) {
-            if (bindingIsLocked(sym, ns)) {
-              unlockBinding(sym, ns)
-              on.exit(lockBinding(sym, ns))
-            }
-            assign(sym, value, ns)
+      inspect_env <- function(env) {
+        all_names <- ls(env)
+        is_promise <- rlang::env_binding_are_lazy(env, all_names)
+        is_active <- rlang::env_binding_are_active(env, all_names)
+        objs <- lapply(all_names, function(name) {
+          if (is_promise[[name]]) {
+            info <- list(
+              class = "promise",
+              type = unbox("promise"),
+              length = unbox(0L),
+              str = unbox("(promise)")
+            )
+          } else if (is_active[[name]]) {
+            info <- list(
+              class = "active_binding",
+              type = unbox("active_binding"),
+              length = unbox(0L),
+              str = unbox("(active-binding)")
+            )
           } else {
-            stop("ns must be a string or environment")
+            obj <- env[[name]]
+            str <- capture_str(obj)[[1L]]
+            info <- list(
+              class = class(obj),
+              type = unbox(typeof(obj)),
+              length = unbox(length(obj)),
+              str = unbox(trimws(str))
+            )
+            if ((is.list(obj) ||
+              is.environment(obj)) &&
+              !is.null(names(obj))) {
+              info$names <- names(obj)
+            }
+            if (isS4(obj)) {
+              info$slots <- slotNames(obj)
+            }
+            if (is.list(obj) &&
+              !is.null(dim(obj))) {
+              info$dim <- dim(obj)
+            }
+          }
+          info
+        })
+        names(objs) <- all_names
+        objs
+      }
+
+      dir_session <- file.path(tempdir, "vscode-R")
+      dir.create(dir_session, showWarnings = FALSE, recursive = TRUE)
+
+      removeTaskCallback("vsc.globalenv")
+      show_globalenv <- isTRUE(getOption("vsc.globalenv", TRUE))
+      if (show_globalenv) {
+        globalenv_file <- file.path(dir_session, "globalenv.json")
+        globalenv_lock_file <- file.path(dir_session, "globalenv.lock")
+        file.create(globalenv_lock_file, showWarnings = FALSE)
+
+        update_globalenv <- function(...) {
+          tryCatch({
+            objs <- inspect_env(.GlobalEnv)
+            jsonlite::write_json(objs, globalenv_file, pretty = FALSE)
+            cat(get_timestamp(), file = globalenv_lock_file)
+          }, error = message)
+          TRUE
+        }
+
+        update_globalenv()
+        addTaskCallback(update_globalenv, name = "vsc.globalenv")
+      }
+
+      removeTaskCallback("vsc.plot")
+      show_plot <- !identical(getOption("vsc.plot", "Two"), FALSE)
+      if (show_plot) {
+        dir_plot_history <- file.path(dir_session, "images")
+        dir.create(dir_plot_history, showWarnings = FALSE, recursive = TRUE)
+        plot_file <- file.path(dir_session, "plot.png")
+        plot_lock_file <- file.path(dir_session, "plot.lock")
+        file.create(plot_file, plot_lock_file, showWarnings = FALSE)
+
+        plot_history_file <- NULL
+        plot_updated <- FALSE
+        null_dev_id <- c(pdf = 2L)
+        null_dev_size <- c(7 + pi, 7 + pi)
+
+        check_null_dev <- function() {
+          identical(dev.cur(), null_dev_id) &&
+            identical(dev.size(), null_dev_size)
+        }
+
+        new_plot <- function() {
+          if (check_null_dev()) {
+            plot_history_file <<- file.path(dir_plot_history,
+              format(Sys.time(), "%Y%m%d-%H%M%OS6.png"))
+            plot_updated <<- TRUE
           }
         }
 
-        inspect_env <- function(env) {
-          all_names <- ls(env)
-          is_promise <- rlang::env_binding_are_lazy(env, all_names)
-          is_active <- rlang::env_binding_are_active(env, all_names)
-          objs <- lapply(all_names, function(name) {
-            if (is_promise[[name]]) {
-              info <- list(
-                class = "promise",
-                type = unbox("promise"),
-                length = unbox(0L),
-                str = unbox("(promise)")
-              )
-            } else if (is_active[[name]]) {
-              info <- list(
-                class = "active_binding",
-                type = unbox("active_binding"),
-                length = unbox(0L),
-                str = unbox("(active-binding)")
-              )
+        options(
+          device = function(...) {
+            pdf(NULL,
+              width = null_dev_size[[1L]],
+              height = null_dev_size[[2L]],
+              bg = "white")
+            dev.control(displaylist = "enable")
+          }
+        )
+
+        update_plot <- function(...) {
+          tryCatch({
+            if (plot_updated && check_null_dev()) {
+              plot_updated <<- FALSE
+              record <- recordPlot()
+              if (length(record[[1L]])) {
+                dev_args <- getOption("vsc.dev.args")
+                do.call(png, c(list(filename = plot_file), dev_args))
+                on.exit({
+                  dev.off()
+                  cat(get_timestamp(), file = plot_lock_file)
+                  if (!is.null(plot_history_file)) {
+                    file.copy(plot_file, plot_history_file, overwrite = TRUE)
+                  }
+                })
+                replayPlot(record)
+              }
+            }
+          }, error = message)
+          TRUE
+        }
+
+        setHook("plot.new", new_plot, "replace")
+        setHook("grid.newpage", new_plot, "replace")
+
+        rebind(".External.graphics", function(...) {
+          out <- .Primitive(".External.graphics")(...)
+          if (check_null_dev()) {
+            plot_updated <<- TRUE
+          }
+          out
+        }, "base")
+
+        update_plot()
+        addTaskCallback(update_plot, name = "vsc.plot")
+      }
+
+      show_view <- !identical(getOption("vsc.view", "Two"), FALSE)
+      if (show_view) {
+        dataview_data_type <- function(x) {
+          if (is.numeric(x)) {
+            if (is.null(attr(x, "class"))) {
+              "num"
             } else {
-              obj <- env[[name]]
-              str <- capture_str(obj)[[1L]]
-              info <- list(
-                class = class(obj),
-                type = unbox(typeof(obj)),
-                length = unbox(length(obj)),
-                str = unbox(trimws(str))
-              )
-              if ((is.list(obj) ||
-                is.environment(obj)) &&
-                !is.null(names(obj))) {
-                info$names <- names(obj)
-              }
-              if (isS4(obj)) {
-                info$slots <- slotNames(obj)
-              }
-              if (is.list(obj) &&
-                !is.null(dim(obj))) {
-                info$dim <- dim(obj)
-              }
+              "num-fmt"
             }
-            info
-          })
-          names(objs) <- all_names
-          objs
+          } else if (inherits(x, "Date")) {
+            "date"
+          } else {
+            "string"
+          }
         }
 
-        dir_session <- file.path(tempdir, "vscode-R")
-        dir.create(dir_session, showWarnings = FALSE, recursive = TRUE)
-
-        removeTaskCallback("vsc.globalenv")
-        show_globalenv <- isTRUE(getOption("vsc.globalenv", TRUE))
-        if (show_globalenv) {
-          globalenv_file <- file.path(dir_session, "globalenv.json")
-          globalenv_lock_file <- file.path(dir_session, "globalenv.lock")
-          file.create(globalenv_lock_file, showWarnings = FALSE)
-
-          update_globalenv <- function(...) {
-            tryCatch({
-              objs <- inspect_env(.GlobalEnv)
-              jsonlite::write_json(objs, globalenv_file, pretty = FALSE)
-              cat(get_timestamp(), file = globalenv_lock_file)
-            }, error = message)
-            TRUE
-          }
-
-          update_globalenv()
-          addTaskCallback(update_globalenv, name = "vsc.globalenv")
-        }
-
-        removeTaskCallback("vsc.plot")
-        show_plot <- !identical(getOption("vsc.plot", "Two"), FALSE)
-        if (show_plot) {
-          dir_plot_history <- file.path(dir_session, "images")
-          dir.create(dir_plot_history, showWarnings = FALSE, recursive = TRUE)
-          plot_file <- file.path(dir_session, "plot.png")
-          plot_lock_file <- file.path(dir_session, "plot.lock")
-          file.create(plot_file, plot_lock_file, showWarnings = FALSE)
-
-          plot_history_file <- NULL
-          plot_updated <- FALSE
-          null_dev_id <- c(pdf = 2L)
-          null_dev_size <- c(7 + pi, 7 + pi)
-
-          check_null_dev <- function() {
-            identical(dev.cur(), null_dev_id) &&
-              identical(dev.size(), null_dev_size)
-          }
-
-          new_plot <- function() {
-            if (check_null_dev()) {
-              plot_history_file <<- file.path(dir_plot_history,
-                format(Sys.time(), "%Y%m%d-%H%M%OS6.png"))
-              plot_updated <<- TRUE
-            }
-          }
-
-          options(
-            device = function(...) {
-              pdf(NULL,
-                width = null_dev_size[[1L]],
-                height = null_dev_size[[2L]],
-                bg = "white")
-              dev.control(displaylist = "enable")
-            }
-          )
-
-          update_plot <- function(...) {
-            tryCatch({
-              if (plot_updated && check_null_dev()) {
-                plot_updated <<- FALSE
-                record <- recordPlot()
-                if (length(record[[1L]])) {
-                  dev_args <- getOption("vsc.dev.args")
-                  do.call(png, c(list(filename = plot_file), dev_args))
-                  on.exit({
-                    dev.off()
-                    cat(get_timestamp(), file = plot_lock_file)
-                    if (!is.null(plot_history_file)) {
-                      file.copy(plot_file, plot_history_file, overwrite = TRUE)
-                    }
-                  })
-                  replayPlot(record)
-                }
-              }
-            }, error = message)
-            TRUE
-          }
-
-          setHook("plot.new", new_plot, "replace")
-          setHook("grid.newpage", new_plot, "replace")
-
-          rebind(".External.graphics", function(...) {
-            out <- .Primitive(".External.graphics")(...)
-            if (check_null_dev()) {
-              plot_updated <<- TRUE
-            }
-            out
-          }, "base")
-
-          update_plot()
-          addTaskCallback(update_plot, name = "vsc.plot")
-        }
-
-        show_view <- !identical(getOption("vsc.view", "Two"), FALSE)
-        if (show_view) {
-          dataview_data_type <- function(x) {
-            if (is.numeric(x)) {
-              if (is.null(attr(x, "class"))) {
-                "num"
-              } else {
-                "num-fmt"
-              }
-            } else if (inherits(x, "Date")) {
-              "date"
+        dataview_table <- function(data) {
+          if (is.data.frame(data)) {
+            nrow <- nrow(data)
+            colnames <- colnames(data)
+            if (is.null(colnames)) {
+              colnames <- sprintf("(X%d)", seq_len(ncol(data)))
             } else {
-              "string"
+              colnames <- trimws(colnames)
             }
-          }
-
-          dataview_table <- function(data) {
-            if (is.data.frame(data)) {
-              nrow <- nrow(data)
-              colnames <- colnames(data)
-              if (is.null(colnames)) {
-                colnames <- sprintf("(X%d)", seq_len(ncol(data)))
-              } else {
-                colnames <- trimws(colnames)
-              }
-              if (.row_names_info(data) > 0L) {
-                rownames <- rownames(data)
-                rownames(data) <- NULL
-              } else {
-                rownames <- seq_len(nrow)
-              }
-              data <- c(list(" " = rownames), .subset(data))
-              colnames <- c(" ", colnames)
-              types <- vapply(data, dataview_data_type,
-                character(1L), USE.NAMES = FALSE)
-              data <- vapply(data, function(x) {
-                trimws(format(x))
-              }, character(nrow), USE.NAMES = FALSE)
-              dim(data) <- c(length(rownames), length(colnames))
-            } else if (is.matrix(data)) {
-              if (is.factor(data)) {
-                data <- format(data)
-              }
-              types <- rep(dataview_data_type(data), ncol(data))
-              colnames <- colnames(data)
-              colnames(data) <- NULL
-              if (is.null(colnames)) {
-                colnames <- sprintf("(X%d)", seq_len(ncol(data)))
-              } else {
-                colnames <- trimws(colnames)
-              }
+            if (.row_names_info(data) > 0L) {
               rownames <- rownames(data)
               rownames(data) <- NULL
-              data <- trimws(format(data))
-              if (is.null(rownames)) {
-                types <- c("num", types)
-                rownames <- seq_len(nrow(data))
-              } else {
-                types <- c("string", types)
-                rownames <- trimws(rownames)
-              }
-              dim(data) <- c(length(rownames), length(colnames))
-              colnames <- c(" ", colnames)
-              data <- cbind(rownames, data)
             } else {
-              stop("data must be data.frame or matrix")
+              rownames <- seq_len(nrow)
             }
-            columns <- .mapply(function(title, type) {
-              class <- if (type == "string") "text-left" else "text-right"
-              list(title = unbox(title),
-                className = unbox(class),
-                type = unbox(type))
-            }, list(colnames, types), NULL)
-            list(columns = columns, data = data)
+            data <- c(list(" " = rownames), .subset(data))
+            colnames <- c(" ", colnames)
+            types <- vapply(data, dataview_data_type,
+              character(1L), USE.NAMES = FALSE)
+            data <- vapply(data, function(x) {
+              trimws(format(x))
+            }, character(nrow), USE.NAMES = FALSE)
+            dim(data) <- c(length(rownames), length(colnames))
+          } else if (is.matrix(data)) {
+            if (is.factor(data)) {
+              data <- format(data)
+            }
+            types <- rep(dataview_data_type(data), ncol(data))
+            colnames <- colnames(data)
+            colnames(data) <- NULL
+            if (is.null(colnames)) {
+              colnames <- sprintf("(X%d)", seq_len(ncol(data)))
+            } else {
+              colnames <- trimws(colnames)
+            }
+            rownames <- rownames(data)
+            rownames(data) <- NULL
+            data <- trimws(format(data))
+            if (is.null(rownames)) {
+              types <- c("num", types)
+              rownames <- seq_len(nrow(data))
+            } else {
+              types <- c("string", types)
+              rownames <- trimws(rownames)
+            }
+            dim(data) <- c(length(rownames), length(colnames))
+            colnames <- c(" ", colnames)
+            data <- cbind(rownames, data)
+          } else {
+            stop("data must be data.frame or matrix")
           }
+          columns <- .mapply(function(title, type) {
+            class <- if (type == "string") "text-left" else "text-right"
+            list(title = unbox(title),
+              className = unbox(class),
+              type = unbox(type))
+          }, list(colnames, types), NULL)
+          list(columns = columns, data = data)
+        }
 
-          show_dataview <- function(x, title,
-                                    viewer = getOption("vsc.view", "Two")) {
-            if (missing(title)) {
-              sub <- substitute(x)
-              title <- deparse(sub, nlines = 1)
-            }
-            if (is.environment(x)) {
-              all_names <- ls(x)
-              is_promise <- rlang::env_binding_are_lazy(x, all_names)
-              is_active <- rlang::env_binding_are_active(x, all_names)
-              x <- lapply(all_names, function(name) {
-                if (is_promise[[name]]) {
-                  data.frame(
-                    class = "promise",
-                    type = "promise",
-                    length = 0L,
-                    size = 0L,
-                    value = "(promise)",
-                    stringsAsFactors = FALSE,
-                    check.names = FALSE
-                  )
-                } else if (is_active[[name]]) {
-                  data.frame(
-                    class = "active_binding",
-                    type = "active_binding",
-                    length = 0L,
-                    size = 0L,
-                    value = "(active-binding)",
-                    stringsAsFactors = FALSE,
-                    check.names = FALSE
-                  )
-                } else {
-                  obj <- x[[name]]
-                  data.frame(
-                    class = paste0(class(obj), collapse = ", "),
-                    type = typeof(obj),
-                    length = length(obj),
-                    size = as.integer(object.size(obj)),
-                    value = trimws(capture_str(obj)),
-                    stringsAsFactors = FALSE,
-                    check.names = FALSE
-                  )
-                }
-              })
-              names(x) <- all_names
-              if (length(x)) {
-                x <- do.call(rbind, x)
+        show_dataview <- function(x, title,
+                                  viewer = getOption("vsc.view", "Two")) {
+          if (missing(title)) {
+            sub <- substitute(x)
+            title <- deparse(sub, nlines = 1)
+          }
+          if (is.environment(x)) {
+            all_names <- ls(x)
+            is_promise <- rlang::env_binding_are_lazy(x, all_names)
+            is_active <- rlang::env_binding_are_active(x, all_names)
+            x <- lapply(all_names, function(name) {
+              if (is_promise[[name]]) {
+                data.frame(
+                  class = "promise",
+                  type = "promise",
+                  length = 0L,
+                  size = 0L,
+                  value = "(promise)",
+                  stringsAsFactors = FALSE,
+                  check.names = FALSE
+                )
+              } else if (is_active[[name]]) {
+                data.frame(
+                  class = "active_binding",
+                  type = "active_binding",
+                  length = 0L,
+                  size = 0L,
+                  value = "(active-binding)",
+                  stringsAsFactors = FALSE,
+                  check.names = FALSE
+                )
               } else {
-                x <- data.frame(
-                  class = character(),
-                  type = character(),
-                  length = integer(),
-                  size = integer(),
-                  value = character(),
+                obj <- x[[name]]
+                data.frame(
+                  class = paste0(class(obj), collapse = ", "),
+                  type = typeof(obj),
+                  length = length(obj),
+                  size = as.integer(object.size(obj)),
+                  value = trimws(capture_str(obj)),
                   stringsAsFactors = FALSE,
                   check.names = FALSE
                 )
               }
-            }
-            if (is.data.frame(x) || is.matrix(x)) {
-              data <- dataview_table(x)
-              file <- tempfile(tmpdir = tempdir, fileext = ".json")
-              jsonlite::write_json(data, file, matrix = "rowmajor")
-              request("dataview", source = "table", type = "json",
-                title = title, file = file, viewer = viewer)
-            } else if (is.list(x)) {
-              tryCatch({
-                file <- tempfile(tmpdir = tempdir, fileext = ".json")
-                jsonlite::write_json(x, file, auto_unbox = TRUE)
-                request("dataview", source = "list", type = "json",
-                  title = title, file = file, viewer = viewer)
-              }, error = function(e) {
-                file <- file.path(tempdir, paste0(make.names(title), ".txt"))
-                text <- utils::capture.output(print(x))
-                writeLines(text, file)
-                request("dataview", source = "object", type = "txt",
-                  title = title, file = file, viewer = viewer)
-              })
+            })
+            names(x) <- all_names
+            if (length(x)) {
+              x <- do.call(rbind, x)
             } else {
-              file <- file.path(tempdir, paste0(make.names(title), ".R"))
-              if (is.primitive(x)) {
-                code <- utils::capture.output(print(x))
-              } else {
-                code <- deparse(x)
-              }
-              writeLines(code, file)
-              request("dataview", source = "object", type = "R",
-                title = title, file = file, viewer = viewer)
-            }
-          }
-
-          rebind("View", show_dataview, "utils")
-        }
-
-        attach <- function() {
-          if (rstudioapi_enabled()) {
-            rstudioapi_util_env$update_addin_registry(addin_registry)
-          }
-          request("attach",
-            tempdir = tempdir,
-            plot = getOption("vsc.plot", "Two"))
-        }
-
-        path_to_uri <- function(path) {
-          if (length(path) == 0) {
-            return(character())
-          }
-          path <- path.expand(path)
-          if (.Platform$OS.type == "windows") {
-            prefix <- "file:///"
-            path <- gsub("\\", "/", path, fixed = TRUE)
-          } else {
-            prefix <- "file://"
-          }
-          paste0(prefix, utils::URLencode(path))
-        }
-
-        request_browser <- function(url, title, ..., viewer) {
-          # Printing URL with specific port triggers
-          # auto port-forwarding under remote development
-          message("Browsing ", url)
-          request("browser", url = url, title = title, ..., viewer = viewer)
-        }
-
-        show_browser <- function(url, title = url, ...,
-                                 viewer = getOption("vsc.browser", "Active")) {
-          if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
-            request_browser(url = url, title = title, ..., viewer = viewer)
-          } else if (grepl("^https?\\://", url)) {
-            message(
-              "VSCode WebView only supports showing local http content.\n",
-              "Opening in external browser..."
-            )
-            request_browser(url = url, title = title, ..., viewer = FALSE)
-          } else if (file.exists(url)) {
-            url <- normalizePath(url, "/", mustWork = TRUE)
-            if (grepl("\\.html?$", url, ignore.case = TRUE)) {
-              message(
-                "VSCode WebView has restricted access to local file.\n",
-                "Opening in external browser..."
+              x <- data.frame(
+                class = character(),
+                type = character(),
+                length = integer(),
+                size = integer(),
+                value = character(),
+                stringsAsFactors = FALSE,
+                check.names = FALSE
               )
-              request_browser(url = path_to_uri(url),
-                title = title, ..., viewer = FALSE)
-            } else {
-              request("dataview", source = "object", type = "txt",
-                title = title, file = url, viewer = viewer)
             }
+          }
+          if (is.data.frame(x) || is.matrix(x)) {
+            data <- dataview_table(x)
+            file <- tempfile(tmpdir = tempdir, fileext = ".json")
+            jsonlite::write_json(data, file, matrix = "rowmajor")
+            request("dataview", source = "table", type = "json",
+              title = title, file = file, viewer = viewer)
+          } else if (is.list(x)) {
+            tryCatch({
+              file <- tempfile(tmpdir = tempdir, fileext = ".json")
+              jsonlite::write_json(x, file, auto_unbox = TRUE)
+              request("dataview", source = "list", type = "json",
+                title = title, file = file, viewer = viewer)
+            }, error = function(e) {
+              file <- file.path(tempdir, paste0(make.names(title), ".txt"))
+              text <- utils::capture.output(print(x))
+              writeLines(text, file)
+              request("dataview", source = "object", type = "txt",
+                title = title, file = file, viewer = viewer)
+            })
           } else {
-            stop("File not exists")
+            file <- file.path(tempdir, paste0(make.names(title), ".R"))
+            if (is.primitive(x)) {
+              code <- utils::capture.output(print(x))
+            } else {
+              code <- deparse(x)
+            }
+            writeLines(code, file)
+            request("dataview", source = "object", type = "R",
+              title = title, file = file, viewer = viewer)
           }
         }
 
-        show_webview <- function(url, title, ..., viewer) {
-          if (!is.character(url)) {
-            real_url <- NULL
-            temp_viewer <- function(url, ...) {
-              real_url <<- url
-            }
-            op <- options(viewer = temp_viewer, page_viewer = temp_viewer)
-            on.exit(options(op))
-            print(url)
-            if (is.character(real_url)) {
-              url <- real_url
-            } else {
-              stop("Invalid object")
-            }
-          }
-          if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
-            request_browser(url = url, title = title, ..., viewer = viewer)
-          } else if (grepl("^https?\\://", url)) {
+        rebind("View", show_dataview, "utils")
+      }
+
+      attach <- function() {
+        if (rstudioapi_enabled()) {
+          rstudioapi_util_env$update_addin_registry(addin_registry)
+        }
+        request("attach",
+          tempdir = tempdir,
+          plot = getOption("vsc.plot", "Two"))
+      }
+
+      path_to_uri <- function(path) {
+        if (length(path) == 0) {
+          return(character())
+        }
+        path <- path.expand(path)
+        if (.Platform$OS.type == "windows") {
+          prefix <- "file:///"
+          path <- gsub("\\", "/", path, fixed = TRUE)
+        } else {
+          prefix <- "file://"
+        }
+        paste0(prefix, utils::URLencode(path))
+      }
+
+      request_browser <- function(url, title, ..., viewer) {
+        # Printing URL with specific port triggers
+        # auto port-forwarding under remote development
+        message("Browsing ", url)
+        request("browser", url = url, title = title, ..., viewer = viewer)
+      }
+
+      show_browser <- function(url, title = url, ...,
+                               viewer = getOption("vsc.browser", "Active")) {
+        if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
+          request_browser(url = url, title = title, ..., viewer = viewer)
+        } else if (grepl("^https?\\://", url)) {
+          message(
+            "VSCode WebView only supports showing local http content.\n",
+            "Opening in external browser..."
+          )
+          request_browser(url = url, title = title, ..., viewer = FALSE)
+        } else if (file.exists(url)) {
+          url <- normalizePath(url, "/", mustWork = TRUE)
+          if (grepl("\\.html?$", url, ignore.case = TRUE)) {
             message(
-              "VSCode WebView only supports showing local http content.\n",
+              "VSCode WebView has restricted access to local file.\n",
               "Opening in external browser..."
             )
-            request_browser(url = url, title = title, ..., viewer = FALSE)
-          } else if (file.exists(url)) {
-            file <- normalizePath(url, "/", mustWork = TRUE)
-            request("webview", file = file, title = title, viewer = viewer, ...)
+            request_browser(url = path_to_uri(url),
+              title = title, ..., viewer = FALSE)
           } else {
-            stop("File not exists")
+            request("dataview", source = "object", type = "txt",
+              title = title, file = url, viewer = viewer)
           }
-        }
-
-        show_viewer <- function(url, title = NULL, ...,
-                                viewer = getOption("vsc.viewer", "Two")) {
-          if (is.null(title)) {
-            expr <- substitute(url)
-            if (is.character(url)) {
-              title <- "Viewer"
-            } else {
-              title <- deparse(expr, nlines = 1)
-            }
-          }
-          show_webview(url = url, title = title, ..., viewer = viewer)
-        }
-
-        show_page_viewer <- function(url, title = NULL, ...,
-                                     viewer = getOption("vsc.page_viewer", "Active")) {
-          if (is.null(title)) {
-            expr <- substitute(url)
-            if (is.character(url)) {
-              title <- "Page Viewer"
-            } else {
-              title <- deparse(expr, nlines = 1)
-            }
-          }
-          show_webview(url = url, title = title, ..., viewer = viewer)
-        }
-
-        options(
-          browser = show_browser,
-          viewer = show_viewer,
-          page_viewer = show_page_viewer
-        )
-
-        # rstudioapi
-        rstudioapi_enabled <- function() {
-          isTRUE(getOption("vsc.rstudioapi"))
-        }
-
-        if (rstudioapi_enabled()) {
-          response_timeout <- 5
-          response_lock_file <- file.path(dir_session, "response.lock")
-          response_file <- file.path(dir_session, "response.log")
-          file.create(response_lock_file, showWarnings = FALSE)
-          file.create(response_file, showWarnings = FALSE)
-          addin_registry <- file.path(dir_session, "addins.json")
-          # This is created in attach()
-
-          get_response_timestamp <- function() {
-            readLines(response_lock_file)
-          }
-          # initialise the reponse timestamp to empty string
-          response_time_stamp <- ""
-
-          get_response_lock <- function() {
-            lock_time_stamp <- get_response_timestamp()
-            if (isTRUE(lock_time_stamp != response_time_stamp)) {
-              response_time_stamp <<- lock_time_stamp
-              TRUE
-            } else {
-              FALSE
-            }
-          }
-
-          request_response <- function(command, ...) {
-            request(command, ..., sd = dir_session)
-            wait_start <- Sys.time()
-            while (!get_response_lock()) {
-              if ((Sys.time() - wait_start) > response_timeout) {
-                stop(
-                  "Did not receive a response from VSCode-R API within ",
-                  response_timeout, " seconds."
-                )
-              }
-              Sys.sleep(0.1)
-            }
-            jsonlite::read_json(response_file)
-          }
-
-          rstudioapi_util_env <- new.env()
-          rstudioapi_env <- new.env(parent = rstudioapi_util_env)
-          source(file.path(dir_extension, "rstudioapi_util.R"),
-            local = rstudioapi_util_env,
-          )
-          source(file.path(dir_extension, "rstudioapi.R"),
-            local = rstudioapi_env
-          )
-          setHook(
-            packageEvent("rstudioapi", "onLoad"),
-            function(...) {
-              rstudioapi_util_env$rstudioapi_patch_hook(rstudioapi_env)
-            }
-          )
-        }
-
-        print.help_files_with_topic <- function(h, ...) {
-          viewer <- getOption("vsc.helpPanel", "Two")
-          if (!identical(FALSE, viewer) && length(h) >= 1 && is.character(h)) {
-            file <- h[1]
-            path <- dirname(file)
-            dirpath <- dirname(path)
-            pkgname <- basename(dirpath)
-            requestPath <- paste0(
-              "/library/",
-              pkgname,
-              "/html/",
-              basename(file),
-              ".html"
-            )
-            request(command = "help", requestPath = requestPath, viewer = viewer)
-          } else {
-            utils:::print.help_files_with_topic(h, ...)
-          }
-          invisible(h)
-        }
-
-        print.hsearch <- function(x, ...) {
-          viewer <- getOption("vsc.helpPanel", "Two")
-          if (!identical(FALSE, viewer) && length(x) >= 1) {
-            requestPath <- paste0(
-              "/doc/html/Search?pattern=",
-              tools:::escapeAmpersand(x$pattern),
-              paste0("&fields.", x$fields, "=1",
-                collapse = ""
-              ),
-              if (!is.null(x$agrep)) paste0("&agrep=", x$agrep),
-              if (!x$ignore.case) "&ignore.case=0",
-              if (!identical(
-                x$types,
-                getOption("help.search.types")
-              )) {
-                paste0("&types.", x$types, "=1",
-                  collapse = ""
-                )
-              },
-              if (!is.null(x$package)) {
-                paste0(
-                  "&package=",
-                  paste(x$package, collapse = ";")
-                )
-              },
-              if (!identical(x$lib.loc, .libPaths())) {
-                paste0(
-                  "&lib.loc=",
-                  paste(x$lib.loc, collapse = ";")
-                )
-              }
-            )
-            request(command = "help", requestPath = requestPath, viewer = viewer)
-          } else {
-            utils:::print.hsearch(x, ...)
-          }
-          invisible(x)
-        }
-
-        environment()
-      })
-
-      if (!identical(getOption("vsc.helpPanel", "Two"), FALSE)) {
-        .First.sys <- function() {
-          # first load utils in order to overwrite its print method for help files
-          base::.First.sys()
-
-          # a copy of .S3method(), since this function is new in R 4.0
-          .S3method <- function(generic, class, method) {
-            if (missing(method)) {
-              method <- paste(generic, class, sep = ".")
-            }
-            method <- match.fun(method)
-            registerS3method(generic, class, method, envir = parent.frame())
-            invisible(NULL)
-          }
-
-          suppressWarnings({
-            .S3method(
-              "print",
-              "help_files_with_topic",
-              .vsc$print.help_files_with_topic
-            )
-            .S3method(
-              "print",
-              "hsearch",
-              .vsc$print.hsearch
-            )
-          })
-
-          rm(".First.sys", envir = parent.env(environment()))
+        } else {
+          stop("File not exists")
         }
       }
 
-      .vsc.attach <- .vsc$attach
-      .vsc.view <- .vsc$show_dataview
-      .vsc.browser <- .vsc$show_browser
-      .vsc.viewer <- .vsc$show_viewer
-      .vsc.page_viewer <- .vsc$show_page_viewer
+      show_webview <- function(url, title, ..., viewer) {
+        if (!is.character(url)) {
+          real_url <- NULL
+          temp_viewer <- function(url, ...) {
+            real_url <<- url
+          }
+          op <- options(viewer = temp_viewer, page_viewer = temp_viewer)
+          on.exit(options(op))
+          print(url)
+          if (is.character(real_url)) {
+            url <- real_url
+          } else {
+            stop("Invalid object")
+          }
+        }
+        if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
+          request_browser(url = url, title = title, ..., viewer = viewer)
+        } else if (grepl("^https?\\://", url)) {
+          message(
+            "VSCode WebView only supports showing local http content.\n",
+            "Opening in external browser..."
+          )
+          request_browser(url = url, title = title, ..., viewer = FALSE)
+        } else if (file.exists(url)) {
+          file <- normalizePath(url, "/", mustWork = TRUE)
+          request("webview", file = file, title = title, viewer = viewer, ...)
+        } else {
+          stop("File not exists")
+        }
+      }
 
-      attach(environment(), name = .vsc.name, warn.conflicts = FALSE)
+      show_viewer <- function(url, title = NULL, ...,
+                              viewer = getOption("vsc.viewer", "Two")) {
+        if (is.null(title)) {
+          expr <- substitute(url)
+          if (is.character(url)) {
+            title <- "Viewer"
+          } else {
+            title <- deparse(expr, nlines = 1)
+          }
+        }
+        show_webview(url = url, title = title, ..., viewer = viewer)
+      }
 
-      .vsc.attach()
+      show_page_viewer <- function(url, title = NULL, ...,
+                                   viewer = getOption("vsc.page_viewer", "Active")) {
+        if (is.null(title)) {
+          expr <- substitute(url)
+          if (is.character(url)) {
+            title <- "Page Viewer"
+          } else {
+            title <- deparse(expr, nlines = 1)
+          }
+        }
+        show_webview(url = url, title = title, ..., viewer = viewer)
+      }
+
+      options(
+        browser = show_browser,
+        viewer = show_viewer,
+        page_viewer = show_page_viewer
+      )
+
+      # rstudioapi
+      rstudioapi_enabled <- function() {
+        isTRUE(getOption("vsc.rstudioapi"))
+      }
+
+      if (rstudioapi_enabled()) {
+        response_timeout <- 5
+        response_lock_file <- file.path(dir_session, "response.lock")
+        response_file <- file.path(dir_session, "response.log")
+        file.create(response_lock_file, showWarnings = FALSE)
+        file.create(response_file, showWarnings = FALSE)
+        addin_registry <- file.path(dir_session, "addins.json")
+        # This is created in attach()
+
+        get_response_timestamp <- function() {
+          readLines(response_lock_file)
+        }
+        # initialise the reponse timestamp to empty string
+        response_time_stamp <- ""
+
+        get_response_lock <- function() {
+          lock_time_stamp <- get_response_timestamp()
+          if (isTRUE(lock_time_stamp != response_time_stamp)) {
+            response_time_stamp <<- lock_time_stamp
+            TRUE
+          } else {
+            FALSE
+          }
+        }
+
+        request_response <- function(command, ...) {
+          request(command, ..., sd = dir_session)
+          wait_start <- Sys.time()
+          while (!get_response_lock()) {
+            if ((Sys.time() - wait_start) > response_timeout) {
+              stop(
+                "Did not receive a response from VSCode-R API within ",
+                response_timeout, " seconds."
+              )
+            }
+            Sys.sleep(0.1)
+          }
+          jsonlite::read_json(response_file)
+        }
+
+        rstudioapi_util_env <- new.env()
+        rstudioapi_env <- new.env(parent = rstudioapi_util_env)
+        source(file.path(dir_extension, "rstudioapi_util.R"),
+          local = rstudioapi_util_env,
+        )
+        source(file.path(dir_extension, "rstudioapi.R"),
+          local = rstudioapi_env
+        )
+        setHook(
+          packageEvent("rstudioapi", "onLoad"),
+          function(...) {
+            rstudioapi_util_env$rstudioapi_patch_hook(rstudioapi_env)
+          }
+        )
+      }
+
+      print.help_files_with_topic <- function(h, ...) {
+        viewer <- getOption("vsc.helpPanel", "Two")
+        if (!identical(FALSE, viewer) && length(h) >= 1 && is.character(h)) {
+          file <- h[1]
+          path <- dirname(file)
+          dirpath <- dirname(path)
+          pkgname <- basename(dirpath)
+          requestPath <- paste0(
+            "/library/",
+            pkgname,
+            "/html/",
+            basename(file),
+            ".html"
+          )
+          request(command = "help", requestPath = requestPath, viewer = viewer)
+        } else {
+          utils:::print.help_files_with_topic(h, ...)
+        }
+        invisible(h)
+      }
+
+      print.hsearch <- function(x, ...) {
+        viewer <- getOption("vsc.helpPanel", "Two")
+        if (!identical(FALSE, viewer) && length(x) >= 1) {
+          requestPath <- paste0(
+            "/doc/html/Search?pattern=",
+            tools:::escapeAmpersand(x$pattern),
+            paste0("&fields.", x$fields, "=1",
+              collapse = ""
+            ),
+            if (!is.null(x$agrep)) paste0("&agrep=", x$agrep),
+            if (!x$ignore.case) "&ignore.case=0",
+            if (!identical(
+              x$types,
+              getOption("help.search.types")
+            )) {
+              paste0("&types.", x$types, "=1",
+                collapse = ""
+              )
+            },
+            if (!is.null(x$package)) {
+              paste0(
+                "&package=",
+                paste(x$package, collapse = ";")
+              )
+            },
+            if (!identical(x$lib.loc, .libPaths())) {
+              paste0(
+                "&lib.loc=",
+                paste(x$lib.loc, collapse = ";")
+              )
+            }
+          )
+          request(command = "help", requestPath = requestPath, viewer = viewer)
+        } else {
+          utils:::print.hsearch(x, ...)
+        }
+        invisible(x)
+      }
+
+      environment()
     })
+
+    if (!identical(getOption("vsc.helpPanel", "Two"), FALSE)) {
+      .First.sys <- function() {
+        # first load utils in order to overwrite its print method for help files
+        base::.First.sys()
+
+        # a copy of .S3method(), since this function is new in R 4.0
+        .S3method <- function(generic, class, method) {
+          if (missing(method)) {
+            method <- paste(generic, class, sep = ".")
+          }
+          method <- match.fun(method)
+          registerS3method(generic, class, method, envir = parent.frame())
+          invisible(NULL)
+        }
+
+        suppressWarnings({
+          .S3method(
+            "print",
+            "help_files_with_topic",
+            .vsc$print.help_files_with_topic
+          )
+          .S3method(
+            "print",
+            "hsearch",
+            .vsc$print.hsearch
+          )
+        })
+
+        rm(".First.sys", envir = parent.env(environment()))
+      }
+    }
+
+    .vsc.attach <- .vsc$attach
+    .vsc.view <- .vsc$show_dataview
+    .vsc.browser <- .vsc$show_browser
+    .vsc.viewer <- .vsc$show_viewer
+    .vsc.page_viewer <- .vsc$show_page_viewer
+
+    attach(environment(), name = .vsc.name, warn.conflicts = FALSE)
+
+    .vsc.attach()
   })
-  
+})


### PR DESCRIPTION
**What problem did you solve?**

Close #520

This PR uses `rlang::env_binding_are_lazy()` and `rlang::env_binding_are_active()` to know which symbols are promises and active bindings so that they are not forced on task callback to write globalenv info.

**(If you have)Screenshot**

<img width="358" alt="image" src="https://user-images.githubusercontent.com/4662568/104114828-af116880-5343-11eb-9741-a1047c718b76.png">

**(If you do not have screenshot) How can I check this pull request?**

Run the following code in the global environment:

```r
x <- 1
delayedAssign("d", 1)
delayedAssign("err", stop("err"))
makeActiveBinding("a1", function() 1, environment())
```

No promise or active binding are forced.