### PR TITLE
Refactor R code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,19 @@
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceRoot}/out/src/**/*.js"
+      ],
+      "preLaunchTask": "npm: compile"
+    },
+    {
+      "name": "Launch Extension (--disable-extensions)",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
         "--extensionDevelopmentPath=${workspaceFolder}",
         "--disable-extensions"
       ],

--- a/R/.Rprofile
+++ b/R/.Rprofile
@@ -28,7 +28,7 @@ local({
 # Run vscode initializer
 local({
   filePathInit <- Sys.getenv("VSCODE_INIT_R")
-  if(nzchar(filePathInit)){
+  if (nzchar(filePathInit)) {
     source(filePathInit, chdir = TRUE, local = TRUE)
   }
 })

--- a/R/.Rprofile
+++ b/R/.Rprofile
@@ -26,8 +26,8 @@ local({
 
 # Run vscode initializer
 local({
-  filePathInit <- Sys.getenv("VSCODE_INIT_R")
-  if (nzchar(filePathInit)) {
-    source(filePathInit, chdir = TRUE, local = TRUE)
+  init_file <- Sys.getenv("VSCODE_INIT_R")
+  if (nzchar(init_file)) {
+    source(init_file, chdir = TRUE, local = TRUE)
   }
 })

--- a/R/.Rprofile
+++ b/R/.Rprofile
@@ -1,3 +1,5 @@
+
+# Source the original .Rprofile
 local({
   try_source <- function(file) {
     if (file.exists(file)) {
@@ -23,9 +25,10 @@ local({
   invisible()
 })
 
-if (!exists(".vsc")) {
-  source(file.path(
-    Sys.getenv(if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"),
-    ".vscode-R", "init.R")
-  )
-}
+# Run vscode initializer
+local({
+  filePathInit <- Sys.getenv("VSCODE_INIT_R")
+  if(nzchar(filePathInit)){
+    source(filePathInit, chdir = TRUE, local = TRUE)
+  }
+})

--- a/R/.Rprofile
+++ b/R/.Rprofile
@@ -1,4 +1,3 @@
-
 # Source the original .Rprofile
 local({
   try_source <- function(file) {

--- a/R/init.R
+++ b/R/init.R
@@ -36,13 +36,14 @@ initFirst <- function() {
   }
 }
 
+old.First.sys <- .First.sys
 
 # Overwrite for `.First.sys`
 # Is used to make sure that all default packages are loaded first
 # Will be assigned to and called from the global environment,
 # Will be run with wd being the user's working directory (!)
 initLast <- function() {
-  base::.First.sys()
+  old.First.sys()
 
   # cleanup previous version
   removeTaskCallback("vscode-R")
@@ -103,7 +104,7 @@ initLast <- function() {
   # Attach to vscode
   exports$.vsc.attach()
 
-  invisible(NULL)
+  invisible()
 }
 
 initFirst()

--- a/R/init.R
+++ b/R/init.R
@@ -13,10 +13,10 @@ initFirst <- function() {
     !interactive()
     || Sys.getenv("RSTUDIO") != ""
     || Sys.getenv("TERM_PROGRAM") != "vscode"
-  ){
+  ) {
     return()
   }
-  
+
   # check requried packages
   required_packages <- c("jsonlite", "rlang")
   missing_packages <- required_packages[
@@ -66,7 +66,7 @@ initLast <- function() {
     .vsc.page_viewer <- .vsc$show_page_viewer
 
     # assign functions that are optional:
-    for(funcName in c("View", ".External.graphics")) {
+    for (funcName in c("View", ".External.graphics")) {
       if (funcName %in% ls(.vsc)) {
         assign(funcName, .vsc[[funcName]])
       }
@@ -77,7 +77,7 @@ initLast <- function() {
 
   # overwrite S3 bindings from other packages
   suppressWarnings({
-    if(!identical(getOption("vsc.helpPanel", "Two"), FALSE)) {
+    if (!identical(getOption("vsc.helpPanel", "Two"), FALSE)) {
       # Overwrite print function for results of `?`
       .vsc$.S3method(
         "print",

--- a/R/init.R
+++ b/R/init.R
@@ -1,13 +1,12 @@
-
 # This file is executed with its containing directory as wd
 
-# Remember absolute path of vsc.R
+# Remember the working directory (should be extension subfolder that contains this script)
 dir_init <- getwd()
 
 
 # This function is run at the beginning of R's startup sequence
-# Code that is meant to be run at the end of the startup should go in `initLast`
-initFirst <- function() {
+# Code that is meant to be run at the end of the startup should go in `init_last`
+init_first <- function() {
   # return early if not a vscode term session
   if (
     !interactive()
@@ -32,7 +31,7 @@ initFirst <- function() {
     )
   } else {
     # Initialize vsc utils after loading other default packages
-    assign(".First.sys", initLast, envir = globalenv())
+    assign(".First.sys", init_last, envir = globalenv())
   }
 }
 
@@ -42,7 +41,7 @@ old.First.sys <- .First.sys
 # Is used to make sure that all default packages are loaded first
 # Will be assigned to and called from the global environment,
 # Will be run with wd being the user's working directory (!)
-initLast <- function() {
+init_last <- function() {
   old.First.sys()
 
   # cleanup previous version
@@ -107,4 +106,4 @@ initLast <- function() {
   invisible()
 }
 
-initFirst()
+init_first()

--- a/R/init.R
+++ b/R/init.R
@@ -1,7 +1,23 @@
-if (interactive() &&
-  Sys.getenv("RSTUDIO") == "" &&
-  Sys.getenv("TERM_PROGRAM") == "vscode") local({
 
+# This file is executed with its containing directory as wd
+
+# Remember absolute path of vsc.R
+filepathVscR <- normalizePath("vsc.R")
+
+
+# This function is run at the beginning of R's startup sequence
+# Code that is meant to be run at the end of the startup should go in `initLast`
+initFirst <- function() {
+  # return early if not a vscode term session
+  if (
+    !interactive()
+    || Sys.getenv("RSTUDIO") != ""
+    || Sys.getenv("TERM_PROGRAM") != "vscode"
+  ){
+    return()
+  }
+  
+  # check requried packages
   required_packages <- c("jsonlite", "rlang")
   missing_packages <- required_packages[
     !vapply(required_packages, requireNamespace,
@@ -14,706 +30,80 @@ if (interactive() &&
       toString(missing_packages), ". ",
       "Please install manually in order to use VSCode-R."
     )
-  } else local({
-    # cleanup previous version
-    removeTaskCallback("vscode-R")
-    options(vscodeR = NULL)
+  } else {
+    # Initialize vsc utils after loading other default packages
+    assign(".First.sys", initLast, envir = globalenv())
+  }
+}
 
-    .vsc.name <- "tools:vscode"
-    if (.vsc.name %in% search()) {
-      detach(.vsc.name, character.only = TRUE)
-    }
 
-    .vsc <- local({
-      pid <- Sys.getpid()
-      wd <- getwd()
-      tempdir <- tempdir()
-      homedir <- Sys.getenv(
-        if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"
-      )
-      dir_extension <- file.path(homedir, ".vscode-R")
-      request_file <- file.path(dir_extension, "request.log")
-      request_lock_file <- file.path(dir_extension, "request.lock")
+# Overwrite for `.First.sys`
+# Is used to make sure that all default packages are loaded first
+# Will be assigned to and called from the global environment,
+# Will be run with wd being the user's working directory (!)
+initLast <- function() {
+  base::.First.sys()
 
-      if (is.null(getOption("help_type"))) {
-        options(help_type = "html")
-      }
+  # cleanup previous version
+  removeTaskCallback("vscode-R")
+  options(vscodeR = NULL)
+  .vsc.name <- "tools:vscode"
+  if (.vsc.name %in% search()) {
+    detach(.vsc.name, character.only = TRUE)
+  }
 
-      get_timestamp <- function() {
-        format.default(Sys.time(), nsmall = 6, scientific = FALSE)
-      }
+  # Source vsc utils in new environmeent
+  .vsc <- new.env()
+  source(filepathVscR, local = .vsc)
 
-      scalar <- function(x) {
-        class(x) <- c("scalar", class(x))
-        x
-      }
-
-      request <- function(command, ...) {
-        obj <- list(
-          time = Sys.time(),
-          pid = pid,
-          wd = wd,
-          command = command,
-          ...
-        )
-        jsonlite::write_json(obj, request_file,
-          auto_unbox = TRUE, null = "null", force = TRUE)
-        cat(get_timestamp(), file = request_lock_file)
-      }
-
-      capture_str <- function(object) {
-        paste0(
-          utils::capture.output(
-            utils::str(object,
-              max.level = getOption("vsc.str.max.level", 0),
-              give.attr = FALSE,
-              vec.len = 1
-            )
-          ),
-          collapse = "\n"
-        )
-      }
-
-      rebind <- function(sym, value, ns) {
-        if (is.character(ns)) {
-          Recall(sym, value, getNamespace(ns))
-          pkg <- paste0("package:", ns)
-          if (pkg %in% search()) {
-            Recall(sym, value, as.environment(pkg))
-          }
-        } else if (is.environment(ns)) {
-          if (bindingIsLocked(sym, ns)) {
-            unlockBinding(sym, ns)
-            on.exit(lockBinding(sym, ns))
-          }
-          assign(sym, value, ns)
-        } else {
-          stop("ns must be a string or environment")
-        }
-      }
-
-      address <- function(x) {
-        info <- utils::capture.output(.Internal(inspect(x, 0L)))
-        gsub("@([a-z0-9]+)\\s+.+", "\\1", info[[1]])
-      }
-
-      globalenv_cache <- new.env(parent = emptyenv())
-
-      inspect_env <- function(env, cache) {
-        all_names <- ls(env)
-        rm(list = setdiff(names(globalenv_cache), all_names), envir = cache)
-        is_promise <- rlang::env_binding_are_lazy(env, all_names)
-        is_active <- rlang::env_binding_are_active(env, all_names)
-        show_object_size <- getOption("vsc.show_object_size", FALSE)
-        objs <- lapply(all_names, function(name) {
-          if (is_promise[[name]]) {
-            info <- list(
-              class = "promise",
-              type = scalar("promise"),
-              length = scalar(0L),
-              str = scalar("(promise)")
-            )
-          } else if (is_active[[name]]) {
-            info <- list(
-              class = "active_binding",
-              type = scalar("active_binding"),
-              length = scalar(0L),
-              str = scalar("(active-binding)")
-            )
-          } else {
-            obj <- env[[name]]
-
-            info <- list(
-              class = class(obj),
-              type = scalar(typeof(obj)),
-              length = scalar(length(obj)),
-              str = scalar(trimws(capture_str(obj)[[1L]]))
-            )
-
-            if (show_object_size) {
-              addr <- address(obj)
-              cobj <- cache[[name]]
-              if (is.null(cobj) || cobj$address != addr || cobj$length != info$length) {
-                cache[[name]] <- cobj <- list(
-                  address = addr,
-                  length = length(obj),
-                  size = unclass(object.size(obj))
-                )
-              }
-              info$size <- scalar(cobj$size)
-            }
-
-            if ((is.list(obj) ||
-              is.environment(obj)) &&
-              !is.null(names(obj))) {
-              info$names <- names(obj)
-            }
-            if (isS4(obj)) {
-              info$slots <- slotNames(obj)
-            }
-            if (is.list(obj) &&
-              !is.null(dim(obj))) {
-              info$dim <- dim(obj)
-            }
-          }
-          info
-        })
-        names(objs) <- all_names
-        objs
-      }
-
-      dir_session <- file.path(tempdir, "vscode-R")
-      dir.create(dir_session, showWarnings = FALSE, recursive = TRUE)
-
-      removeTaskCallback("vsc.globalenv")
-      show_globalenv <- isTRUE(getOption("vsc.globalenv", TRUE))
-      if (show_globalenv) {
-        globalenv_file <- file.path(dir_session, "globalenv.json")
-        globalenv_lock_file <- file.path(dir_session, "globalenv.lock")
-        file.create(globalenv_lock_file, showWarnings = FALSE)
-
-        update_globalenv <- function(...) {
-          tryCatch({
-            objs <- inspect_env(.GlobalEnv, globalenv_cache)
-            jsonlite::write_json(objs, globalenv_file, force = TRUE, pretty = FALSE)
-            cat(get_timestamp(), file = globalenv_lock_file)
-          }, error = message)
-          TRUE
-        }
-
-        update_globalenv()
-        addTaskCallback(update_globalenv, name = "vsc.globalenv")
-      }
-
-      removeTaskCallback("vsc.plot")
-      show_plot <- !identical(getOption("vsc.plot", "Two"), FALSE)
-      if (show_plot) {
-        dir_plot_history <- file.path(dir_session, "images")
-        dir.create(dir_plot_history, showWarnings = FALSE, recursive = TRUE)
-        plot_file <- file.path(dir_session, "plot.png")
-        plot_lock_file <- file.path(dir_session, "plot.lock")
-        file.create(plot_file, plot_lock_file, showWarnings = FALSE)
-
-        plot_history_file <- NULL
-        plot_updated <- FALSE
-        null_dev_id <- c(pdf = 2L)
-        null_dev_size <- c(7 + pi, 7 + pi)
-
-        check_null_dev <- function() {
-          identical(dev.cur(), null_dev_id) &&
-            identical(dev.size(), null_dev_size)
-        }
-
-        new_plot <- function() {
-          if (check_null_dev()) {
-            plot_history_file <<- file.path(dir_plot_history,
-              format(Sys.time(), "%Y%m%d-%H%M%OS6.png"))
-            plot_updated <<- TRUE
-          }
-        }
-
-        options(
-          device = function(...) {
-            pdf(NULL,
-              width = null_dev_size[[1L]],
-              height = null_dev_size[[2L]],
-              bg = "white")
-            dev.control(displaylist = "enable")
-          }
-        )
-
-        update_plot <- function(...) {
-          tryCatch({
-            if (plot_updated && check_null_dev()) {
-              plot_updated <<- FALSE
-              record <- recordPlot()
-              if (length(record[[1L]])) {
-                dev_args <- getOption("vsc.dev.args")
-                do.call(png, c(list(filename = plot_file), dev_args))
-                on.exit({
-                  dev.off()
-                  cat(get_timestamp(), file = plot_lock_file)
-                  if (!is.null(plot_history_file)) {
-                    file.copy(plot_file, plot_history_file, overwrite = TRUE)
-                  }
-                })
-                replayPlot(record)
-              }
-            }
-          }, error = message)
-          TRUE
-        }
-
-        setHook("plot.new", new_plot, "replace")
-        setHook("grid.newpage", new_plot, "replace")
-
-        rebind(".External.graphics", function(...) {
-          out <- .Primitive(".External.graphics")(...)
-          if (check_null_dev()) {
-            plot_updated <<- TRUE
-          }
-          out
-        }, "base")
-
-        update_plot()
-        addTaskCallback(update_plot, name = "vsc.plot")
-      }
-
-      show_view <- !identical(getOption("vsc.view", "Two"), FALSE)
-      if (show_view) {
-        dataview_data_type <- function(x) {
-          if (is.numeric(x)) {
-            if (is.null(attr(x, "class"))) {
-              "num"
-            } else {
-              "num-fmt"
-            }
-          } else if (inherits(x, "Date")) {
-            "date"
-          } else {
-            "string"
-          }
-        }
-
-        dataview_table <- function(data) {
-          if (is.data.frame(data)) {
-            nrow <- nrow(data)
-            colnames <- colnames(data)
-            if (is.null(colnames)) {
-              colnames <- sprintf("(X%d)", seq_len(ncol(data)))
-            } else {
-              colnames <- trimws(colnames)
-            }
-            if (.row_names_info(data) > 0L) {
-              rownames <- rownames(data)
-              rownames(data) <- NULL
-            } else {
-              rownames <- seq_len(nrow)
-            }
-            data <- c(list(" " = rownames), .subset(data))
-            colnames <- c(" ", colnames)
-            types <- vapply(data, dataview_data_type,
-              character(1L), USE.NAMES = FALSE)
-            data <- vapply(data, function(x) {
-              trimws(format(x))
-            }, character(nrow), USE.NAMES = FALSE)
-            dim(data) <- c(length(rownames), length(colnames))
-          } else if (is.matrix(data)) {
-            if (is.factor(data)) {
-              data <- format(data)
-            }
-            types <- rep(dataview_data_type(data), ncol(data))
-            colnames <- colnames(data)
-            colnames(data) <- NULL
-            if (is.null(colnames)) {
-              colnames <- sprintf("(X%d)", seq_len(ncol(data)))
-            } else {
-              colnames <- trimws(colnames)
-            }
-            rownames <- rownames(data)
-            rownames(data) <- NULL
-            data <- trimws(format(data))
-            if (is.null(rownames)) {
-              types <- c("num", types)
-              rownames <- seq_len(nrow(data))
-            } else {
-              types <- c("string", types)
-              rownames <- trimws(rownames)
-            }
-            dim(data) <- c(length(rownames), length(colnames))
-            colnames <- c(" ", colnames)
-            data <- cbind(rownames, data)
-          } else {
-            stop("data must be data.frame or matrix")
-          }
-          columns <- .mapply(function(title, type) {
-            class <- if (type == "string") "text-left" else "text-right"
-            list(title = scalar(title),
-              className = scalar(class),
-              type = scalar(type))
-          }, list(colnames, types), NULL)
-          list(columns = columns, data = data)
-        }
-
-        show_dataview <- function(x, title,
-                                  viewer = getOption("vsc.view", "Two")) {
-          if (missing(title)) {
-            sub <- substitute(x)
-            title <- deparse(sub, nlines = 1)
-          }
-          if (is.environment(x)) {
-            all_names <- ls(x)
-            is_promise <- rlang::env_binding_are_lazy(x, all_names)
-            is_active <- rlang::env_binding_are_active(x, all_names)
-            x <- lapply(all_names, function(name) {
-              if (is_promise[[name]]) {
-                data.frame(
-                  class = "promise",
-                  type = "promise",
-                  length = 0L,
-                  size = 0L,
-                  value = "(promise)",
-                  stringsAsFactors = FALSE,
-                  check.names = FALSE
-                )
-              } else if (is_active[[name]]) {
-                data.frame(
-                  class = "active_binding",
-                  type = "active_binding",
-                  length = 0L,
-                  size = 0L,
-                  value = "(active-binding)",
-                  stringsAsFactors = FALSE,
-                  check.names = FALSE
-                )
-              } else {
-                obj <- x[[name]]
-                data.frame(
-                  class = paste0(class(obj), collapse = ", "),
-                  type = typeof(obj),
-                  length = length(obj),
-                  size = as.integer(object.size(obj)),
-                  value = trimws(capture_str(obj)),
-                  stringsAsFactors = FALSE,
-                  check.names = FALSE
-                )
-              }
-            })
-            names(x) <- all_names
-            if (length(x)) {
-              x <- do.call(rbind, x)
-            } else {
-              x <- data.frame(
-                class = character(),
-                type = character(),
-                length = integer(),
-                size = integer(),
-                value = character(),
-                stringsAsFactors = FALSE,
-                check.names = FALSE
-              )
-            }
-          }
-          if (is.data.frame(x) || is.matrix(x)) {
-            data <- dataview_table(x)
-            file <- tempfile(tmpdir = tempdir, fileext = ".json")
-            jsonlite::write_json(data, file, matrix = "rowmajor")
-            request("dataview", source = "table", type = "json",
-              title = title, file = file, viewer = viewer)
-          } else if (is.list(x)) {
-            tryCatch({
-              file <- tempfile(tmpdir = tempdir, fileext = ".json")
-              jsonlite::write_json(x, file, auto_unbox = TRUE)
-              request("dataview", source = "list", type = "json",
-                title = title, file = file, viewer = viewer)
-            }, error = function(e) {
-              file <- file.path(tempdir, paste0(make.names(title), ".txt"))
-              text <- utils::capture.output(print(x))
-              writeLines(text, file)
-              request("dataview", source = "object", type = "txt",
-                title = title, file = file, viewer = viewer)
-            })
-          } else {
-            file <- file.path(tempdir, paste0(make.names(title), ".R"))
-            if (is.primitive(x)) {
-              code <- utils::capture.output(print(x))
-            } else {
-              code <- deparse(x)
-            }
-            writeLines(code, file)
-            request("dataview", source = "object", type = "R",
-              title = title, file = file, viewer = viewer)
-          }
-        }
-
-        rebind("View", show_dataview, "utils")
-      }
-
-      attach <- function() {
-        if (rstudioapi_enabled()) {
-          rstudioapi_util_env$update_addin_registry(addin_registry)
-        }
-        request("attach",
-          tempdir = tempdir,
-          plot = getOption("vsc.plot", "Two"))
-      }
-
-      path_to_uri <- function(path) {
-        if (length(path) == 0) {
-          return(character())
-        }
-        path <- path.expand(path)
-        if (.Platform$OS.type == "windows") {
-          prefix <- "file:///"
-          path <- gsub("\\", "/", path, fixed = TRUE)
-        } else {
-          prefix <- "file://"
-        }
-        paste0(prefix, utils::URLencode(path))
-      }
-
-      request_browser <- function(url, title, ..., viewer) {
-        # Printing URL with specific port triggers
-        # auto port-forwarding under remote development
-        message("Browsing ", url)
-        request("browser", url = url, title = title, ..., viewer = viewer)
-      }
-
-      show_browser <- function(url, title = url, ...,
-                               viewer = getOption("vsc.browser", "Active")) {
-        if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
-          request_browser(url = url, title = title, ..., viewer = viewer)
-        } else if (grepl("^https?\\://", url)) {
-          message(
-            "VSCode WebView only supports showing local http content.\n",
-            "Opening in external browser..."
-          )
-          request_browser(url = url, title = title, ..., viewer = FALSE)
-        } else if (file.exists(url)) {
-          url <- normalizePath(url, "/", mustWork = TRUE)
-          if (grepl("\\.html?$", url, ignore.case = TRUE)) {
-            message(
-              "VSCode WebView has restricted access to local file.\n",
-              "Opening in external browser..."
-            )
-            request_browser(url = path_to_uri(url),
-              title = title, ..., viewer = FALSE)
-          } else {
-            request("dataview", source = "object", type = "txt",
-              title = title, file = url, viewer = viewer)
-          }
-        } else {
-          stop("File not exists")
-        }
-      }
-
-      show_webview <- function(url, title, ..., viewer) {
-        if (!is.character(url)) {
-          real_url <- NULL
-          temp_viewer <- function(url, ...) {
-            real_url <<- url
-          }
-          op <- options(viewer = temp_viewer, page_viewer = temp_viewer)
-          on.exit(options(op))
-          print(url)
-          if (is.character(real_url)) {
-            url <- real_url
-          } else {
-            stop("Invalid object")
-          }
-        }
-        if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
-          request_browser(url = url, title = title, ..., viewer = viewer)
-        } else if (grepl("^https?\\://", url)) {
-          message(
-            "VSCode WebView only supports showing local http content.\n",
-            "Opening in external browser..."
-          )
-          request_browser(url = url, title = title, ..., viewer = FALSE)
-        } else if (file.exists(url)) {
-          file <- normalizePath(url, "/", mustWork = TRUE)
-          request("webview", file = file, title = title, viewer = viewer, ...)
-        } else {
-          stop("File not exists")
-        }
-      }
-
-      show_viewer <- function(url, title = NULL, ...,
-                              viewer = getOption("vsc.viewer", "Two")) {
-        if (is.null(title)) {
-          expr <- substitute(url)
-          if (is.character(url)) {
-            title <- "Viewer"
-          } else {
-            title <- deparse(expr, nlines = 1)
-          }
-        }
-        show_webview(url = url, title = title, ..., viewer = viewer)
-      }
-
-      show_page_viewer <- function(url, title = NULL, ...,
-                                   viewer = getOption("vsc.page_viewer", "Active")) {
-        if (is.null(title)) {
-          expr <- substitute(url)
-          if (is.character(url)) {
-            title <- "Page Viewer"
-          } else {
-            title <- deparse(expr, nlines = 1)
-          }
-        }
-        show_webview(url = url, title = title, ..., viewer = viewer)
-      }
-
-      options(
-        browser = show_browser,
-        viewer = show_viewer,
-        page_viewer = show_page_viewer
-      )
-
-      # rstudioapi
-      rstudioapi_enabled <- function() {
-        isTRUE(getOption("vsc.rstudioapi"))
-      }
-
-      if (rstudioapi_enabled()) {
-        response_timeout <- 5
-        response_lock_file <- file.path(dir_session, "response.lock")
-        response_file <- file.path(dir_session, "response.log")
-        file.create(response_lock_file, showWarnings = FALSE)
-        file.create(response_file, showWarnings = FALSE)
-        addin_registry <- file.path(dir_session, "addins.json")
-        # This is created in attach()
-
-        get_response_timestamp <- function() {
-          readLines(response_lock_file)
-        }
-        # initialise the reponse timestamp to empty string
-        response_time_stamp <- ""
-
-        get_response_lock <- function() {
-          lock_time_stamp <- get_response_timestamp()
-          if (isTRUE(lock_time_stamp != response_time_stamp)) {
-            response_time_stamp <<- lock_time_stamp
-            TRUE
-          } else {
-            FALSE
-          }
-        }
-
-        request_response <- function(command, ...) {
-          request(command, ..., sd = dir_session)
-          wait_start <- Sys.time()
-          while (!get_response_lock()) {
-            if ((Sys.time() - wait_start) > response_timeout) {
-              stop(
-                "Did not receive a response from VSCode-R API within ",
-                response_timeout, " seconds."
-              )
-            }
-            Sys.sleep(0.1)
-          }
-          jsonlite::read_json(response_file)
-        }
-
-        rstudioapi_util_env <- new.env()
-        rstudioapi_env <- new.env(parent = rstudioapi_util_env)
-        source(file.path(dir_extension, "rstudioapi_util.R"),
-          local = rstudioapi_util_env,
-        )
-        source(file.path(dir_extension, "rstudioapi.R"),
-          local = rstudioapi_env
-        )
-        setHook(
-          packageEvent("rstudioapi", "onLoad"),
-          function(...) {
-            rstudioapi_util_env$rstudioapi_patch_hook(rstudioapi_env)
-          }
-        )
-      }
-
-      print.help_files_with_topic <- function(h, ...) {
-        viewer <- getOption("vsc.helpPanel", "Two")
-        if (!identical(FALSE, viewer) && length(h) >= 1 && is.character(h)) {
-          file <- h[1]
-          path <- dirname(file)
-          dirpath <- dirname(path)
-          pkgname <- basename(dirpath)
-          requestPath <- paste0(
-            "/library/",
-            pkgname,
-            "/html/",
-            basename(file),
-            ".html"
-          )
-          request(command = "help", requestPath = requestPath, viewer = viewer)
-        } else {
-          utils:::print.help_files_with_topic(h, ...)
-        }
-        invisible(h)
-      }
-
-      print.hsearch <- function(x, ...) {
-        viewer <- getOption("vsc.helpPanel", "Two")
-        if (!identical(FALSE, viewer) && length(x) >= 1) {
-          requestPath <- paste0(
-            "/doc/html/Search?pattern=",
-            tools:::escapeAmpersand(x$pattern),
-            paste0("&fields.", x$fields, "=1",
-              collapse = ""
-            ),
-            if (!is.null(x$agrep)) paste0("&agrep=", x$agrep),
-            if (!x$ignore.case) "&ignore.case=0",
-            if (!identical(
-              x$types,
-              getOption("help.search.types")
-            )) {
-              paste0("&types.", x$types, "=1",
-                collapse = ""
-              )
-            },
-            if (!is.null(x$package)) {
-              paste0(
-                "&package=",
-                paste(x$package, collapse = ";")
-              )
-            },
-            if (!identical(x$lib.loc, .libPaths())) {
-              paste0(
-                "&lib.loc=",
-                paste(x$lib.loc, collapse = ";")
-              )
-            }
-          )
-          request(command = "help", requestPath = requestPath, viewer = viewer)
-        } else {
-          utils:::print.hsearch(x, ...)
-        }
-        invisible(x)
-      }
-
-      environment()
-    })
-
-    if (!identical(getOption("vsc.helpPanel", "Two"), FALSE)) {
-      .First.sys <- function() {
-        # first load utils in order to overwrite its print method for help files
-        base::.First.sys()
-
-        # a copy of .S3method(), since this function is new in R 4.0
-        .S3method <- function(generic, class, method) {
-          if (missing(method)) {
-            method <- paste(generic, class, sep = ".")
-          }
-          method <- match.fun(method)
-          registerS3method(generic, class, method, envir = parent.frame())
-          invisible(NULL)
-        }
-
-        suppressWarnings({
-          .S3method(
-            "print",
-            "help_files_with_topic",
-            .vsc$print.help_files_with_topic
-          )
-          .S3method(
-            "print",
-            "hsearch",
-            .vsc$print.hsearch
-          )
-        })
-
-        rm(".First.sys", envir = parent.env(environment()))
-      }
-    }
-
+  # attach functions that are meant to be called by the user/vscode
+  exports <- local({
+    .vsc <- .vsc
     .vsc.attach <- .vsc$attach
     .vsc.view <- .vsc$show_dataview
     .vsc.browser <- .vsc$show_browser
     .vsc.viewer <- .vsc$show_viewer
     .vsc.page_viewer <- .vsc$show_page_viewer
 
-    attach(environment(), name = .vsc.name, warn.conflicts = FALSE)
-
-    .vsc.attach()
+    # assign functions that are optional:
+    for(funcName in c("View", ".External.graphics")) {
+      if (funcName %in% ls(.vsc)) {
+        assign(funcName, .vsc[[funcName]])
+      }
+    }
+    environment()
   })
-})
+  attach(exports, name = .vsc.name, warn.conflicts = FALSE)
+
+  # overwrite S3 bindings from other packages
+  suppressWarnings({
+    if(!identical(getOption("vsc.helpPanel", "Two"), FALSE)) {
+      # Overwrite print function for results of `?`
+      .vsc$.S3method(
+        "print",
+        "help_files_with_topic",
+        .vsc$print.help_files_with_topic
+      )
+      # Overwrite print function for results of `??`
+      .vsc$.S3method(
+        "print",
+        "hsearch",
+        .vsc$print.hsearch
+      )
+    }
+    # Further S3 overwrites can go here
+    # ...
+  })
+
+  # remove this function from globalenv()
+  suppressWarnings(
+    rm(".First.sys", envir = globalenv())
+  )
+
+  # Attach to vscode
+  exports$.vsc.attach()
+
+  invisible(NULL)
+}
+
+initFirst()

--- a/R/init.R
+++ b/R/init.R
@@ -2,7 +2,7 @@
 # This file is executed with its containing directory as wd
 
 # Remember absolute path of vsc.R
-filepathVscR <- normalizePath("vsc.R")
+dir_init <- getwd()
 
 
 # This function is run at the beginning of R's startup sequence
@@ -55,7 +55,7 @@ initLast <- function() {
 
   # Source vsc utils in new environmeent
   .vsc <- new.env()
-  source(filepathVscR, local = .vsc)
+  source(file.path(dir_init, "vsc.R"), local = .vsc)
 
   # attach functions that are meant to be called by the user/vscode
   exports <- local({

--- a/R/vsc.R
+++ b/R/vsc.R
@@ -5,9 +5,9 @@ tempdir <- tempdir()
 homedir <- Sys.getenv(
   if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"
 )
-dir_extension <- Sys.getenv("VSCODE_WATCHER_DIR", file.path(homedir, ".vscode-R"))
-request_file <- file.path(dir_extension, "request.log")
-request_lock_file <- file.path(dir_extension, "request.lock")
+dir_watcher <- Sys.getenv("VSCODE_WATCHER_DIR", file.path(homedir, ".vscode-R"))
+request_file <- file.path(dir_watcher, "request.log")
+request_lock_file <- file.path(dir_watcher, "request.lock")
 
 if (is.null(getOption("help_type"))) {
   options(help_type = "html")
@@ -553,12 +553,8 @@ if (rstudioapi_enabled()) {
 
   rstudioapi_util_env <- new.env()
   rstudioapi_env <- new.env(parent = rstudioapi_util_env)
-  source(file.path(dir_extension, "rstudioapi_util.R"),
-    local = rstudioapi_util_env,
-  )
-  source(file.path(dir_extension, "rstudioapi.R"),
-    local = rstudioapi_env
-  )
+  source(file.path(dir_init, "rstudioapi_util.R"), local = rstudioapi_util_env)
+  source(file.path(dir_init, "rstudioapi.R"), local = rstudioapi_env)
   setHook(
     packageEvent("rstudioapi", "onLoad"),
     function(...) {

--- a/R/vsc.R
+++ b/R/vsc.R
@@ -1,0 +1,646 @@
+
+pid <- Sys.getpid()
+wd <- getwd()
+tempdir <- tempdir()
+homedir <- Sys.getenv(
+  if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"
+)
+dir_extension <- Sys.getenv("VSCODE_WATCHER_DIR")
+request_file <- file.path(dir_extension, "request.log")
+request_lock_file <- file.path(dir_extension, "request.lock")
+
+if (is.null(getOption("help_type"))) {
+  options(help_type = "html")
+}
+
+get_timestamp <- function() {
+  format.default(Sys.time(), nsmall = 6, scientific = FALSE)
+}
+
+scalar <- function(x) {
+  class(x) <- c("scalar", class(x))
+  x
+}
+
+request <- function(command, ...) {
+  obj <- list(
+    time = Sys.time(),
+    pid = pid,
+    wd = wd,
+    command = command,
+    ...
+  )
+  jsonlite::write_json(obj, request_file,
+    auto_unbox = TRUE, null = "null", force = TRUE)
+  cat(get_timestamp(), file = request_lock_file)
+}
+
+capture_str <- function(object) {
+  paste0(
+    utils::capture.output(
+      utils::str(object,
+        max.level = getOption("vsc.str.max.level", 0),
+        give.attr = FALSE,
+        vec.len = 1
+      )
+    ),
+    collapse = "\n"
+  )
+}
+
+address <- function(x) {
+  info <- utils::capture.output(.Internal(inspect(x, 0L)))
+  gsub("@([a-z0-9]+)\\s+.+", "\\1", info[[1]])
+}
+
+globalenv_cache <- new.env(parent = emptyenv())
+
+inspect_env <- function(env, cache) {
+  all_names <- ls(env)
+  rm(list = setdiff(names(globalenv_cache), all_names), envir = cache)
+  is_promise <- rlang::env_binding_are_lazy(env, all_names)
+  is_active <- rlang::env_binding_are_active(env, all_names)
+  show_object_size <- getOption("vsc.show_object_size", FALSE)
+  objs <- lapply(all_names, function(name) {
+    if (is_promise[[name]]) {
+      info <- list(
+        class = "promise",
+        type = scalar("promise"),
+        length = scalar(0L),
+        str = scalar("(promise)")
+      )
+    } else if (is_active[[name]]) {
+      info <- list(
+        class = "active_binding",
+        type = scalar("active_binding"),
+        length = scalar(0L),
+        str = scalar("(active-binding)")
+      )
+    } else {
+      obj <- env[[name]]
+
+      info <- list(
+        class = class(obj),
+        type = scalar(typeof(obj)),
+        length = scalar(length(obj)),
+        str = scalar(trimws(capture_str(obj)[[1L]]))
+      )
+
+      if (show_object_size) {
+        addr <- address(obj)
+        cobj <- cache[[name]]
+        if (is.null(cobj) || cobj$address != addr || cobj$length != info$length) {
+          cache[[name]] <- cobj <- list(
+            address = addr,
+            length = length(obj),
+            size = unclass(object.size(obj))
+          )
+        }
+        info$size <- scalar(cobj$size)
+      }
+
+      if ((is.list(obj) ||
+        is.environment(obj)) &&
+        !is.null(names(obj))) {
+        info$names <- names(obj)
+      }
+      if (isS4(obj)) {
+        info$slots <- slotNames(obj)
+      }
+      if (is.list(obj) &&
+        !is.null(dim(obj))) {
+        info$dim <- dim(obj)
+      }
+    }
+    info
+  })
+  names(objs) <- all_names
+  objs
+}
+
+dir_session <- file.path(tempdir, "vscode-R")
+dir.create(dir_session, showWarnings = FALSE, recursive = TRUE)
+
+removeTaskCallback("vsc.globalenv")
+show_globalenv <- isTRUE(getOption("vsc.globalenv", TRUE))
+if (show_globalenv) {
+  globalenv_file <- file.path(dir_session, "globalenv.json")
+  globalenv_lock_file <- file.path(dir_session, "globalenv.lock")
+  file.create(globalenv_lock_file, showWarnings = FALSE)
+
+  update_globalenv <- function(...) {
+    tryCatch({
+      objs <- inspect_env(.GlobalEnv, globalenv_cache)
+      jsonlite::write_json(objs, globalenv_file, force = TRUE, pretty = FALSE)
+      cat(get_timestamp(), file = globalenv_lock_file)
+    }, error = message)
+    TRUE
+  }
+
+  update_globalenv()
+  addTaskCallback(update_globalenv, name = "vsc.globalenv")
+}
+
+removeTaskCallback("vsc.plot")
+show_plot <- !identical(getOption("vsc.plot", "Two"), FALSE)
+if (show_plot) {
+  dir_plot_history <- file.path(dir_session, "images")
+  dir.create(dir_plot_history, showWarnings = FALSE, recursive = TRUE)
+  plot_file <- file.path(dir_session, "plot.png")
+  plot_lock_file <- file.path(dir_session, "plot.lock")
+  file.create(plot_file, plot_lock_file, showWarnings = FALSE)
+
+  plot_history_file <- NULL
+  plot_updated <- FALSE
+  null_dev_id <- c(pdf = 2L)
+  null_dev_size <- c(7 + pi, 7 + pi)
+
+  check_null_dev <- function() {
+    identical(dev.cur(), null_dev_id) &&
+      identical(dev.size(), null_dev_size)
+  }
+
+  new_plot <- function() {
+    if (check_null_dev()) {
+      plot_history_file <<- file.path(dir_plot_history,
+        format(Sys.time(), "%Y%m%d-%H%M%OS6.png"))
+      plot_updated <<- TRUE
+    }
+  }
+
+  options(
+    device = function(...) {
+      pdf(NULL,
+        width = null_dev_size[[1L]],
+        height = null_dev_size[[2L]],
+        bg = "white")
+      dev.control(displaylist = "enable")
+    }
+  )
+
+  update_plot <- function(...) {
+    tryCatch({
+      if (plot_updated && check_null_dev()) {
+        plot_updated <<- FALSE
+        record <- recordPlot()
+        if (length(record[[1L]])) {
+          dev_args <- getOption("vsc.dev.args")
+          do.call(png, c(list(filename = plot_file), dev_args))
+          on.exit({
+            dev.off()
+            cat(get_timestamp(), file = plot_lock_file)
+            if (!is.null(plot_history_file)) {
+              file.copy(plot_file, plot_history_file, overwrite = TRUE)
+            }
+          })
+          replayPlot(record)
+        }
+      }
+    }, error = message)
+    TRUE
+  }
+
+  setHook("plot.new", new_plot, "replace")
+  setHook("grid.newpage", new_plot, "replace")
+
+  # rebind(".External.graphics", function(...) {
+  #   out <- .Primitive(".External.graphics")(...)
+  #   if (check_null_dev()) {
+  #     plot_updated <<- TRUE
+  #   }
+  #   out
+  # }, "base")
+  .External.graphics <- function(...) {
+    out <- .Primitive(".External.graphics")(...)
+    if (check_null_dev()) {
+      plot_updated <<- TRUE
+    }
+    out
+  }
+
+  update_plot()
+  addTaskCallback(update_plot, name = "vsc.plot")
+}
+
+show_view <- !identical(getOption("vsc.view", "Two"), FALSE)
+if (show_view) {
+  dataview_data_type <- function(x) {
+    if (is.numeric(x)) {
+      if (is.null(attr(x, "class"))) {
+        "num"
+      } else {
+        "num-fmt"
+      }
+    } else if (inherits(x, "Date")) {
+      "date"
+    } else {
+      "string"
+    }
+  }
+
+  dataview_table <- function(data) {
+    if (is.data.frame(data)) {
+      nrow <- nrow(data)
+      colnames <- colnames(data)
+      if (is.null(colnames)) {
+        colnames <- sprintf("(X%d)", seq_len(ncol(data)))
+      } else {
+        colnames <- trimws(colnames)
+      }
+      if (.row_names_info(data) > 0L) {
+        rownames <- rownames(data)
+        rownames(data) <- NULL
+      } else {
+        rownames <- seq_len(nrow)
+      }
+      data <- c(list(" " = rownames), .subset(data))
+      colnames <- c(" ", colnames)
+      types <- vapply(data, dataview_data_type,
+        character(1L), USE.NAMES = FALSE)
+      data <- vapply(data, function(x) {
+        trimws(format(x))
+      }, character(nrow), USE.NAMES = FALSE)
+      dim(data) <- c(length(rownames), length(colnames))
+    } else if (is.matrix(data)) {
+      if (is.factor(data)) {
+        data <- format(data)
+      }
+      types <- rep(dataview_data_type(data), ncol(data))
+      colnames <- colnames(data)
+      colnames(data) <- NULL
+      if (is.null(colnames)) {
+        colnames <- sprintf("(X%d)", seq_len(ncol(data)))
+      } else {
+        colnames <- trimws(colnames)
+      }
+      rownames <- rownames(data)
+      rownames(data) <- NULL
+      data <- trimws(format(data))
+      if (is.null(rownames)) {
+        types <- c("num", types)
+        rownames <- seq_len(nrow(data))
+      } else {
+        types <- c("string", types)
+        rownames <- trimws(rownames)
+      }
+      dim(data) <- c(length(rownames), length(colnames))
+      colnames <- c(" ", colnames)
+      data <- cbind(rownames, data)
+    } else {
+      stop("data must be data.frame or matrix")
+    }
+    columns <- .mapply(function(title, type) {
+      class <- if (type == "string") "text-left" else "text-right"
+      list(title = scalar(title),
+        className = scalar(class),
+        type = scalar(type))
+    }, list(colnames, types), NULL)
+    list(columns = columns, data = data)
+  }
+
+  show_dataview <- function(x, title,
+                            viewer = getOption("vsc.view", "Two")) {
+    if (missing(title)) {
+      sub <- substitute(x)
+      title <- deparse(sub, nlines = 1)
+    }
+    if (is.environment(x)) {
+      all_names <- ls(x)
+      is_promise <- rlang::env_binding_are_lazy(x, all_names)
+      is_active <- rlang::env_binding_are_active(x, all_names)
+      x <- lapply(all_names, function(name) {
+        if (is_promise[[name]]) {
+          data.frame(
+            class = "promise",
+            type = "promise",
+            length = 0L,
+            size = 0L,
+            value = "(promise)",
+            stringsAsFactors = FALSE,
+            check.names = FALSE
+          )
+        } else if (is_active[[name]]) {
+          data.frame(
+            class = "active_binding",
+            type = "active_binding",
+            length = 0L,
+            size = 0L,
+            value = "(active-binding)",
+            stringsAsFactors = FALSE,
+            check.names = FALSE
+          )
+        } else {
+          obj <- x[[name]]
+          data.frame(
+            class = paste0(class(obj), collapse = ", "),
+            type = typeof(obj),
+            length = length(obj),
+            size = as.integer(object.size(obj)),
+            value = trimws(capture_str(obj)),
+            stringsAsFactors = FALSE,
+            check.names = FALSE
+          )
+        }
+      })
+      names(x) <- all_names
+      if (length(x)) {
+        x <- do.call(rbind, x)
+      } else {
+        x <- data.frame(
+          class = character(),
+          type = character(),
+          length = integer(),
+          size = integer(),
+          value = character(),
+          stringsAsFactors = FALSE,
+          check.names = FALSE
+        )
+      }
+    }
+    if (is.data.frame(x) || is.matrix(x)) {
+      data <- dataview_table(x)
+      file <- tempfile(tmpdir = tempdir, fileext = ".json")
+      jsonlite::write_json(data, file, matrix = "rowmajor")
+      request("dataview", source = "table", type = "json",
+        title = title, file = file, viewer = viewer)
+    } else if (is.list(x)) {
+      tryCatch({
+        file <- tempfile(tmpdir = tempdir, fileext = ".json")
+        jsonlite::write_json(x, file, auto_unbox = TRUE)
+        request("dataview", source = "list", type = "json",
+          title = title, file = file, viewer = viewer)
+      }, error = function(e) {
+        file <- file.path(tempdir, paste0(make.names(title), ".txt"))
+        text <- utils::capture.output(print(x))
+        writeLines(text, file)
+        request("dataview", source = "object", type = "txt",
+          title = title, file = file, viewer = viewer)
+      })
+    } else {
+      file <- file.path(tempdir, paste0(make.names(title), ".R"))
+      if (is.primitive(x)) {
+        code <- utils::capture.output(print(x))
+      } else {
+        code <- deparse(x)
+      }
+      writeLines(code, file)
+      request("dataview", source = "object", type = "R",
+        title = title, file = file, viewer = viewer)
+    }
+  }
+
+  # rebind("View", show_dataview, "utils")
+  View <- show_dataview
+}
+
+attach <- function() {
+  if (rstudioapi_enabled()) {
+    rstudioapi_util_env$update_addin_registry(addin_registry)
+  }
+  request("attach",
+    tempdir = tempdir,
+    plot = getOption("vsc.plot", "Two"))
+}
+
+path_to_uri <- function(path) {
+  if (length(path) == 0) {
+    return(character())
+  }
+  path <- path.expand(path)
+  if (.Platform$OS.type == "windows") {
+    prefix <- "file:///"
+    path <- gsub("\\", "/", path, fixed = TRUE)
+  } else {
+    prefix <- "file://"
+  }
+  paste0(prefix, utils::URLencode(path))
+}
+
+request_browser <- function(url, title, ..., viewer) {
+  # Printing URL with specific port triggers
+  # auto port-forwarding under remote development
+  message("Browsing ", url)
+  request("browser", url = url, title = title, ..., viewer = viewer)
+}
+
+show_browser <- function(url, title = url, ...,
+                         viewer = getOption("vsc.browser", "Active")) {
+  if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
+    request_browser(url = url, title = title, ..., viewer = viewer)
+  } else if (grepl("^https?\\://", url)) {
+    message(
+      "VSCode WebView only supports showing local http content.\n",
+      "Opening in external browser..."
+    )
+    request_browser(url = url, title = title, ..., viewer = FALSE)
+  } else if (file.exists(url)) {
+    url <- normalizePath(url, "/", mustWork = TRUE)
+    if (grepl("\\.html?$", url, ignore.case = TRUE)) {
+      message(
+        "VSCode WebView has restricted access to local file.\n",
+        "Opening in external browser..."
+      )
+      request_browser(url = path_to_uri(url),
+        title = title, ..., viewer = FALSE)
+    } else {
+      request("dataview", source = "object", type = "txt",
+        title = title, file = url, viewer = viewer)
+    }
+  } else {
+    stop("File not exists")
+  }
+}
+
+show_webview <- function(url, title, ..., viewer) {
+  if (!is.character(url)) {
+    real_url <- NULL
+    temp_viewer <- function(url, ...) {
+      real_url <<- url
+    }
+    op <- options(viewer = temp_viewer, page_viewer = temp_viewer)
+    on.exit(options(op))
+    print(url)
+    if (is.character(real_url)) {
+      url <- real_url
+    } else {
+      stop("Invalid object")
+    }
+  }
+  if (grepl("^https?\\://(127\\.0\\.0\\.1|localhost)(\\:\\d+)?", url)) {
+    request_browser(url = url, title = title, ..., viewer = viewer)
+  } else if (grepl("^https?\\://", url)) {
+    message(
+      "VSCode WebView only supports showing local http content.\n",
+      "Opening in external browser..."
+    )
+    request_browser(url = url, title = title, ..., viewer = FALSE)
+  } else if (file.exists(url)) {
+    file <- normalizePath(url, "/", mustWork = TRUE)
+    request("webview", file = file, title = title, viewer = viewer, ...)
+  } else {
+    stop("File not exists")
+  }
+}
+
+show_viewer <- function(url, title = NULL, ...,
+                        viewer = getOption("vsc.viewer", "Two")) {
+  if (is.null(title)) {
+    expr <- substitute(url)
+    if (is.character(url)) {
+      title <- "Viewer"
+    } else {
+      title <- deparse(expr, nlines = 1)
+    }
+  }
+  show_webview(url = url, title = title, ..., viewer = viewer)
+}
+
+show_page_viewer <- function(url, title = NULL, ...,
+                             viewer = getOption("vsc.page_viewer", "Active")) {
+  if (is.null(title)) {
+    expr <- substitute(url)
+    if (is.character(url)) {
+      title <- "Page Viewer"
+    } else {
+      title <- deparse(expr, nlines = 1)
+    }
+  }
+  show_webview(url = url, title = title, ..., viewer = viewer)
+}
+
+options(
+  browser = show_browser,
+  viewer = show_viewer,
+  page_viewer = show_page_viewer
+)
+
+# rstudioapi
+rstudioapi_enabled <- function() {
+  isTRUE(getOption("vsc.rstudioapi"))
+}
+
+if (rstudioapi_enabled()) {
+  response_timeout <- 5
+  response_lock_file <- file.path(dir_session, "response.lock")
+  response_file <- file.path(dir_session, "response.log")
+  file.create(response_lock_file, showWarnings = FALSE)
+  file.create(response_file, showWarnings = FALSE)
+  addin_registry <- file.path(dir_session, "addins.json")
+  # This is created in attach()
+
+  get_response_timestamp <- function() {
+    readLines(response_lock_file)
+  }
+  # initialise the reponse timestamp to empty string
+  response_time_stamp <- ""
+
+  get_response_lock <- function() {
+    lock_time_stamp <- get_response_timestamp()
+    if (isTRUE(lock_time_stamp != response_time_stamp)) {
+      response_time_stamp <<- lock_time_stamp
+      TRUE
+    } else {
+      FALSE
+    }
+  }
+
+  request_response <- function(command, ...) {
+    request(command, ..., sd = dir_session)
+    wait_start <- Sys.time()
+    while (!get_response_lock()) {
+      if ((Sys.time() - wait_start) > response_timeout) {
+        stop(
+          "Did not receive a response from VSCode-R API within ",
+          response_timeout, " seconds."
+        )
+      }
+      Sys.sleep(0.1)
+    }
+    jsonlite::read_json(response_file)
+  }
+
+  rstudioapi_util_env <- new.env()
+  rstudioapi_env <- new.env(parent = rstudioapi_util_env)
+  source(file.path(dir_extension, "rstudioapi_util.R"),
+    local = rstudioapi_util_env,
+  )
+  source(file.path(dir_extension, "rstudioapi.R"),
+    local = rstudioapi_env
+  )
+  setHook(
+    packageEvent("rstudioapi", "onLoad"),
+    function(...) {
+      rstudioapi_util_env$rstudioapi_patch_hook(rstudioapi_env)
+    }
+  )
+}
+
+print.help_files_with_topic <- function(h, ...) {
+  viewer <- getOption("vsc.helpPanel", "Two")
+  if (!identical(FALSE, viewer) && length(h) >= 1 && is.character(h)) {
+    file <- h[1]
+    path <- dirname(file)
+    dirpath <- dirname(path)
+    pkgname <- basename(dirpath)
+    requestPath <- paste0(
+      "/library/",
+      pkgname,
+      "/html/",
+      basename(file),
+      ".html"
+    )
+    request(command = "help", requestPath = requestPath, viewer = viewer)
+  } else {
+    utils:::print.help_files_with_topic(h, ...)
+  }
+  invisible(h)
+}
+
+print.hsearch <- function(x, ...) {
+  viewer <- getOption("vsc.helpPanel", "Two")
+  if (!identical(FALSE, viewer) && length(x) >= 1) {
+    requestPath <- paste0(
+      "/doc/html/Search?pattern=",
+      tools:::escapeAmpersand(x$pattern),
+      paste0("&fields.", x$fields, "=1",
+        collapse = ""
+      ),
+      if (!is.null(x$agrep)) paste0("&agrep=", x$agrep),
+      if (!x$ignore.case) "&ignore.case=0",
+      if (!identical(
+        x$types,
+        getOption("help.search.types")
+      )) {
+        paste0("&types.", x$types, "=1",
+          collapse = ""
+        )
+      },
+      if (!is.null(x$package)) {
+        paste0(
+          "&package=",
+          paste(x$package, collapse = ";")
+        )
+      },
+      if (!identical(x$lib.loc, .libPaths())) {
+        paste0(
+          "&lib.loc=",
+          paste(x$lib.loc, collapse = ";")
+        )
+      }
+    )
+    request(command = "help", requestPath = requestPath, viewer = viewer)
+  } else {
+    utils:::print.hsearch(x, ...)
+  }
+  invisible(x)
+}
+
+# a copy of .S3method(), since this function is new in R 4.0
+.S3method <- function(generic, class, method) {
+  if (missing(method)) {
+    method <- paste(generic, class, sep = ".")
+  }
+  method <- match.fun(method)
+  registerS3method(generic, class, method, envir = parent.frame())
+  invisible(NULL)
+}

--- a/R/vsc.R
+++ b/R/vsc.R
@@ -5,7 +5,7 @@ tempdir <- tempdir()
 homedir <- Sys.getenv(
   if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"
 )
-dir_extension <- Sys.getenv("VSCODE_WATCHER_DIR")
+dir_extension <- Sys.getenv("VSCODE_WATCHER_DIR", file.path(homedir, ".vscode-R"))
 request_file <- file.path(dir_extension, "request.log")
 request_lock_file <- file.path(dir_extension, "request.lock")
 

--- a/R/vsc.R
+++ b/R/vsc.R
@@ -203,13 +203,6 @@ if (show_plot) {
   setHook("plot.new", new_plot, "replace")
   setHook("grid.newpage", new_plot, "replace")
 
-  # rebind(".External.graphics", function(...) {
-  #   out <- .Primitive(".External.graphics")(...)
-  #   if (check_null_dev()) {
-  #     plot_updated <<- TRUE
-  #   }
-  #   out
-  # }, "base")
   .External.graphics <- function(...) {
     out <- .Primitive(".External.graphics")(...)
     if (check_null_dev()) {
@@ -389,7 +382,6 @@ if (show_view) {
     }
   }
 
-  # rebind("View", show_dataview, "utils")
   View <- show_dataview
 }
 

--- a/R/vsc.R
+++ b/R/vsc.R
@@ -1,4 +1,3 @@
-
 pid <- Sys.getpid()
 wd <- getwd()
 tempdir <- tempdir()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import * as completions from './completions';
 // global objects used in other files
 export let rWorkspace: workspaceViewer.WorkspaceDataProvider | undefined = undefined;
 export let globalRHelp: rHelp.RHelp | undefined = undefined;
+export let extensionContext: vscode.ExtensionContext | undefined = undefined;
 
 
 // Called (once) when the extension is activated
@@ -29,7 +30,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
     // is used to export an interface to the help panel
     // this export is used e.g. by vscode-r-debugger to show the help panel from within debug sessions
     const rExtension = new apiImplementation.RExtensionImplementation();
-
+    
+    // assign extension context to global variable
+    extensionContext = context;
 
     // register commands specified in package.json
     const commands = {

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -1,16 +1,16 @@
 'use strict';
 
 import * as path from 'path';
-import * as os from 'os';
 import { pathExists } from 'fs-extra';
 import { isDeepStrictEqual } from 'util';
 
 import * as vscode from 'vscode';
 
+import { extensionContext } from './extension';
 import * as util from './util';
 import * as selection from './selection';
 import { getSelection } from './selection';
-import { removeSessionFiles } from './session';
+import { removeSessionFiles, watcherDir } from './session';
 import { config, delay, getRterm } from './util';
 export let rTerm: vscode.Terminal;
 
@@ -116,10 +116,14 @@ export async function createRTerm(preserveshow?: boolean): Promise<boolean> {
                 shellPath: termPath,
                 shellArgs: termOpt,
             };
+            const newRprofile = extensionContext.asAbsolutePath(path.join('R', '.Rprofile'));
+            const initR = extensionContext.asAbsolutePath(path.join('R', 'init.R'));
             if (config().get<boolean>('sessionWatcher')) {
                 termOptions.env = {
                     R_PROFILE_USER_OLD: process.env.R_PROFILE_USER,
-                    R_PROFILE_USER: path.join(os.homedir(), '.vscode-R', '.Rprofile'),
+                    R_PROFILE_USER: newRprofile,
+                    VSCODE_INIT_R: initR,
+                    VSCODE_WATCHER_DIR: watcherDir
                 };
             }
             rTerm = vscode.window.createTerminal(termOptions);

--- a/src/session.ts
+++ b/src/session.ts
@@ -43,8 +43,7 @@ let activeBrowserExternalUri: Uri;
 export function deploySessionWatcher(extensionPath: string): void {
     console.info(`[deploySessionWatcher] extensionPath: ${extensionPath}`);
     resDir = path.join(extensionPath, 'dist', 'resources');
-    const tempPath = os.tmpdir();
-    watcherDir = path.join(tempPath, '.vscode-R');
+    watcherDir = path.join(os.homedir(), '.vscode-R');
     console.info(`[deploySessionWatcher] watcherDir: ${watcherDir}`);
     if (!fs.existsSync(watcherDir)) {
         console.info('[deploySessionWatcher] watcherDir not exists, create directory');

--- a/src/session.ts
+++ b/src/session.ts
@@ -49,6 +49,9 @@ export function deploySessionWatcher(extensionPath: string): void {
         console.info('[deploySessionWatcher] watcherDir not exists, create directory');
         fs.mkdirSync(watcherDir);
     }
+    const initPath = path.join(extensionPath, 'R', 'init.R');
+    const linkPath = path.join(watcherDir, 'init.R');
+    fs.writeFileSync(linkPath, `local(source("${initPath.replace(/\\/g, '\\\\')}", chdir = TRUE, local = TRUE))`);
 }
 
 export function startRequestWatcher(sessionStatusBarItem: StatusBarItem): void {

--- a/src/session.ts
+++ b/src/session.ts
@@ -51,7 +51,7 @@ export function deploySessionWatcher(extensionPath: string): void {
     }
     const initPath = path.join(extensionPath, 'R', 'init.R');
     const linkPath = path.join(watcherDir, 'init.R');
-    fs.writeFileSync(linkPath, `local(source("${initPath.replace(/\\/g, '\\\\')}", chdir = TRUE, local = TRUE))`);
+    fs.writeFileSync(linkPath, `local(source("${initPath.replace(/\\/g, '\\\\')}", chdir = TRUE, local = TRUE))\n`);
 }
 
 export function startRequestWatcher(sessionStatusBarItem: StatusBarItem): void {

--- a/src/session.ts
+++ b/src/session.ts
@@ -18,7 +18,7 @@ import { rWorkspace, globalRHelp } from './extension';
 
 export let globalenv: any;
 let resDir: string;
-let watcherDir: string;
+export let watcherDir: string;
 let requestFile: string;
 let requestLockFile: string;
 let requestTimeStamp: number;
@@ -43,21 +43,13 @@ let activeBrowserExternalUri: Uri;
 export function deploySessionWatcher(extensionPath: string): void {
     console.info(`[deploySessionWatcher] extensionPath: ${extensionPath}`);
     resDir = path.join(extensionPath, 'dist', 'resources');
-    watcherDir = path.join(os.homedir(), '.vscode-R');
+    const tempPath = os.tmpdir();
+    watcherDir = path.join(tempPath, '.vscode-R');
     console.info(`[deploySessionWatcher] watcherDir: ${watcherDir}`);
     if (!fs.existsSync(watcherDir)) {
         console.info('[deploySessionWatcher] watcherDir not exists, create directory');
         fs.mkdirSync(watcherDir);
     }
-    console.info('[deploySessionWatcher] Deploy init.R');
-    fs.copySync(path.join(extensionPath, 'R', 'init.R'), path.join(watcherDir, 'init.R'));
-    console.info('[deploySessionWatcher] Deploy .Rprofile');
-    fs.copySync(path.join(extensionPath, 'R', '.Rprofile'), path.join(watcherDir, '.Rprofile'));
-    console.info('[deploySessionWatcher] Deploy rstudioapi_util.R');
-    fs.copySync(path.join(extensionPath, 'R', 'rstudioapi_util.R'), path.join(watcherDir, 'rstudioapi_util.R'));
-    console.info('[deploySessionWatcher] Deploy rstudioapi.R');
-    fs.copySync(path.join(extensionPath, 'R', 'rstudioapi.R'), path.join(watcherDir, 'rstudioapi.R'));
-    console.info('[deploySessionWatcher] Done');
 }
 
 export function startRequestWatcher(sessionStatusBarItem: StatusBarItem): void {


### PR DESCRIPTION
This PR contains some restructuring of the R code used in the extension. Changes are:
- Move function definitions from `init.R` to their own file `vsc.R`. This hopefully makes it easier to contribute new functions etc. (in `vsc.R`) without having to worry about the technical issues solved in `init.R`.
- Attach `tools:vscode` after loading default packages. This makes it possible to mask e.g. `View` without having to mess with the environment of the `utils` package itself.
- Source R code directly from the installation directory of the extension. Since vscode is guaranteed to have access to its own files and the R process is launched by vscode, I don't think this should cause any read-access issues (please correct me if I'm wrong here)
- ~Move temporary files (`request.log`, `request.lock`) to a temporary directory instead of the home directory.~

~The last two points imply that the directory `~/.vscode-R` is not needed anymore.~


*~Todo:~*
- ~Check Rstudio api~
- ~Find solution for self-managed sessions (Maybe we should leave an optional "link file" in `~/.vscode-R`? Or expose the path to `init.R` in the extension files somehow and let the user copy it to their `.Rprofile`?)~
