### PR TITLE
Add links to help pages in hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -615,6 +615,11 @@
         "title": "Open help for selection",
         "category": "R",
         "command": "r.helpPanel.openForSelection"
+      },
+      {
+        "title": "Open help for path",
+        "category": "R",
+        "command": "r.helpPanel.openForPath"
       }
     ],
     "keybindings": [
@@ -944,6 +949,11 @@
           "markdownDescription": "DEPRECATED! Path to an R executable. Must be \"vanilla\" R, not radian etc.! Will be read from registry or path if not set.",
           "markdownDeprecationMessage": "Will be deprecated. Use `#r.rpath.windows#`, `#r.rpath.mac#`, or `#r.rpath.linux#` instead.",
           "deprecationMessage": "Will be deprecated. Use r.rpath.windows, r.rpath.mac, or r.rpath.linux instead."
+        },
+        "r.helpPanel.enableHoverLinks": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show links to matching help pages in hover"
         },
         "r.source.encoding": {
           "type": "string",

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -10,6 +10,8 @@ import * as vscode from 'vscode';
 import * as session from './session';
 import { extendSelection } from './selection';
 import { cleanLine } from './lineCache';
+import { globalRHelp } from './extension';
+import { config } from './util';
 
 
 // Get with names(roxygen2:::default_tags())
@@ -33,6 +35,30 @@ export class HoverProvider implements vscode.HoverProvider {
         return new vscode.Hover(`\`\`\`\n${session.globalenv[text].str}\n\`\`\``);
     }
 }
+
+export class HelpLinkHoverProvider implements vscode.HoverProvider {
+    async provideHover(document: vscode.TextDocument, position: vscode.Position): Promise<vscode.Hover> {
+        if(!config().get<boolean>('helpPanel.enableHoverLinks')){
+            return null;
+        }
+        const re = /([a-zA-Z0-9._:])+/;
+        const wordRange = document.getWordRangeAtPosition(position, re);
+        const token = document.getText(wordRange);
+        const aliases = await globalRHelp?.getMatchingAliases(token) || [];
+        const mds = aliases.map(a => {
+            const cmdText = `${a.package}::${a.name}`;
+            const args = [`/library/${a.package}/html/${a.alias}.html`];
+            const encodedArgs = encodeURIComponent(JSON.stringify(args));
+            const cmd = 'command:r.helpPanel.openForPath';
+            const cmdUri = vscode.Uri.parse(`${cmd}?${encodedArgs}`);
+            return `[${cmdText}](${cmdUri})`;
+        });
+        const md = new vscode.MarkdownString(mds.join('\n\n'));
+        md.isTrusted = true;
+        return new vscode.Hover(md, wordRange);        
+    }
+}
+
 
 export class StaticCompletionItemProvider implements vscode.CompletionItemProvider {
     provideCompletionItems(document: vscode.TextDocument, position: vscode.Position): vscode.CompletionItem[] | undefined {

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -51,9 +51,9 @@ export class HelpLinkHoverProvider implements vscode.HoverProvider {
             const encodedArgs = encodeURIComponent(JSON.stringify(args));
             const cmd = 'command:r.helpPanel.openForPath';
             const cmdUri = vscode.Uri.parse(`${cmd}?${encodedArgs}`);
-            return `[${cmdText}](${cmdUri})`;
+            return `[\`${cmdText}\`](${cmdUri})`;
         });
-        const md = new vscode.MarkdownString(mds.join('\n\n'));
+        const md = new vscode.MarkdownString(mds.join('  \n'));
         md.isTrusted = true;
         return new vscode.Hover(md, wordRange);        
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,6 +132,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
     // register (session) hover and completion providers
     vscode.languages.registerHoverProvider('r', new completions.HoverProvider());
+    vscode.languages.registerHoverProvider('r', new completions.HelpLinkHoverProvider());
     vscode.languages.registerCompletionItemProvider('r', new completions.StaticCompletionItemProvider(), '@');
 
 


### PR DESCRIPTION
**What problem did you solve?**
This PR adds a hover provider that that shows links to matching help pages when hovering over names of R functions.

**How can I check this pull request?**
Hover over the name of a (documented) R function, wait for hover to show up and check if a link to a help page shows up.

**Limitations:**
On my machine the link shows up below other hovers, which can be a bit cumbersome if a large help page is shown e.g. by the languageserver.
The hover can be a bit eager, e.g. showing `dplyr::n` when hovering over a single `n`. This would be rather hard to solve properly, since the hover is unaware of any tokenization or other languageserver functions. If this is too annoying, the hover can be disabled completely using `r.helpPanel.enableHoverLinks = false`