### PR TITLE
Fix get_timestamp() so that it will not be affected by e.g. options(digits=3)

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -40,7 +40,7 @@ if (interactive() &&
       }
 
       get_timestamp <- function() {
-        format.default(Sys.time(), nsmall = 6)
+        format.default(Sys.time(), nsmall = 6, scientific = FALSE)
       }
 
       scalar <- function(x) {


### PR DESCRIPTION
**What problem did you solve?**

Close #549 

This PR fixes `get_timestamp()` by using `scientific = FALSE` so that if user sets `options(digits=3)` the timestamp will not be converted to scientific form to be smaller than previous timestamps.

**(If you do not have screenshot) How can I check this pull request?**

The following code should correctly trigger webview now:

```r
help("getwd") # webview works and close the tab
options(digits = 3)
help("getwd") # webview works and close the tab
help("getwd") # webview works and close the tab
options(digits = 7)
help("getwd") # webview works and close the tab
```
