### PR TITLE
Add option to keep terminal hidden after running code

### DIFF
--- a/package.json
+++ b/package.json
@@ -958,7 +958,7 @@
             "terminal",
             "none"
           ],
-          "description": "Keeping focus when running."
+          "description": "What to show/focus after running code. Set to 'editor' or 'terminal' to show the terminal. Set to 'none' to not show the terminal."
         },
         "r.alwaysUseActiveTerminal": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -955,7 +955,8 @@
           "default": "editor",
           "enum": [
             "editor",
-            "terminal"
+            "terminal",
+            "none"
           ],
           "description": "Keeping focus when running."
         },

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -265,5 +265,7 @@ export async function runTextInTerm(text: string): Promise<void> {
 
 function setFocus(term: vscode.Terminal) {
     const focus: string = config().get('source.focus');
-    term.show(focus !== 'terminal');
+    if (focus !== 'none') {
+        term.show(focus !== 'terminal');
+    }
 }


### PR DESCRIPTION
Closes #510 

**What problem did you solve?**

This PR adds an option 'none' to `r.source.focus` to keep the terminal hidden after sending code to the terminal.

**How can I check this pull request?**

With session watcher on.

1. Add this line to `settings.json`:

```json
    "r.source.focus": "none"
```

2. Run command `R: Create R terminal`
3. Hide the terminal by clicking the X at the top right
4. In a file 'temp.R', write this code and send it to the terminal: `plot(1, 1)`
5. Observe that the plot window appears (so the code was executed), but the terminal stays hidden

**Note**

I believe `r.source.focus` is the right setting for this option, but I am concerned that the difference between the options 'editor' and 'none' is not obvious. I have updated the description with this in mind so please check whether you think it is clear enough.