### PR TITLE
Fix replacing `base::.External.graphics`

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -66,7 +66,7 @@ init_last <- function() {
     .vsc.page_viewer <- .vsc$show_page_viewer
 
     # assign functions that are optional:
-    for (funcName in c("View", ".External.graphics")) {
+    for (funcName in c("View")) {
       if (funcName %in% ls(.vsc)) {
         assign(funcName, .vsc[[funcName]])
       }

--- a/R/vsc.R
+++ b/R/vsc.R
@@ -47,6 +47,24 @@ capture_str <- function(object) {
   )
 }
 
+rebind <- function(sym, value, ns) {
+  if (is.character(ns)) {
+    Recall(sym, value, getNamespace(ns))
+    pkg <- paste0("package:", ns)
+    if (pkg %in% search()) {
+      Recall(sym, value, as.environment(pkg))
+    }
+  } else if (is.environment(ns)) {
+    if (bindingIsLocked(sym, ns)) {
+      unlockBinding(sym, ns)
+      on.exit(lockBinding(sym, ns))
+    }
+    assign(sym, value, ns)
+  } else {
+    stop("ns must be a string or environment")
+  }
+}
+
 address <- function(x) {
   info <- utils::capture.output(.Internal(inspect(x, 0L)))
   gsub("@([a-z0-9]+)\\s+.+", "\\1", info[[1]])
@@ -202,13 +220,13 @@ if (show_plot) {
   setHook("plot.new", new_plot, "replace")
   setHook("grid.newpage", new_plot, "replace")
 
-  .External.graphics <- function(...) {
+  rebind(".External.graphics", function(...) {
     out <- .Primitive(".External.graphics")(...)
     if (check_null_dev()) {
       plot_updated <<- TRUE
     }
     out
-  }
+  }, "base")
 
   update_plot()
   addTaskCallback(update_plot, name = "vsc.plot")


### PR DESCRIPTION
# What problem did you solve?

Closes #624 

This PR fixes a regression introduced in #602 where `base::.External.graphics` is not successfully replaced to trigger graphics replay so that functions like `abline()`, `points()` could cause the plot to refresh.

## (If you do not have screenshot) How can I check this pull request?

When each the following lines is run, the png plot file is refreshed in vscode.

```r
plot(rnorm(100))
abline(h = 0, col = "red")
abline(v = 0, col = "blue")
```