### PR TITLE
Initial Workspace Viewer str() functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -747,12 +747,12 @@
         {
           "command": "r.workspaceViewer.view",
           "group": "inline",
-          "when": "view == workspaceViewer"
+          "when": "view == workspaceViewer && viewItem == rootNode"
         },
         {
           "command": "r.workspaceViewer.remove",
           "group": "inline",
-          "when": "view == workspaceViewer"
+          "when": "view == workspaceViewer && viewItem == rootNode"
         },
         {
           "command": "r.helpPanel.searchPackage",

--- a/src/workspaceViewer.ts
+++ b/src/workspaceViewer.ts
@@ -29,8 +29,25 @@ export class WorkspaceDataProvider implements TreeDataProvider<WorkspaceItem> {
 		return element;
 	}
 
-	getChildren(): WorkspaceItem[] {
-		return this.getWorkspaceItems(this.data);
+	getChildren(element?: WorkspaceItem): WorkspaceItem[] {
+		if (element) {
+			return element.str
+				.split('\n')
+				.filter((elem, index) => {return index > 0;})
+				.map(strItem => 
+					new WorkspaceItem(
+						'', 
+						'', 
+						strItem.replace(/\s+/g,' ').trim(), 
+						'', 
+						0, 
+						element.treeLevel + 1
+					)
+				);
+		} else {
+			return this.getWorkspaceItems(this.data);
+		}
+
 	}
 
 	private getWorkspaceItems(data: WorkspaceAttr): WorkspaceItem[] {
@@ -48,7 +65,7 @@ export class WorkspaceDataProvider implements TreeDataProvider<WorkspaceItem> {
 				str,
 				type,
 				size,
-				TreeItemCollapsibleState.None,
+				0,
 				dim,
 			);
 		};
@@ -83,20 +100,28 @@ export class WorkspaceDataProvider implements TreeDataProvider<WorkspaceItem> {
 }
 
 export class WorkspaceItem extends TreeItem {
-	public label: string;
+	label: string;
+	desc: string;
+	str: string;
+	treeLevel: number;
+	contextValue: string;
+
 	constructor(
 		label: string,
 		rClass: string,
 		str: string,
 		type: string,
 		size: number,
-		collapsibleState: TreeItemCollapsibleState,
-		dim?: number[]
+		treeLevel: number,
+		dim?: number[],
 	) {
-		super(label, collapsibleState);
+		super(label, WorkspaceItem.setCollapsibleState(treeLevel, type, str));
 		this.description = this.getDescription(dim, str, rClass);
-		this.tooltip = this.getTooltip(label, rClass, size);
+		this.tooltip = this.getTooltip(label, rClass, size, treeLevel);
 		this.contextValue = type;
+		this.str = str;
+		this.treeLevel = treeLevel;
+		this.contextValue = treeLevel === 0 ? 'rootNode' : `childNode${treeLevel}`;
 	}
 
 	private getDescription(dim: number[], str: string, rClass: string): string {
@@ -110,12 +135,29 @@ export class WorkspaceItem extends TreeItem {
 			return str;
 		}
 	}
-	private getTooltip(label:string, rClass: string, size: number): string {
-		if (size !== undefined) {
+	private getTooltip(label:string, rClass: string, 
+				size: number, treeLevel: number): string {
+
+		if (size !== undefined && treeLevel === 0) {
 			return `${label} (${rClass}, ${size} bytes)`;
+		} else if (treeLevel === 1) {
+			return null;
 		} else {
 			return `${label} (${rClass})`;
 		}
+	}
+
+	/* This logic has to be implemented this way to allow it to be called
+	during the super constructor above. I created it to give full control
+	of what elements can have have 'child' nodes os not. It can be expanded
+	in the futere for more tree levels.*/
+
+	private static setCollapsibleState(treeLevel: number, type: string, str: string) { 
+		if (treeLevel === 0 && type === 'list' && str.includes('\n')){
+			return TreeItemCollapsibleState.Collapsed;
+		} else {
+			return TreeItemCollapsibleState.None;
+		} 
 	}
 }
 


### PR DESCRIPTION
**What problem did you solve?**

As stated in #577, the current workspace viewer displays a list of globalEnv objects without further detail. For lists and dataframes, would be nice to see a sub-list of its elements, like the function `str()` output. I've implemented this functionality taking advantage of the already implemented `.Rprofile` option for `src()`-like output on hover, `vsc.str.max.level = 0 | 1 | 2`

**Screenshot**

Take for example this code:

```
library(tidyverse)

my_list  <-  list(a = function(x) x, y = " small string", z = c(1, 2, 3))

my_tibble  <- tibble(x = c(1,2,4,5,5,5,5,5,5,5), 
                  y = c(2,2,2,2,2,2,2,7,8,9), 
                  z = rep("aaa\n", 10),
                  shrnm = rnorm(10),
                  really_long_variable_name = rnorm(10))                  

my_number  <-  123

my_string  <-  "lala \n lala"
```

**`vsc.str.max.level = 2`**

![image](https://user-images.githubusercontent.com/20959177/111666641-aaa97600-87f2-11eb-8f0b-6920cafcc3d6.png)

**`vsc.str.max.level = 1`**

![image](https://user-images.githubusercontent.com/20959177/111666720-bdbc4600-87f2-11eb-8d19-ae4293a67597.png)

**`vsc.str.max.level = 0` (as before)**

![image](https://user-images.githubusercontent.com/20959177/111666815-d75d8d80-87f2-11eb-9aa5-e72a42380282.png)

As far as I tested, it is robust to line breaks (`\n`); it won't show any tooltip or View/Remove buttons for the subitens (harder to implement that I expected); It will only show expandable icons (>) for objects of list type:
![image](https://user-images.githubusercontent.com/20959177/111667129-2a374500-87f3-11eb-8c2d-ea6fb7cc4e48.png)

Known issue: as it uses the same option for `str()` display on object hover, you can't set one option apart from the other. I decided to let it this way mainly because two reasons:

1) The option name `vsc.str.max.level` is generic enough to allow this and;

2) It would have required extra work to implement another option just for this, risking breaking something that is already working. I can't think of any concrete example of someone that would lika an complete `str()` on hover and none in the workspace, or vice-versa. Seemed to me an extra work for little return.