### PR TITLE
Add function to open help for selected text

### DIFF
--- a/package.json
+++ b/package.json
@@ -600,7 +600,7 @@
         "icon": "$(unfold)"
       },
       {
-        "title": "Open help for selection",
+        "title": "R: Open help for selection",
         "command": "r.helpPanel.openForSelection"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -600,7 +600,8 @@
         "icon": "$(unfold)"
       },
       {
-        "title": "R: Open help for selection",
+        "title": "Open help for selection",
+        "category": "R",
         "command": "r.helpPanel.openForSelection"
       }
     ],
@@ -712,6 +713,16 @@
           "command": "r.helpPanel.openExternal",
           "when": "resourceScheme =~ /webview/ && r.helpPanel.active",
           "group": "navigation"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "r.helpPanel.openForSelection",
+          "when": "resourceLangId == r"
+        },
+        {
+          "command": "r.helpPanel.openForSelection",
+          "when": "resourceLangId == rmd"
         }
       ],
       "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -598,6 +598,10 @@
         "title": "Don't Summarize Identical Topics",
         "command": "r.helpPanel.unsummarizeTopics",
         "icon": "$(unfold)"
+      },
+      {
+        "title": "Open help for selection",
+        "command": "r.helpPanel.openForSelection"
       }
     ],
     "keybindings": [

--- a/src/rHelp.ts
+++ b/src/rHelp.ts
@@ -83,8 +83,16 @@ export async function initializeHelp(context: vscode.ExtensionContext, rExtensio
 
 			vscode.commands.registerCommand('r.helpPanel.openForSelection', () => {
 				const editor = vscode.window.activeTextEditor;
-				const txt = editor?.document.getText(editor.selection);
-				void rHelp?.openHelpByAlias(txt);
+				if (editor !== undefined) {
+					let txt: string;
+					if (editor.selection.isEmpty) {
+						const range = editor.document.getWordRangeAtPosition(editor.selection.start);
+						txt = editor.document.getText(range);
+					} else {
+						txt = editor.document.getText(editor.selection);
+					}
+					void rHelp?.openHelpByAlias(txt);
+				}
 			})
 		);
 	}

--- a/src/rHelp.ts
+++ b/src/rHelp.ts
@@ -79,7 +79,13 @@ export async function initializeHelp(context: vscode.ExtensionContext, rExtensio
 			vscode.commands.registerCommand('r.showHelp', () => rHelp?.treeViewWrapper.helpViewProvider.rootItem.showQuickPick()),
 			vscode.commands.registerCommand('r.helpPanel.back', () => rHelp?.goBack()),
 			vscode.commands.registerCommand('r.helpPanel.forward', () => rHelp?.goForward()),
-			vscode.commands.registerCommand('r.helpPanel.openExternal', () => rHelp?.openExternal())
+			vscode.commands.registerCommand('r.helpPanel.openExternal', () => rHelp?.openExternal()),
+
+			vscode.commands.registerCommand('r.helpPanel.openForSelection', () => {
+				const editor = vscode.window.activeTextEditor;
+				const txt = editor?.document.getText(editor.selection);
+				void rHelp?.openHelpByAlias(txt);
+			})
 		);
 	}
 
@@ -293,14 +299,58 @@ export class RHelp implements api.HelpPanel {
 		return false;
 	}
 
+	// quickly open help page by alias
+	public async openHelpByAlias(token: string = ''): Promise<boolean> {
+		const aliases = await this.getAllAliases();
+		if(!aliases){
+			return false;
+		}
+
+		const matchingAliases = aliases.filter(alias => (
+			token === alias.name
+			|| token === `${alias.package}::${alias.name}`
+			|| token === `${alias.package}:::${alias.name}`
+		));
+
+		let pickedAlias: Alias | undefined;
+		if(matchingAliases.length === 0){
+			pickedAlias = undefined;
+		} else if(matchingAliases.length === 1){
+			pickedAlias = matchingAliases[0];
+		} else{
+			pickedAlias = await this.pickAlias(matchingAliases);
+		}
+		if(pickedAlias){
+			return await this.showHelpForAlias(pickedAlias);
+		}
+		return false;
+	}
+
 	// search function, similar to calling `?` in R
 	public async searchHelpByAlias(): Promise<boolean> {
+		const alias = await this.pickAlias();
+		if(alias){
+			return this.showHelpForAlias(alias);
+		}
+		return false;
+	}
 
+	// helper function to get aliases from aliasprovider
+	private async getAllAliases(): Promise<Alias[] | null | undefined> {
 		const aliases = await doWithProgress(() => this.aliasProvider.getAllAliases());
-
 		if(!aliases){
 			void vscode.window.showErrorMessage('Failed to get list of R functions. Make sure that `jsonlite` is installed and r.helpPanel.rpath points to a valid R executable.');
-			return false;
+		}
+		return aliases;
+	}
+
+	// let the user pick an alias from a supplied list of aliases
+	// if no list supplied, get all aliases from alias provider
+	private async pickAlias(aliases?: Alias[], prompt?: string): Promise<Alias | undefined>{
+		prompt ||= 'Please type a function name/documentation entry';
+		aliases ||= await this.getAllAliases();
+		if(!aliases){
+			return undefined;
 		}
 		const qpItems: (vscode.QuickPickItem & Alias)[] = aliases.map(v => {
 			return {
@@ -311,16 +361,17 @@ export class RHelp implements api.HelpPanel {
 		});
 		const qpOptions = {
 			matchOnDescription: true,
-			placeHolder: 'Please type a function name/documentation entry'
+			placeHolder: prompt
 		};
 		const qp = await vscode.window.showQuickPick(
 			qpItems,
 			qpOptions
 		);
-		if(qp){
-			return this.showHelpForPath(`/library/${qp.package}/html/${qp.alias}.html`);
-		}
-		return false;
+		return qp;
+	}
+
+	private async showHelpForAlias(alias: Alias): Promise<boolean> {
+		return this.showHelpForPath(`/library/${alias.package}/html/${alias.alias}.html`);
 	}
 
 	// shows help for request path as used by R's internal help server

--- a/src/rHelpTree.ts
+++ b/src/rHelpTree.ts
@@ -309,6 +309,7 @@ class RootNode extends MetaNode {
             new HomeNode(this),
             new Search1Node(this),
             new Search2Node(this),
+            new OpenForSelectionNode(this),
             new RefreshNode(this),
             new InstallPackageNode(this),
             this.pkgRootNode,
@@ -565,6 +566,16 @@ class RefreshNode extends MetaNode {
     callBack(){
         this.rHelp.refresh();
         this.parent.pkgRootNode.refresh();
+    }
+}
+
+class OpenForSelectionNode extends MetaNode {
+    parent: RootNode;
+    label = 'Open Help Page for Selected Text';
+    iconPath = new vscode.ThemeIcon('symbol-key');
+    
+    callBack(){
+        void this.rHelp.openHelpForSelection();
     }
 }
 


### PR DESCRIPTION
**What problem did you solve?**
Fix #528 
This PR adds a command `r.helpPanel.openForSelection` that opens the help page for the currently selected function/topic.
Does not contain any error notifications if no matching help page is found.
Does not contain automatic detection of the correct "token" to be used.
Does not containt automatic detection of the correct package to be used (if not specified by using `::`).

**How can I check this pull request?**
Type e.g. `print`, `base::print`, `base:::print`, select the text and execute the command `r.helpPanel.openForSelection`.
