### PR TITLE
Scroll to bottom after running a command

### DIFF
--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -260,7 +260,7 @@ export async function runTextInTerm(text: string): Promise<void> {
     }
     setFocus(term);
     // Scroll console to see latest output
-    await vscode.commands.executeCommand("workbench.action.terminal.scrollToBottom");
+    await vscode.commands.executeCommand('workbench.action.terminal.scrollToBottom');
 }
 
 function setFocus(term: vscode.Terminal) {

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -259,6 +259,8 @@ export async function runTextInTerm(text: string): Promise<void> {
         }
     }
     setFocus(term);
+    // Scroll console to see latest output
+    await vscode.commands.executeCommand("workbench.action.terminal.scrollToBottom");
 }
 
 function setFocus(term: vscode.Terminal) {


### PR DESCRIPTION
**Problem Description**
Run some codes in R Integrated Terminal and scroll up so that you can't see the bottom. Run another R code chunk in the editor window, and the R Integrated Terminal window does not move to show the latest execution result. The same problem has already been [solved](https://github.com/PowerShell/vscode-powershell/issues/1257#issuecomment-403311905) for vscode-powershell extension, and a single line of code seems to solve this problem. 

If you think this is useful, please set it as default. Alternatively, we can add a setting (a toggle switch) so people can choose the R terminal scroll behavior.