### PR TITLE
add sendToConsole to rstudioapi emulation

### DIFF
--- a/R/rstudioapi.R
+++ b/R/rstudioapi.R
@@ -240,6 +240,19 @@ versionInfo <- function() {
         release_name = "vscode"
     )
 }
+
+sendToConsole <- function(code, execute = TRUE, echo = TRUE, focus = FALSE) {
+    if (!execute || !echo) {
+          stop("rstudioapi::sendToConsole only supports execute = TRUE and echo = TRUE in VSCode.")
+      }
+
+    code_to_run <- paste0(code, collapse = "\n")
+    invisible(
+        rstudioapi_call("send_to_console", code = code_to_run, focus = focus)
+    )
+}
+
+
 # Unimplemented API calls that will error if called.
 
 .vsc_not_yet_implemented <- function(...) {
@@ -250,7 +263,6 @@ versionInfo <- function() {
 getConsoleEditorContext <- .vsc_not_yet_implemented
 sourceMarkers <- .vsc_not_yet_implemented
 documentClose <- .vsc_not_yet_implemented
-sendToConsole <- .vsc_not_yet_implemented
 showPrompt <- .vsc_not_yet_implemented
 showQuestion <- .vsc_not_yet_implemented
 updateDialog <- .vsc_not_yet_implemented

--- a/src/rstudioapi.ts
+++ b/src/rstudioapi.ts
@@ -13,7 +13,7 @@ import {
 import { sessionDir, sessionDirectoryExists, writeResponse, writeSuccessResponse } from './session';
 import fs = require('fs-extra');
 import path = require('path');
-import { runTextInTerm, restartRTerminal } from './rTerminal';
+import { runTextInTerm, restartRTerminal, chooseTerminal } from './rTerminal';
 import { config } from './util';
 
 let lastActiveTextEditor: TextEditor;
@@ -75,6 +75,11 @@ export async function dispatchRStudioAPICall(action: string, args: any, sd: stri
     }
     case 'restart_r': {
       await restartRTerminal();
+      await writeSuccessResponse(sd);
+      break;
+    }
+    case 'send_to_console': {
+      await sendCodeToRTerminal(args.code, args.focus);
       await writeSuccessResponse(sd);
       break;
     }
@@ -331,6 +336,15 @@ export async function launchAddinPicker(): Promise<void> {
 
   if (!(typeof addinSelection === 'undefined')) {
     await runTextInTerm(addinSelection.package + ':::' + addinSelection.binding + '()');
+  }
+}
+
+export async function sendCodeToRTerminal(code: string, focus: boolean) {
+  console.info(`[sendCodeToRTerminal] inserting code: ${code}`);
+  await runTextInTerm(code);
+  if (focus) {
+    const rTerm = await chooseTerminal();
+    rTerm.show();
   }
 }
 


### PR DESCRIPTION
**What problem did you solve?**

Adds support for [`rstudioapi::sendToConsole`](https://rstudio.github.io/rstudioapi/reference/sendToConsole.html) to VSCode.

Previously I had thought that this was probably not needed, but now it's attractive to support: https://github.com/MilesMcBain/breakerofchains.

The function is a bit more limited than the RStudio version since we can't easily implement the `execute = FALSE` and `echo = FALSE` options (sending to terminal without running or terminal session without echoing). The function errors with informative message if `TRUE` is supplied for these args.

**(If you do not have screenshot) How can I check this pull request?**

Try the following code:

```r
rstudioapi::sendToConsole("version")
rstudioapi::sendToConsole("version", focus = TRUE)
rstudioapi::sendToConsole("version", execute = FALSE) #error
rstudioapi::sendToConsole("version", echo = FALSE) #error
rstudioapi::sendToConsole(c(      
    "library(dplyr)",
      "mtcars %>%",
      "summary()",
      "",
      "starwars %>%",
      "group_by(species, sex) %>%",
      "select(height, mass) %>%",
      "summarise(",
      "height = mean(height, na.rm = TRUE),",
      "mass = mean(mass, na.rm = TRUE))"))
```
