### PR TITLE
Add knit task

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,6 +152,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
                     new vscode.ShellExecution('Rscript -e "devtools::install()"')),
                 new vscode.Task({type: type}, vscode.TaskScope.Workspace, 'Test', 'R',
                     new vscode.ShellExecution('Rscript -e "devtools::test()"')),
+                new vscode.Task({type: type}, vscode.TaskScope.Workspace, 'Knit', 'R',
+                    new vscode.ShellExecution('Rscript -e "rmarkdown::render(\'${file}\')"')),
             ];
         },
         resolveTask(task: vscode.Task) {


### PR DESCRIPTION
Expand list of tasks so that documents kan be rendered in a fresh session using tasks. Reference: https://github.com/Ikuyadeu/vscode-R/issues/59#issuecomment-813690674.

Open an `.Rmd` file, run the "R: Knit" task.

I wonder:

- How can we expand the task so that the rendered document is opened upon completion? Should we add an `rstudioapi::xxx()` call to the command line?
- Do we need "Knit as HTML", "Knit as PDF", "Knit all"?
- Should we eventually remap the Ctrl + Shift + K shortcut to this task
    - and enable it also for `.R` files
    - and also remap other shortcuts?