### PR TITLE
Clarify R path error messages

### DIFF
--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -127,7 +127,7 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
 
             return true;
         }
-        void vscode.window.showErrorMessage('Cannot find R client.  Please check R path in preferences and reload.');
+        void vscode.window.showErrorMessage(`Cannot find R client at ${termPath}. Please check r.rterm setting.`);
 
         return false;
     });

--- a/src/util.ts
+++ b/src/util.ts
@@ -80,7 +80,7 @@ export async function getRpath(quote=false, overwriteConfig?: string): Promise<s
 
     if(!rpath){
         // inform user about missing R path:
-        void vscode.window.showErrorMessage(`${process.platform} can't use R`);
+        void vscode.window.showErrorMessage(`Cannot find R to use for help, package installation etc. Change setting r.${configEntry} to R path.`);
     } else if(quote && /^[^'"].* .*[^'"]$/.exec(rpath)){
         // if requested and rpath contains spaces, add quotes:
         rpath = `"${rpath}"`;
@@ -93,17 +93,12 @@ export async function getRpath(quote=false, overwriteConfig?: string): Promise<s
 }
 
 export async function getRterm(): Promise<string|undefined> {
-    
-    let rpath = '';
-    const platform: string = process.platform;
-    
-    if ( platform === 'win32') {
-        rpath = config().get<string>('rterm.windows');
-    } else if (platform === 'darwin') {
-        rpath = config().get<string>('rterm.mac');
-    } else if (platform === 'linux') {
-        rpath = config().get<string>('rterm.linux');
-    }
+    const configEntry = (
+        process.platform === 'win32' ? 'rterm.windows' :
+        process.platform === 'darwin' ? 'rterm.mac' :
+        'rterm.linux'
+    );
+    let rpath = config().get<string>(configEntry);
 
     rpath ||= await getRpathFromSystem();
     
@@ -111,7 +106,7 @@ export async function getRterm(): Promise<string|undefined> {
         return rpath;
     }
 
-    void vscode.window.showErrorMessage(`${process.platform} can't use R`);
+    void vscode.window.showErrorMessage(`Cannot find R for creating R terminal. Change setting r.${configEntry} to R path.`);
     return undefined;
 }
 


### PR DESCRIPTION
Closes #568 

**What problem did you solve?**

Adds info to error messages when there are problems with the R path so that user knows what they need to do.

**How can I check this pull request?**

**Verify it doesn't break anything**
1. Run command `R: Create R terminal`
2. Observe that R terminal is created as expected

**Test error when specified R path doesn't exist**
1. Set `rterm` setting to a nonsense path (e.g., 'abc')
2. Run command `R: Create R terminal`
3. Observe error message that mentions `rterm`

These next two are slightly tricky to test because you have to intentionally create an error.

**Test `rpath` error**
1. Change line 79 of `util.ts` to `rpath = undefined`, so that an error will always occur
2. In R sidebar, use "Open Help Topic using '?'" and choose the top option
3. Observe error message that mentions `rpath`

**Test `rterm` error**
1. Change line 103 of `util.ts` to `rpath = ''`, so that error with always occur
2. Run command `R: Create R terminal`
3. Observe error message that mentions `rterm`