### PR TITLE
Add tasks Check, Document, Install, Test

### DIFF
--- a/package.json
+++ b/package.json
@@ -997,7 +997,12 @@
           "description": "Remove hidden items when clearing workspace."
         }
       }
-    }
+    },
+    "taskDefinitions": [
+      {
+        "type": "R"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "webpack --mode production",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -139,6 +139,25 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
     vscode.languages.registerCompletionItemProvider('r', new completions.StaticCompletionItemProvider(), '@');
 
 
+    // register task provider
+    const type = 'R';
+    vscode.tasks.registerTaskProvider(type, {
+        provideTasks() {
+            return [
+                new vscode.Task({type: type}, vscode.TaskScope.Workspace, 'Document', 'R',
+                    new vscode.ShellExecution('Rscript -e "devtools::document()"')),
+                new vscode.Task({type: type}, vscode.TaskScope.Workspace, 'Install', 'R',
+                    new vscode.ShellExecution('Rscript -e "devtools::install()"')),
+                new vscode.Task({type: type}, vscode.TaskScope.Workspace, 'Test', 'R',
+                    new vscode.ShellExecution('Rscript -e "devtools::test()"')),
+            ];
+        },
+        resolveTask(task: vscode.Task) {
+            return task;
+        }
+    });
+
+
     // deploy session watcher (if configured by user)
     const enableSessionWatcher = util.config().get<boolean>('sessionWatcher', false);
     if (enableSessionWatcher) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -144,6 +144,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
     vscode.tasks.registerTaskProvider(type, {
         provideTasks() {
             return [
+                new vscode.Task({type: type}, vscode.TaskScope.Workspace, 'Check', 'R',
+                    new vscode.ShellExecution('Rscript -e "devtools::check()"')),
                 new vscode.Task({type: type}, vscode.TaskScope.Workspace, 'Document', 'R',
                     new vscode.ShellExecution('Rscript -e "devtools::document()"')),
                 new vscode.Task({type: type}, vscode.TaskScope.Workspace, 'Install', 'R',


### PR DESCRIPTION
Relevant to #59 

**What problem did you solve?**

Adds some Tasks (Document, Install, Test).

I'm hoping that having these in the code will encourage others to add tasks they think would be useful, since it should be pretty clear how these can be copy-pasted to add new tasks.

**How can I check this pull request?**

Run command `Tasks: Run Task`. Select `R`. Observe `R: Document`, `R: Install`, `R: Check`. Select one of them. Select `Continue without scanning the task output`. Observe that the Rscript command is sent to a new terminal. E.g., for `R: Install`, the following appears in the terminal:

`Executing task: Rscript -e "devtools::install()"`