### PR TITLE
Add initial pipeline completion support

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -96,12 +96,12 @@ export class LiveCompletionItemProvider implements vscode.CompletionItemProvider
             });
         }
 
-        if (trigger === undefined || trigger === ',' || trigger === '"' || trigger === '\'') {
+        if (trigger === undefined || trigger === '[' || trigger === ',' || trigger === '"' || trigger === '\'') {
             const bracketItems = getBracketCompletionItems(document, position, token);
             items.push(...bracketItems);
         }
 
-        if (trigger === undefined || trigger === ',') {
+        if (trigger === undefined || trigger === '(' || trigger === ',') {
             const pipelineItems = getPipelineCompletionItems(document, position, token);
             items.push(...pipelineItems);
         }

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -178,7 +178,7 @@ function getPipelineCompletionItems(document: vscode.TextDocument, position: vsc
             continue;
         }
 
-        const pipeSymbolIndex = line.text.search(/([\w_.]+|`.+`)\s*(%.+%|\|>)/);
+        const pipeSymbolIndex = line.text.search(/([\w_.]+)\s*(%.+%|\|>)/);
         if (pipeSymbolIndex < 0) {
             break;
         }

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -158,7 +158,6 @@ function getBracketCompletionItems(document: vscode.TextDocument, position: vsco
     return items;
 }
 
-
 function getPipelineCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken) {
     const items: vscode.CompletionItem[] = [];
     const range = extendSelection(position.line, (x) => document.lineAt(x).text, document.lineCount);
@@ -179,7 +178,12 @@ function getPipelineCompletionItems(document: vscode.TextDocument, position: vsc
             continue;
         }
 
-        const symbolPosition = new vscode.Position(i, line.firstNonWhitespaceCharacterIndex);
+        const pipeSymbolIndex = line.text.search(/([\w_.]+|`.+`)\s*(%.+%|\|>)/);
+        if (pipeSymbolIndex < 0) {
+            break;
+        }
+
+        const symbolPosition = new vscode.Position(i, pipeSymbolIndex);
         const symbolRange = document.getWordRangeAtPosition(symbolPosition);
 
         if (symbolRange !== undefined) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -164,7 +164,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         void vscode.commands.executeCommand('setContext', 'r.WorkspaceViewer:show', enableSessionWatcher);
 
         // if session watcher is active, register dyamic completion provider
-        const liveTriggerCharacters = ['', '$', '@', '"', '\'' ];
+        const liveTriggerCharacters = ['', ',', '$', '@', '"', '\'' ];
         vscode.languages.registerCompletionItemProvider('r', new completions.LiveCompletionItemProvider(), ...liveTriggerCharacters);
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -164,7 +164,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         void vscode.commands.executeCommand('setContext', 'r.WorkspaceViewer:show', enableSessionWatcher);
 
         // if session watcher is active, register dyamic completion provider
-        const liveTriggerCharacters = ['', ',', '$', '@', '"', '\'' ];
+        const liveTriggerCharacters = ['', '[', '(', ',', '$', '@', '"', '\'' ];
         vscode.languages.registerCompletionItemProvider('r', new completions.LiveCompletionItemProvider(), ...liveTriggerCharacters);
     }
 

--- a/src/lineCache.ts
+++ b/src/lineCache.ts
@@ -48,7 +48,7 @@ function isComment(c: string) {
     return c === '#';
 }
 
-function cleanLine(text: string) {
+export function cleanLine(text: string): string {
     let cleaned = '';
     let withinQuotes = null;
     for (let i = 0; i < text.length; i++) {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -190,8 +190,8 @@ export function extendSelection(line: number, getLine: (line: number) => string,
     endLine: number;
 } {
     const lc = new LineCache(getLine, lineCount);
-    const getLineFromCache = (x) => lc.getLineFromCache(x);
-    const getEndsInOperatorFromCache = (x) => lc.getEndsInOperatorFromCache(x);
+    const getLineFromCache = (x: number) => lc.getLineFromCache(x);
+    const getEndsInOperatorFromCache = (x: number) => lc.getEndsInOperatorFromCache(x);
     let lookingForward = true;
     /* poss[1] is the farthest point reached looking forward from line,
      and poss[0] is the farthest point reached looking backward from line. */


### PR DESCRIPTION
**What problem did you solve?**

Closes #323 

This PR implements a simple function `getPipelineCompletionItems()` based on `extendSelection` so that the beginning symbol of the pipeline expression is extracted and its `names()` stored in `globalenv.json` is used to provide live completion items in user session.

Note that for subsequent pipeline expressions such as `mutate()` and `summarize()`, new variables may be introduced. https://github.com/REditorSupport/languageserver/pull/324 should be helpful in this case to provide token completion for these newly introduced variables even if the code is not executed but those symbols already appear in the code.

**(If you have)Screenshot**

![image](https://user-images.githubusercontent.com/4662568/105280456-c58dae80-5be4-11eb-846c-9830a020a9ab.png)

**(If you do not have screenshot) How can I check this pull request?**

In the following example, `tbl1` is created and saved to disk. The language server should be able to capture all these symbols in `tbl1` if they appear in the code rather than comments. After storing `tbl1` to disk, we could comment out the `tbl1` code and let session watcher completion provider work to capture `tbl1` in the pipeline expression and provide its names in the whole expression.

We could test the completions in each `mutate()` and `select()` call.

```r
library(dplyr)
library(tibble)

# tbl1 <- tibble(
#   Name = c("Product1", "Product2", "Product3"),
#   Quality = c("Good", "Good", "Best"),
#   Score = c(8, 9, 10),
#   Type = c("B", "B", "A")
# )
# saveRDS(tbl1, "tbl1.rds")

tbl1 <- readRDS("tbl1.rds")

# typical pipeline without assignment
tbl1 %>%
  mutate(Score_mean = mean(Score)) %>%
  select(Score)

# typical pipeline with assignment
tbl2 <- tbl1 %>%
  mutate(Score_mean = mean(Score)) %>%
  select(Score)

# one-lined pipeline
tpl3 <- tbl1 %>% mutate(Name2 = Name) %>% select(Score)

# mixed case
tpl3 <- tbl1 %>% mutate(Name2 = Name) %>% 
  select(Score)

```