### PR TITLE
Provide help links in CodeActions

### DIFF
--- a/package.json
+++ b/package.json
@@ -951,10 +951,15 @@
           "markdownDeprecationMessage": "Will be deprecated. Use `#r.rpath.windows#`, `#r.rpath.mac#`, or `#r.rpath.linux#` instead.",
           "deprecationMessage": "Will be deprecated. Use r.rpath.windows, r.rpath.mac, or r.rpath.linux instead."
         },
-        "r.helpPanel.enableHoverLinks": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Show links to matching help pages in hover"
+        "r.helpPanel.showHelpLinks": {
+          "type": "string",
+          "default": "hover",
+          "enum": [
+            "hover",
+            "codeActions",
+            "none"
+          ],
+          "description": "Where to show links to matching help pages in editor."
         },
         "r.source.encoding": {
           "type": "string",

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -12,7 +12,6 @@ import { extendSelection } from './selection';
 import { cleanLine } from './lineCache';
 import { globalRHelp } from './extension';
 import { config } from './util';
-import { activeEditorContext } from './rstudioapi';
 
 
 // Get with names(roxygen2:::default_tags())

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,6 +132,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
     // register (session) hover and completion providers
     vscode.languages.registerHoverProvider('r', new completions.HoverProvider());
+    vscode.languages.registerHoverProvider('r', new completions.HelpLinkHoverProvider());
     vscode.languages.registerCodeActionsProvider('r', new completions.HelpLinkCodeActionProvider());
     vscode.languages.registerCompletionItemProvider('r', new completions.StaticCompletionItemProvider(), '@');
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,7 +132,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
     // register (session) hover and completion providers
     vscode.languages.registerHoverProvider('r', new completions.HoverProvider());
-    vscode.languages.registerHoverProvider('r', new completions.HelpLinkHoverProvider());
+    vscode.languages.registerCodeActionsProvider('r', new completions.HelpLinkCodeActionProvider());
     vscode.languages.registerCompletionItemProvider('r', new completions.StaticCompletionItemProvider(), '@');
 
 


### PR DESCRIPTION
**What problem did you solve?**

This PR moves the help links provided in hover (#578) to CodeActions so that they appear more clearly, especially along with languageserver which already shows help documentation in hover.

An added value of this is that user could use keyboard only to move cursor around and press a shortcut key (e.g. cmd+.) to show the CodeActions menu and choose the action, in this case, show help for a particular function.

**(If you have)Screenshot**

![image](https://user-images.githubusercontent.com/4662568/111030548-dcf75400-843d-11eb-9214-62a22e4a134a.png)

**(If you do not have screenshot) How can I check this pull request?**

* Type some code and move cursor to a token, a lightbulb will show near the token.
* Click the lightbulb and all aliases are listed.
* Click one aliases and the help viewer will show up.