### PR TITLE
shim the rstudioapi if it has already been loaded

### DIFF
--- a/R/vsc.R
+++ b/R/vsc.R
@@ -560,6 +560,14 @@ if (rstudioapi_enabled()) {
       rstudioapi_util_env$rstudioapi_patch_hook(rstudioapi_env)
     }
   )
+  if ("rstudioapi" %in% loadedNamespaces()) {
+    # if the rstudioapi is already loaded, for example via a call to
+    # library(tidyverse) in the user's profile, we need to shim it now.
+    # There's no harm in having also registered the hook in this case. It can
+    # work in the event that the namespace is unloaded and reloaded.
+    rstudioapi_util_env$rstudioapi_patch_hook(rstudioapi_env)
+  }
+  
 }
 
 print.help_files_with_topic <- function(h, ...) {


### PR DESCRIPTION
fixes bug reported in #605

**What problem did you solve?**

If the user has something in their .Rprofile that refers to the `rstudioapi` namespace, then that causes the namespace to be loaded before we can attach our onLoad hook in the extension R session initialisation routine.

RStudio Addins can be browsed via the picker, but not run in this case.

**(If you do not have screenshot) How can I check this pull request?**

If you want to verify the bug you can add `rstudioapi::is_available()` to your alongside `vsc.rstudioapi = TRUE` in your `.Rprofile` and then try to run

`rstudioapi::insert_text("test")`

You should see: `Error: RStudio not running`

With this PR in place, try the same sequence and the text will be inserted into the current text editor window.


