### PR TITLE
Prefer rPath from PATH

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -35,7 +35,9 @@ export async function getRpathFromSystem(): Promise<string> {
     let rpath = '';
     const platform: string = process.platform;
     
-    if ( platform === 'win32') {
+    rpath ||= getRfromEnvPath(platform);
+
+    if ( !rpath && platform === 'win32') {
         // Find path from registry
         try {
             const key = new winreg({
@@ -49,8 +51,6 @@ export async function getRpathFromSystem(): Promise<string> {
             rpath = '';
         }
     }
-
-    rpath ||= getRfromEnvPath(platform);
 
     return rpath;
 }


### PR DESCRIPTION
## What problem did you solve?

This PR changes the order in which the extension tries to find an R path on windows.

I think it makes sense to prefer `PATH` over the registry since this is more transparent and makes it easier to switch between R versions systemwide (i.e. normal terminals and vscode-R).

## How can I check this pull request?
Leave `r.rterm.windows` empty, have different r paths in the `PATH` environment variable and registry, and run `R: create R Terminal`
