### PR TITLE
Refactor extension.ts

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,0 +1,151 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+
+import * as vscode from 'vscode';
+
+import * as session from './session';
+
+
+// Get with names(roxygen2:::default_tags())
+const roxygenTagCompletionItems = [
+    'export', 'exportClass', 'exportMethod', 'exportPattern', 'import', 'importClassesFrom',
+    'importFrom', 'importMethodsFrom', 'rawNamespace', 'S3method', 'useDynLib', 'aliases',
+    'author', 'backref', 'concept', 'describeIn', 'description', 'details',
+    'docType', 'encoding', 'evalRd', 'example', 'examples', 'family',
+    'field', 'format', 'inherit', 'inheritParams', 'inheritDotParams', 'inheritSection',
+    'keywords', 'method', 'name', 'md', 'noMd', 'noRd',
+    'note', 'param', 'rdname', 'rawRd', 'references', 'return',
+    'section', 'seealso', 'slot', 'source', 'template', 'templateVar',
+    'title', 'usage'
+].map((x: string) => new vscode.CompletionItem(`${x} `));
+
+
+export class HoverProvider implements vscode.HoverProvider {
+    provideHover(document: vscode.TextDocument, position: vscode.Position): vscode.Hover {
+        const wordRange = document.getWordRangeAtPosition(position);
+        const text = document.getText(wordRange);
+        return new vscode.Hover(`\`\`\`\n${session.globalenv[text].str}\n\`\`\``);
+    }
+}
+
+export class StaticCompletionItemProvider implements vscode.CompletionItemProvider {
+    provideCompletionItems(document: vscode.TextDocument, position: vscode.Position): vscode.CompletionItem[] | undefined {
+        if (document.lineAt(position).text
+                    .substr(0, 2) === '#\'') {
+            return roxygenTagCompletionItems;
+        }
+
+        return undefined;
+    }
+}
+
+
+export class LiveCompletionItemProvider implements vscode.CompletionItemProvider {
+    provideCompletionItems(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        token: vscode.CancellationToken,
+        completionContext: vscode.CompletionContext
+    ): vscode.CompletionItem[] {
+        const items = [];
+        if (token.isCancellationRequested) {
+            return items;
+        }
+
+        const trigger = completionContext.triggerCharacter;
+
+        if (trigger === undefined) {
+            Object.keys(session.globalenv).map((key) => {
+                const obj = session.globalenv[key];
+                const item = new vscode.CompletionItem(
+                    key,
+                    obj.type === 'closure' || obj.type === 'builtin'
+                        ? vscode.CompletionItemKind.Function
+                        : vscode.CompletionItemKind.Field
+                );
+                item.detail = '[session]';
+                item.documentation = new vscode.MarkdownString(`\`\`\`r\n${obj.str}\n\`\`\``);
+                items.push(item);
+            });
+        } else if(trigger === '$' || trigger === '@') {
+            const symbolPosition = new vscode.Position(position.line, position.character - 1);
+            const symbolRange = document.getWordRangeAtPosition(symbolPosition);
+            const symbol = document.getText(symbolRange);
+            const doc = new vscode.MarkdownString('Element of `' + symbol + '`');
+            const obj = session.globalenv[symbol];
+            let elements: string[];
+            if (obj !== undefined) {
+                if (completionContext.triggerCharacter === '$') {
+                    elements = obj.names;
+                } else if (completionContext.triggerCharacter === '@') {
+                    elements = obj.slots;
+                }
+            }
+            elements.map((key) => {
+                const item = new vscode.CompletionItem(key, vscode.CompletionItemKind.Field);
+                item.detail = '[session]';
+                item.documentation = doc;
+                items.push(item);
+            });
+        }
+
+        if (trigger === undefined || trigger === '"' || trigger === '\'') {
+            const bracketItems = getBracketCompletionItems(document, position, token);
+            items.push(...bracketItems);
+        }
+
+        return items;
+    }
+}
+
+
+function getBracketCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken) {
+    const items: vscode.CompletionItem[] = [];
+    let range = new vscode.Range(new vscode.Position(position.line, 0), position);
+    let expectOpenBrackets = 0;
+    let symbol: string;
+
+    while (range) {
+        if (token.isCancellationRequested) { return; }
+        const text = document.getText(range);
+        for (let i = text.length - 1; i >= 0; i -= 1) {
+            const chr = text.charAt(i);
+            if (chr === ']') {
+                expectOpenBrackets += 1;
+            } else if (chr === '[') {
+                if (expectOpenBrackets === 0) {
+                    const symbolPosition = new vscode.Position(range.start.line, i - 1);
+                    const symbolRange = document.getWordRangeAtPosition(symbolPosition);
+                    symbol = document.getText(symbolRange);
+                    range = undefined;
+                    break;
+                } else {
+                    expectOpenBrackets -= 1;
+                }
+            }
+        }
+        if (range?.start.line > 0) {
+            range = document.lineAt(range.start.line - 1).range; // check previous line
+        } else {
+            range = undefined;
+        }
+    }
+
+    if (!token.isCancellationRequested && symbol !== undefined) {
+        const obj = session.globalenv[symbol];
+        if (obj !== undefined && obj.names !== undefined) {
+            const doc = new vscode.MarkdownString('Element of `' + symbol + '`');
+            obj.names.map((name: string) => {
+                const item = new vscode.CompletionItem(name, vscode.CompletionItemKind.Field);
+                item.detail = '[session]';
+                item.documentation = doc;
+                items.push(item);
+            });
+        }
+    }
+    return items;
+}

