### PR TITLE
Fix so code can be run after creating terminal 

### DIFF
--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -206,11 +206,8 @@ export async function chooseTerminal(): Promise<vscode.Terminal> {
     }
 
     if (rTerm === undefined) {
-        const success = await createRTerm(true);
+        await createRTerm(true);
         await delay(200); // Let RTerm warm up
-        if (!success) {
-            return undefined;
-        }
     }
 
     return rTerm;

--- a/src/rstudioapi.ts
+++ b/src/rstudioapi.ts
@@ -344,7 +344,9 @@ export async function sendCodeToRTerminal(code: string, focus: boolean) {
   await runTextInTerm(code);
   if (focus) {
     const rTerm = await chooseTerminal();
-    rTerm.show();
+    if (rTerm !== undefined) {
+      rTerm.show();
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #563 

Fixes #483 

**What problem did you solve?**

Trying to create a terminal and run code at the same time results in a new terminal but does not run the code. The user has to run the command again to send the code to the terminal. This PR fixes that.

The problem was that even when terminal was successfully created, `success` was `undefined` and so `chooseTerminal` would always return `undefined`. Since failure to create a terminal should result in `rTerm` being `undefined` anyway, it should be safe to remove `success` and always return `rTerm`.

**How can I check this pull request?**

1. Create a file `temp.R` containing the code `x <- 1`
1. Disable setting `R: Always Use Active Terminal`
1. Run command `R: Run Selection/Line`. Observe that a new R terminal is created and that `x <- 1` is sent to that terminal
1. Close the R terminal by clicking the trash icon
1. Run command `R: Run Source`. Observe that a new a new R terminal is created and that `source(...)` is sent to that terminal
1. Close the R terminal by clicking the trash icon
1. Check that it still fails gracefully if there is a problem creating the terminal:
    1. Change setting `R: Rterm Linux/Mac/Windows` to a nonsense path like 'abc'
    2. Run command `R: Run Selection/Line`. Observe appropriate error message 'Cannot find R client ...'

**Note**

This is the output I get when using `R: Run Selection/Line`. Note the doubled `x <- 1`. I could avoid that by increasing the delay amount but the amount required is presumably going to vary according to how fast the user's PC is. I've left it as-is for now. We could add a setting if it bothers people.

```
Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

x <- 1
> x <- 1
> 
```