### PR TITLE
Revert syntax for lambda

### DIFF
--- a/syntax/r.json
+++ b/syntax/r.json
@@ -404,47 +404,6 @@
                             "name": "punctuation.separator.parameters.r"
                         }
                     ]
-                },
-                {
-                    "begin": "\\b(\\)\\s*(\\()",
-                    "beginCaptures": {
-                        "1": {
-                            "name": "keyword.control.r"
-                        },
-                        "2": {
-                            "name": "punctuation.section.parens.begin.r"
-                        }
-                    },
-                    "end": "\\)",
-                    "endCaptures": {
-                        "0": {
-                            "name": "punctuation.section.parens.end.r"
-                        }
-                    },
-                    "name": "meta.function.r",
-                    "contentName": "meta.function.parameters.r",
-                    "patterns": [
-                        {
-                            "include": "#comments"
-                        },
-                        {
-                            "match": "(?:[a-zA-Z._][\\w.]*|`[^`]+`)",
-                            "name": "variable.parameter.r"
-                        },
-                        {
-                            "begin": "(?==)",
-                            "end": "(?=[,)])",
-                            "patterns": [
-                                {
-                                    "include": "source.r"
-                                }
-                            ]
-                        },
-                        {
-                            "match": ",",
-                            "name": "punctuation.separator.parameters.r"
-                        }
-                    ]
                 }
             ]
         },


### PR DESCRIPTION
# What problem did you solve?

Closes #656 

#647 introduces some bug in syntax. This PR reverts the part that causes syntax highlighting to stop working.

@Ikuyadeu I suggest that we do a quick release for this.