--- a/src/rHelp.ts
+++ b/src/rHelp.ts
@@ -14,7 +14,6 @@ import { HelpTreeWrapper } from './rHelpTree';
 import { PackageManager } from './rHelpPackages';
 
 
-export let globalRHelp: RHelp | undefined;
 
 
 class DummyMemento implements vscode.Memento {
@@ -32,7 +31,7 @@ class DummyMemento implements vscode.Memento {
 	}
 }
 
-export async function initializeHelp(context: vscode.ExtensionContext, rExtension: api.RExtension): Promise<void> {
+export async function initializeHelp(context: vscode.ExtensionContext, rExtension: api.RExtension): Promise<RHelp|undefined> {
 
 	void vscode.commands.executeCommand('setContext', 'r.helpViewer.show', true);
 
@@ -70,7 +69,6 @@ export async function initializeHelp(context: vscode.ExtensionContext, rExtensio
         void vscode.window.showErrorMessage(`Help Panel not available`);
     }
 
-    globalRHelp = rHelp;
     rExtension.helpPanel = rHelp;
 
 	if(rHelp){
@@ -84,6 +82,8 @@ export async function initializeHelp(context: vscode.ExtensionContext, rExtensio
 			vscode.commands.registerCommand('r.helpPanel.openExternal', () => rHelp?.openExternal())
 		);
 	}
+
+	return rHelp;
 }
 
 

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -5,7 +5,6 @@ import path = require('path');
 
 import { pathExists } from 'fs-extra';
 import { isDeepStrictEqual } from 'util';
-import { commands, Position, Range, Terminal, TerminalOptions, window } from 'vscode';
 
 import * as vscode from 'vscode';
 import * as util from './util';
@@ -14,7 +13,7 @@ import * as selection from './selection';
 import { getSelection } from './selection';
 import { removeSessionFiles } from './session';
 import { config, delay, getRterm } from './util';
-export let rTerm: Terminal;
+export let rTerm: vscode.Terminal;
 
 
 
@@ -115,7 +114,7 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
     const termOpt: string[] = config().get('rterm.option');
     pathExists(termPath, (err, exists) => {
         if (exists) {
-            const termOptions: TerminalOptions = {
+            const termOptions: vscode.TerminalOptions = {
                 name: termName,
                 shellPath: termPath,
                 shellArgs: termOpt,
@@ -126,12 +125,12 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
                     R_PROFILE_USER: path.join(os.homedir(), '.vscode-R', '.Rprofile'),
                 };
             }
-            rTerm = window.createTerminal(termOptions);
+            rTerm = vscode.window.createTerminal(termOptions);
             rTerm.show(preserveshow);
 
             return true;
         }
-        void window.showErrorMessage('Cannot find R client.  Please check R path in preferences and reload.');
+        void vscode.window.showErrorMessage('Cannot find R client.  Please check R path in preferences and reload.');
 
         return false;
     });
@@ -145,7 +144,7 @@ export async function restartRTerminal(): Promise<void>{
     }
 }
 
