### PR TITLE
Change workspace tooltip

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -43,7 +43,10 @@ if (interactive() &&
         format.default(Sys.time(), nsmall = 6)
       }
 
-      unbox <- jsonlite::unbox
+      scalar <- function(x) {
+        class(x) <- c("scalar", class(x))
+        x
+      }
 
       request <- function(command, ...) {
         obj <- list(
@@ -90,26 +93,26 @@ if (interactive() &&
           if (is_promise[[name]]) {
             info <- list(
               class = "promise",
-              type = unbox("promise"),
-              length = unbox(0L),
-              str = unbox("(promise)")
+              type = scalar("promise"),
+              length = scalar(0L),
+              str = scalar("(promise)")
             )
           } else if (is_active[[name]]) {
             info <- list(
               class = "active_binding",
-              type = unbox("active_binding"),
-              length = unbox(0L),
-              str = unbox("(active-binding)")
+              type = scalar("active_binding"),
+              length = scalar(0L),
+              str = scalar("(active-binding)")
             )
           } else {
             obj <- env[[name]]
             str <- capture_str(obj)[[1L]]
             info <- list(
               class = class(obj),
-              type = unbox(typeof(obj)),
-              length = unbox(length(obj)),
-              str = unbox(trimws(str)),
-              size = as.integer(object.size(obj))
+              type = scalar(typeof(obj)),
+              length = scalar(length(obj)),
+              str = scalar(trimws(str)),
+              size = scalar(unclass(object.size(obj)))
             )
             if ((is.list(obj) ||
               is.environment(obj)) &&
@@ -143,7 +146,7 @@ if (interactive() &&
         update_globalenv <- function(...) {
           tryCatch({
             objs <- inspect_env(.GlobalEnv)
-            jsonlite::write_json(objs, globalenv_file, pretty = FALSE)
+            jsonlite::write_json(objs, globalenv_file, force = TRUE, pretty = FALSE)
             cat(get_timestamp(), file = globalenv_lock_file)
           }, error = message)
           TRUE
@@ -296,9 +299,9 @@ if (interactive() &&
           }
           columns <- .mapply(function(title, type) {
             class <- if (type == "string") "text-left" else "text-right"
-            list(title = unbox(title),
-              className = unbox(class),
-              type = unbox(type))
+            list(title = scalar(title),
+              className = scalar(class),
+              type = scalar(type))
           }, list(colnames, types), NULL)
           list(columns = columns, data = data)
         }

--- a/R/init.R
+++ b/R/init.R
@@ -108,7 +108,8 @@ if (interactive() &&
               class = class(obj),
               type = unbox(typeof(obj)),
               length = unbox(length(obj)),
-              str = unbox(trimws(str))
+              str = unbox(trimws(str)),
+              size = as.integer(object.size(obj))
             )
             if ((is.list(obj) ||
               is.environment(obj)) &&

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -8,8 +8,8 @@ interface WorkspaceAttr {
     [key: string]: {
         class: string[];
         type: string;
-        length: number;
 		str: string;
+		size?: number;
 		dim?: number[]
     }
 }
@@ -39,7 +39,7 @@ export class WorkspaceDataProvider implements TreeDataProvider<WorkspaceItem> {
 			rClass: string,
 			str: string,
 			type: string,
-			length: number,
+			size?: number,
 			dim?: number[]
 		): WorkspaceItem => {
 			return new WorkspaceItem(
@@ -47,7 +47,7 @@ export class WorkspaceDataProvider implements TreeDataProvider<WorkspaceItem> {
 				rClass,
 				str,
 				type,
-				length,
+				size,
 				TreeItemCollapsibleState.None,
 				dim,
 			);
@@ -59,7 +59,7 @@ export class WorkspaceDataProvider implements TreeDataProvider<WorkspaceItem> {
 				data[key].class[0],
 				data[key].str,
 				data[key].type,
-				data[key].length,
+				data[key].size,
 				data[key].dim,
 			)) : [];
 
@@ -89,13 +89,13 @@ export class WorkspaceItem extends TreeItem {
 		rClass: string,
 		str: string,
 		type: string,
-		length: number,
+		size: number,
 		collapsibleState: TreeItemCollapsibleState,
 		dim?: number[]
 	) {
 		super(label, collapsibleState);
 		this.description = this.getDescription(dim, str, rClass);
-		this.tooltip = `${label} (${rClass}, length of ${length})`;
+		this.tooltip = this.getTooltip(label, rClass, size);
 		this.contextValue = type;
 	}
 
@@ -108,6 +108,13 @@ export class WorkspaceItem extends TreeItem {
 			}
 		} else {
 			return str;
+		}
+	}
+	private getTooltip(label:string, rClass: string, size: number): string {
+		if (size !== undefined) {
+			return `${label} (${rClass}, ${size} bytes)`;
+		} else {
+			return `${label} (${rClass})`;
 		}
 	}
 }


### PR DESCRIPTION
Change workspace tooltip from showing length (e.g. length of 5) to showing size in bytes. does not apply to active-bindings or promises

**What problem did you solve?**
At the moment, the workspace viewer tooltip shows the length of a given object. This is a little redundant given that this can be inferred from the object description (e.g. `data.frame: 32 obs. of 11 variables`). 

As a result, this PR changes the tooltip to show the memory size of the object when possible, bringing the workspace viewer closer in behaviour to RStudio's environment pane. Object sizes are returned for all variables, barring promises and active-bindings. 

One difference between the PR and RStudio's environment pane is that the environment pane does not show sizes for numeric lists (e.g. `x <- 1:5`), whereas this PR does. 

**Screenshot**
*VScode-R*
![image](https://user-images.githubusercontent.com/60372411/106449066-7d3f7d80-647b-11eb-98a6-22dfeae04268.png)

*RStudio*
![image](https://user-images.githubusercontent.com/60372411/106449157-92b4a780-647b-11eb-804a-f10e47dec09b.png)

**(If you do not have screenshot) How can I check this pull request?**

Object sizes should be shown in bytes for all eligible object types