### PR TITLE
add option vsc.hover.str.max.level

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -59,8 +59,15 @@ if (interactive() &&
       }
 
       capture_str <- function(object) {
-        utils::capture.output(
-          utils::str(object, max.level = 0, give.attr = FALSE)
+        paste0(
+          utils::capture.output(
+            utils::str(object,
+              max.level = getOption("vsc.hover.str.max.level", 0),
+              give.attr = FALSE,
+              vec.len = 1
+            )
+          ),
+          collapse = "\n"
         )
       }
 

--- a/R/init.R
+++ b/R/init.R
@@ -62,7 +62,7 @@ if (interactive() &&
         paste0(
           utils::capture.output(
             utils::str(object,
-              max.level = getOption("vsc.hover.str.max.level", 0),
+              max.level = getOption("vsc.str.max.level", 0),
               give.attr = FALSE,
               vec.len = 1
             )

--- a/README.md
+++ b/README.md
@@ -224,6 +224,11 @@ options(vsc.view = "Two" | "Active" | "Beside" | FALSE)
 # (e.g. after sending `?mean` to terminal)?
 # Use FALSE to disable help panel and revert to old behaviour.
 options(vsc.helpPanel = "Two" | "Active" | "Beside" | FALSE)
+
+# How much of the object to show on hover? As controlled by max.level arg of str().
+# Use 0 (or 1) is the default - literal value or object type and dimensions
+# Use 2 to show list contents, data frame columns, and example values.
+options(vsc.hover.str.max.level = 0 | 2 )
 ```
 
 The first values are the default and all subsequent values after `|` are available choices.

--- a/README.md
+++ b/README.md
@@ -225,10 +225,11 @@ options(vsc.view = "Two" | "Active" | "Beside" | FALSE)
 # Use FALSE to disable help panel and revert to old behaviour.
 options(vsc.helpPanel = "Two" | "Active" | "Beside" | FALSE)
 
-# How much of the object to show on hover? As controlled by max.level arg of str().
+# How much of the object to show on hover and autocomplete detail? 
+# As controlled by max.level arg of str().
 # Use 0 (or 1) is the default - literal value or object type and dimensions
 # Use 2 to show list contents, data frame columns, and example values.
-options(vsc.hover.str.max.level = 0 | 2 )
+options(vsc.str.max.level = 0 | 2 )
 ```
 
 The first values are the default and all subsequent values after `|` are available choices.


### PR DESCRIPTION
**What problem did you solve?**

Added an option, `vsc.hover.str.max.level`, that configures how R objects hover information is displayed. This is the `max.level` arg in the `str` call in `capture_str` in `init.R`. It was previously set to `0` which just captured type/dimension info for data frames.

Now the user can configure it to show more info for data frames, e.g. `vsc.hover.str.max.level = 2`:

![df_preview](https://user-images.githubusercontent.com/9996346/106454689-de486f00-64d6-11eb-9c63-c08e05cc2f09.png)

**(If you do not have screenshot) How can I check this pull request?**

Try this example code with  `vsc.hover.str.max.level = 0` and  `vsc.hover.str.max.level = 2` Hover over the variables and notice the improved info, without becoming overly large:

```r

library(nycflights13)

foo <- flights

bar <- airports

biz <- letters

baz <- as.list(letters)

var <- list(first = "a", 
            second = "b",
            third = list("c", list("d")))

```

Note I also added the `vec.len = 1` arg into the `str` call. It has no effect at the default level.

