### PR TITLE
Add updatePackage command

### DIFF
--- a/package.json
+++ b/package.json
@@ -580,6 +580,11 @@
         "icon": "$(trash)"
       },
       {
+        "title": "Update/reinstall Package",
+        "command": "r.helpPanel.updatePackage",
+        "icon": "$(cloud-download)"
+      },
+      {
         "title": "Install multiple packages",
         "command": "r.helpPanel.installPackages",
         "icon": "$(expand-all)"
@@ -760,6 +765,11 @@
           "command": "r.helpPanel.removePackage",
           "group": "inline",
           "when": "view == rHelpPages && viewItem =~ /_removePackage_/"
+        },
+        {
+          "command": "r.helpPanel.updatePackage",
+          "group": "inline",
+          "when": "view == rHelpPages && viewItem =~ /_updatePackage_/"
         },
         {
           "command": "r.helpPanel.installPackages",

--- a/package.json
+++ b/package.json
@@ -580,6 +580,11 @@
         "icon": "$(trash)"
       },
       {
+        "title": "Update Installed Packages",
+        "command": "r.helpPanel.updateInstalledPackages",
+        "icon": "$(clone)"
+      },
+      {
         "title": "Update/reinstall Package",
         "command": "r.helpPanel.updatePackage",
         "icon": "$(cloud-download)"
@@ -767,13 +772,18 @@
           "when": "view == rHelpPages && viewItem =~ /_removePackage_/"
         },
         {
+          "command": "r.helpPanel.updateInstalledPackages",
+          "group": "inline",
+          "when": "view == rHelpPages && viewItem =~ /_updateInstalledPackages_/"
+        },
+        {
           "command": "r.helpPanel.updatePackage",
           "group": "inline",
           "when": "view == rHelpPages && viewItem =~ /_updatePackage_/"
         },
         {
           "command": "r.helpPanel.installPackages",
-          "group": "inline",
+          "group": "inline@9",
           "when": "view == rHelpPages && viewItem =~ /_installPackages_/"
         },
         {

--- a/src/rHelpPackages.ts
+++ b/src/rHelpPackages.ts
@@ -185,9 +185,9 @@ export class PackageManager {
     // let the user pick and install a package from CRAN 
     public async pickAndInstallPackages(pickMany: boolean = false): Promise<boolean> {
         const pkgs = await this.pickPackages('Please selecte a package.', true, pickMany);
-        if(pkgs?.length){
+        if(pkgs?.length > 1){
             const pkgsConfirmed = await this.confirmPackages('Are you sure you want to install these packages?', pkgs);
-            if(pkgsConfirmed?.length > 1){
+            if(pkgsConfirmed?.length){
                 const names = pkgsConfirmed.map(v => v.name);
                 return await this.installPackages(names, true);
             }
@@ -219,8 +219,9 @@ export class PackageManager {
         const cranUrl = await getCranUrl('', this.cwd);
         const args = [`--silent`, '--slave', `-e`, `install.packages(c(${pkgNames.map(v => `'${v}'`).join(',')}),repos='${cranUrl}')`];
         const cmd = `${rPath} ${args.join(' ')}`;
-        const confirmation = 'Yes, install package(s)!';
-        const prompt = `Are you sure you want to install package(s): ${pkgNames.join(', ')}?`;
+        const pluralS = pkgNames.length > 1? 's' : '';
+        const confirmation = `Yes, install package${pluralS}!`;
+        const prompt = `Are you sure you want to install package${pluralS}: ${pkgNames.join(', ')}?`;
 
         if(skipConfirmation || await getConfirmation(prompt, confirmation, cmd)){
             await executeAsTask('Install Package', rPath, args);

--- a/src/rHelpPackages.ts
+++ b/src/rHelpPackages.ts
@@ -230,6 +230,22 @@ export class PackageManager {
             return false;
         }
     }
+    
+    public async updatePackages(skipConfirmation: boolean = false): Promise<boolean> {
+        const rPath = await getRpath(false);
+        const cranUrl = await getCranUrl('', this.cwd);
+        const args = ['--silent', '--slave', '-e', `update.packages(ask=FALSE,repos='${cranUrl}')`];
+        const cmd = `${rPath} ${args.join(' ')}`;
+        const confirmation = 'Yes, update all packages!';
+        const prompt = 'Are you sure you want to update all installed packages? This might take some time!';
+
+        if(skipConfirmation || await getConfirmation(prompt, confirmation, cmd)){
+            await executeAsTask('Update Packages', rPath, args);
+            return true;
+        } else{
+            return false;
+        }
+    }
 
     public async getPackages(fromCran: boolean = false): Promise<Package[]|undefined> {
         let packages: Package[]|undefined;

--- a/src/rHelpTree.ts
+++ b/src/rHelpTree.ts
@@ -464,8 +464,8 @@ class PackageNode extends Node {
             this.parent.refresh();
         } else if(cmd === 'updatePackage'){
             const success = await this.rHelp.packageManager.installPackages([this.pkg.name]);
-            // only refresh if user confirmed removing the package (success === true)
-            // might still refresh if removing was attempted but failed
+            // only reinstall if user confirmed removing the package (success === true)
+            // might still refresh if install was attempted but failed
             if(success){
                 this.parent.refresh(true);
             }

--- a/src/rHelpTree.ts
+++ b/src/rHelpTree.ts
@@ -19,6 +19,7 @@ const nodeCommands = {
     removeFromFavorites: 'r.helpPanel.removeFromFavorites',
     addToFavorites: 'r.helpPanel.addToFavorites',
     removePackage: 'r.helpPanel.removePackage',
+    updatePackage: 'r.helpPanel.updatePackage',
     showOnlyFavorites: 'r.helpPanel.showOnlyFavorites',
     showAllPackages: 'r.helpPanel.showAllPackages',
     filterPackages: 'r.helpPanel.filterPackages',
@@ -423,7 +424,7 @@ class PackageNode extends Node {
     // TreeItem
     public command = undefined;
     public collapsibleState = CollapsibleState.Collapsed;
-    public contextValue = Node.makeContextValue('QUICKPICK', 'clearCache', 'removePackage');
+    public contextValue = Node.makeContextValue('QUICKPICK', 'clearCache', 'removePackage', 'updatePackage');
 
     // Node
     public parent: PkgRootNode;
@@ -461,6 +462,13 @@ class PackageNode extends Node {
         } else if(cmd === 'removeFromFavorites'){
             this.rHelp.packageManager.removeFavorite(this.pkg.name);
             this.parent.refresh();
+        } else if(cmd === 'updatePackage'){
+            const success = await this.rHelp.packageManager.installPackages([this.pkg.name]);
+            // only refresh if user confirmed removing the package (success === true)
+            // might still refresh if removing was attempted but failed
+            if(success){
+                this.parent.refresh(true);
+            }
         } else if(cmd === 'removePackage'){
             const success = await this.rHelp.packageManager.removePackage(this.pkg.name);
             // only refresh if user confirmed removing the package (success === true)

--- a/src/rHelpTree.ts
+++ b/src/rHelpTree.ts
@@ -25,7 +25,8 @@ const nodeCommands = {
     filterPackages: 'r.helpPanel.filterPackages',
     summarizeTopics: 'r.helpPanel.summarizeTopics',
     unsummarizeTopics: 'r.helpPanel.unsummarizeTopics',
-    installPackages: 'r.helpPanel.installPackages'
+    installPackages: 'r.helpPanel.installPackages',
+    updateInstalledPackages: 'r.helpPanel.updateInstalledPackages'
 };
 
 // used to avoid typos when handling commands
@@ -312,6 +313,7 @@ class RootNode extends MetaNode {
             new Search2Node(this),
             new RefreshNode(this),
             new InstallPackageNode(this),
+            // new UpdatePackagesNode(this),
             this.pkgRootNode,
         ];
     }
@@ -576,6 +578,19 @@ class RefreshNode extends MetaNode {
     }
 }
 
+class UpdatePackagesNode extends MetaNode {
+    parent: RootNode;
+    label = 'Update all Packages';
+    iconPath = new vscode.ThemeIcon('versions');
+    
+    async callBack(){
+        const ret = await this.rHelp.packageManager.updatePackages();
+        if(ret){
+            this.rootNode.pkgRootNode.refresh(true);
+        }
+    }
+}
+
 // class NewHelpPanelNode extends MetaNode {
 //     label = 'Make New Helppanel';
 //     description = '(Opened with next help command)';
@@ -590,11 +605,16 @@ class InstallPackageNode extends MetaNode {
     label = 'Install CRAN Package';
     iconPath = new vscode.ThemeIcon('cloud-download');
 
-    contextValue = Node.makeContextValue('installPackages');
+    contextValue = Node.makeContextValue('installPackages', 'updateInstalledPackages');
 
     public async _handleCommand(cmd: cmdName){
         if(cmd === 'installPackages'){
             const ret = await this.rHelp.packageManager.pickAndInstallPackages(true);
+            if(ret){
+                this.rootNode.pkgRootNode.refresh(true);
+            }
+        } else if(cmd === 'updateInstalledPackages'){
+            const ret = await this.rHelp.packageManager.updatePackages();
             if(ret){
                 this.rootNode.pkgRootNode.refresh(true);
             }


### PR DESCRIPTION
**What problem did you solve?**
#529 

**How can I check this pull request?**
This PR adds a command `Update/reinstall package` to the package tree view that reinstalls/updates the package. This is done by a simple call to `install.packages('PKG_NAME')` and does not check if the package is installed from CRAN and does not compare versions.