-export function deleteTerminal(term: Terminal): void {
+export function deleteTerminal(term: vscode.Terminal): void {
     if (isDeepStrictEqual(term, rTerm)) {
         rTerm = undefined;
         if (config().get<boolean>('sessionWatcher')) {
@@ -154,31 +153,31 @@ export function deleteTerminal(term: Terminal): void {
     }
 }
 
-export async function chooseTerminal(): Promise<Terminal> {
+export async function chooseTerminal(): Promise<vscode.Terminal> {
     if (config().get('alwaysUseActiveTerminal')) {
-        if (window.terminals.length < 1) {
-            void window.showInformationMessage('There are no open terminals.');
+        if (vscode.window.terminals.length < 1) {
+            void vscode.window.showInformationMessage('There are no open terminals.');
 
             return undefined;
         }
 
-        return window.activeTerminal;
+        return vscode.window.activeTerminal;
     }
 
     let msg = '[chooseTerminal] ';
-    msg += `A. There are ${window.terminals.length} terminals: `;
-    for (let i = 0; i < window.terminals.length; i++){
-        msg += `Terminal ${i}: ${window.terminals[i].name} `;
+    msg += `A. There are ${vscode.window.terminals.length} terminals: `;
+    for (let i = 0; i < vscode.window.terminals.length; i++){
+        msg += `Terminal ${i}: ${vscode.window.terminals[i].name} `;
     }
-    if (window.terminals.length > 0) {
+    if (vscode.window.terminals.length > 0) {
         const rTermNameOptions = ['R', 'R Interactive'];
-        if (window.activeTerminal !== undefined) {
-            const activeTerminalName = window.activeTerminal.name;
+        if (vscode.window.activeTerminal !== undefined) {
+            const activeTerminalName = vscode.window.activeTerminal.name;
             if (rTermNameOptions.includes(activeTerminalName)) {
-                return window.activeTerminal;
+                return vscode.window.activeTerminal;
             }
-            for (let i = window.terminals.length - 1; i >= 0; i--){
-                const terminal = window.terminals[i];
+            for (let i = vscode.window.terminals.length - 1; i >= 0; i--){
+                const terminal = vscode.window.terminals[i];
                 const terminalName = terminal.name;
                 if (rTermNameOptions.includes(terminalName)) {
                     terminal.show(true);
@@ -186,23 +185,23 @@ export async function chooseTerminal(): Promise<Terminal> {
                 }
             }
         } else {
-            msg += `B. There are ${window.terminals.length} terminals: `;
-            for (let i = 0; i < window.terminals.length; i++){
-                msg += `Terminal ${i}: ${window.terminals[i].name} `;
+            msg += `B. There are ${vscode.window.terminals.length} terminals: `;
+            for (let i = 0; i < vscode.window.terminals.length; i++){
+                msg += `Terminal ${i}: ${vscode.window.terminals[i].name} `;
             }
             // Creating a terminal when there aren't any already does not seem to set activeTerminal
-            if (window.terminals.length === 1) {
-                const activeTerminalName = window.terminals[0].name;
+            if (vscode.window.terminals.length === 1) {
+                const activeTerminalName = vscode.window.terminals[0].name;
                 if (rTermNameOptions.includes(activeTerminalName)) {
-                    return window.terminals[0];
+                    return vscode.window.terminals[0];
                 }
             } else {
-                msg += `C. There are ${window.terminals.length} terminals: `;
-                for (let i = 0; i < window.terminals.length; i++){
-                    msg += `Terminal ${i}: ${window.terminals[i].name} `;
+                msg += `C. There are ${vscode.window.terminals.length} terminals: `;
+                for (let i = 0; i < vscode.window.terminals.length; i++){
+                    msg += `Terminal ${i}: ${vscode.window.terminals[i].name} `;
                 }
                 console.info(msg);
-                void window.showErrorMessage('Error identifying terminal! Please run command "Developer: Toggle Developer Tools", find the message starting with "[chooseTerminal]", and copy the message to https://github.com/Ikuyadeu/vscode-R/issues');
+                void vscode.window.showErrorMessage('Error identifying terminal! Please run command "Developer: Toggle Developer Tools", find the message starting with "[chooseTerminal]", and copy the message to https://github.com/Ikuyadeu/vscode-R/issues');
 
                 return undefined;
             }
@@ -223,20 +222,20 @@ export async function chooseTerminal(): Promise<Terminal> {
 export async function runSelectionInTerm(moveCursor: boolean): Promise<void> {
     const selection = getSelection();
     if (moveCursor && selection.linesDownToMoveCursor > 0) {
-        const lineCount = window.activeTextEditor.document.lineCount;
-        if (selection.linesDownToMoveCursor + window.activeTextEditor.selection.end.line === lineCount) {
-            const endPos = new Position(lineCount, window.activeTextEditor.document.lineAt(lineCount - 1).text.length);
-            await window.activeTextEditor.edit(e => e.insert(endPos, '\n'));
+        const lineCount = vscode.window.activeTextEditor.document.lineCount;
+        if (selection.linesDownToMoveCursor + vscode.window.activeTextEditor.selection.end.line === lineCount) {
+            const endPos = new vscode.Position(lineCount, vscode.window.activeTextEditor.document.lineAt(lineCount - 1).text.length);
+            await vscode.window.activeTextEditor.edit(e => e.insert(endPos, '\n'));
         }
-        await commands.executeCommand('cursorMove', { to: 'down', value: selection.linesDownToMoveCursor });
-        await commands.executeCommand('cursorMove', { to: 'wrappedLineFirstNonWhitespaceCharacter' });
+        await vscode.commands.executeCommand('cursorMove', { to: 'down', value: selection.linesDownToMoveCursor });
+        await vscode.commands.executeCommand('cursorMove', { to: 'wrappedLineFirstNonWhitespaceCharacter' });
     }
     await runTextInTerm(selection.selectedText);
 }
 
-export async function runChunksInTerm(chunks: Range[]): Promise<void> {
+export async function runChunksInTerm(chunks: vscode.Range[]): Promise<void> {
     const text = chunks
-        .map((chunk) => window.activeTextEditor.document.getText(chunk).trim())
+        .map((chunk) => vscode.window.activeTextEditor.document.getText(chunk).trim())
         .filter((chunk) => chunk.length > 0)
         .join('\n');
     if (text.length > 0) {
@@ -265,7 +264,7 @@ export async function runTextInTerm(text: string): Promise<void> {
     setFocus(term);
 }
 
-function setFocus(term: Terminal) {
+function setFocus(term: vscode.Terminal) {
     const focus: string = config().get('source.focus');
     term.show(focus !== 'terminal');
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,8 +14,7 @@ import { FSWatcher } from 'fs-extra';
 import { config } from './util';
 import { purgeAddinPickerItems, dispatchRStudioAPICall } from './rstudioapi';
 
-import { globalRHelp } from './rHelp';
-import { rWorkspace } from './extension';
+import { rWorkspace, globalRHelp } from './extension';
 
 export let globalenv: any;
 let resDir: string;
@@ -177,7 +176,7 @@ async function updateGlobalenv() {
         if (fs.existsSync(globalenvFile)) {
             const content = await fs.readFile(globalenvFile, 'utf8');
             globalenv = JSON.parse(content);
-            rWorkspace.refresh();
+            rWorkspace?.refresh();
             console.info('[updateGlobalenv] Done');
         } else {
             console.info('[updateGlobalenv] File not found');

--- a/src/util.ts
+++ b/src/util.ts
@@ -148,6 +148,23 @@ export function checkIfFileExists(filePath: string): boolean {
 }
 
 
+export async function saveDocument(document: vscode.TextDocument): Promise<boolean> {
+    if (document.isUntitled) {
+        void vscode.window.showErrorMessage('Document is unsaved. Please save and retry running R command.');
+
+        return false;
+    }
+
+    const isSaved: boolean = document.isDirty ? (await document.save()) : true;
+    if (!isSaved) {
+        void vscode.window.showErrorMessage('Cannot run R command: document could not be saved.');
+
+        return false;
+    }
+
+    return true;
+}
+
 // shows a quick pick asking the user for confirmation
 // returns true if the user confirms, false if they cancel or dismiss the quickpick
 export async function getConfirmation(prompt: string, confirmation?: string, detail?: string): Promise<boolean> {


### PR DESCRIPTION
**What problem did you solve?**
Implements the refactoring suggested in #479.

**How can I check this pull request?**
This PR is not intended to change the behavior of the extension. 


I also changed the imports at the top of `extension.ts` to namespace imports:
* Improves the readibility of the code
* Makes it easier to keep track of where each function comes from
* Makes life easier for developers. E.g.
    * you can use intellisense to access imported functions (e.g. `vscode.` + `ctrl+space` to view all exported variables from vscode) 
    * it's easier to move code around between files (you only need to add/remove the namespace imports sometimes, previously you had to add/remove each function individually)
    * Fewer (redundant) changes in Git diffs

If you disagree, this can of course be reverted, but I'd strongly suggest using namespace imports here.