### PR TITLE
Don't run chunks with eval = FALSE. Fixes #651

### DIFF
--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -314,7 +314,9 @@ export async function runAboveChunks(chunks: RMarkdownChunk[] = _getChunks(),
 
   for (let i = firstChunkId ; i <= previousChunkId ; i++) {
     const chunk = chunks.filter(e => e.id === i)[0];
-    codeRanges.push(chunk.codeRange);
+    if (chunk.eval) {
+      codeRanges.push(chunk.codeRange);
+    }
   }
   await runChunksInTerm(codeRanges);
 }
@@ -330,7 +332,9 @@ export async function runBelowChunks(chunks: RMarkdownChunk[] = _getChunks(),
 
   for (let i = nextChunkId ; i <= lastChunkId ; i++) {
     const chunk = chunks.filter(e => e.id === i)[0];
-    codeRanges.push(chunk.codeRange);
+    if (chunk.eval) {
+      codeRanges.push(chunk.codeRange);
+    }
   }
   await runChunksInTerm(codeRanges);
 }
@@ -359,7 +363,9 @@ export async function runAllChunks(chunks: RMarkdownChunk[] = _getChunks()): Pro
 
   for (let i = firstChunkId ; i <= lastChunkId ; i++) {
     const chunk = chunks.filter(e => e.id === i)[0];
-    codeRanges.push(chunk.codeRange);
+    if (chunk.eval) {
+      codeRanges.push(chunk.codeRange);
+    }
   }
   await runChunksInTerm(codeRanges);
 }


### PR DESCRIPTION
# What problem did you solve?

When using the code lens actions in the extension, such as "Run Above", code chunks with `eval = FALSE` are evaluated although they probably should not be since they often contain pseudo-code or other things that are not intended to actually be run. The default behavior in R Studio, for instance, is not to run these code chunks. See #653 for more details.

The extension already collects information on the value of `eval`, so the fix is just to implement a few if-clauses to prevent evaluation when `eval = FALSE`. I purposely did not include actions `runNextChunk`, `runPreviousChunk`, `runCurrentChunk`, and `runCurrentAndBelowChunks` since I think they signal that the user explicitly wants the specific chunk to be run. This also conforms to the behavior in R Studio when using "Run Next Chunk" and "Run Current Chunk".

## Screenshot

![Peek 2021-05-29 22-00](https://user-images.githubusercontent.com/13087841/120083502-675c6500-c0c9-11eb-98c7-fbba74da8801.gif)

