### PR TITLE
Move `r.runSource` and `r.knitRmd` to `editor/title/run` (Fix #572)

### DIFF
--- a/package.json
+++ b/package.json
@@ -680,17 +680,18 @@
       }
     ],
     "menus": {
-      "editor/title": [
+      "editor/title/run": [
         {
           "when": "editorLangId == r",
-          "command": "r.runSource",
-          "group": "navigation"
+          "command": "r.runSource"
         },
         {
           "when": "editorLangId == rmd",
           "command": "r.knitRmd",
           "group": "navigation"
-        },
+        }
+      ],
+      "editor/title": [
         {
           "command": "r.browser.refresh",
           "when": "resourceScheme =~ /webview/ && r.browser.active",


### PR DESCRIPTION
**What problem did you solve?**

Fix #572
This change has no impact for the current behavior.