### PR TITLE
Code cells in .R files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
     // is used to export an interface to the help panel
     // this export is used e.g. by vscode-r-debugger to show the help panel from within debug sessions
     const rExtension = new apiImplementation.RExtensionImplementation();
-    
+
     // assign extension context to global variable
     extensionContext = context;
 
@@ -41,7 +41,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         // create R terminal
         'r.createRTerm': rTerminal.createRTerm,
 
-        // run code from editor in terminal 
+        // run code from editor in terminal
         'r.nrow': () => rTerminal.runSelectionOrWord(['nrow']),
         'r.length': () => rTerminal.runSelectionOrWord(['length']),
         'r.head': () => rTerminal.runSelectionOrWord(['head']),
@@ -103,7 +103,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
         // (help related commands are registered in rHelp.initializeHelp)
     };
-    for(const key in commands){
+    for (const key in commands) {
         context.subscriptions.push(vscode.commands.registerCommand(key, commands[key]));
     }
 
@@ -115,15 +115,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
     // register on-enter rule for roxygen comments
     const wordPattern = /(-?\d*\.\d\w*)|([^`~!@$^&*()=+[{\]}\\|;:'",<>/\s]+)/g;
     vscode.languages.setLanguageConfiguration('r', {
-		onEnterRules: [
-			{
-				// Automatically continue roxygen comments: #'
-				action: { indentAction: vscode.IndentAction.None, appendText: '#\' ' },
-				beforeText: /^#'.*/,
-			},
-		],
-		wordPattern,
-	});
+        onEnterRules: [
+            {
+                // Automatically continue roxygen comments: #'
+                action: { indentAction: vscode.IndentAction.None, appendText: '#\' ' },
+                beforeText: /^#'.*/,
+            },
+        ],
+        wordPattern,
+    });
 
     // initialize httpgd viewer
     globalHttpgdManager = httpgdViewer.initializeHttpgd();
@@ -133,7 +133,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
 
 
     // register codelens and complmetion providers for r markdown
-    vscode.languages.registerCodeLensProvider('rmd', new rmarkdown.RMarkdownCodeLensProvider());
+    vscode.languages.registerCodeLensProvider(['r', 'rmd'], new rmarkdown.RMarkdownCodeLensProvider());
     vscode.languages.registerCompletionItemProvider('rmd', new rmarkdown.RMarkdownCompletionItemProvider(), ' ', ',');
 
 
@@ -148,13 +148,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
     vscode.tasks.registerTaskProvider(type, {
         provideTasks() {
             return [
-                new vscode.Task({type: type}, vscode.TaskScope.Workspace, 'Check', 'R',
+                new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Check', 'R',
                     new vscode.ShellExecution('Rscript -e "devtools::check()"')),
-                new vscode.Task({type: type}, vscode.TaskScope.Workspace, 'Document', 'R',
+                new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Document', 'R',
                     new vscode.ShellExecution('Rscript -e "devtools::document()"')),
-                new vscode.Task({type: type}, vscode.TaskScope.Workspace, 'Install', 'R',
+                new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Install', 'R',
                     new vscode.ShellExecution('Rscript -e "devtools::install()"')),
-                new vscode.Task({type: type}, vscode.TaskScope.Workspace, 'Test', 'R',
+                new vscode.Task({ type: type }, vscode.TaskScope.Workspace, 'Test', 'R',
                     new vscode.ShellExecution('Rscript -e "devtools::test()"')),
             ];
         },
@@ -195,10 +195,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         void vscode.commands.executeCommand('setContext', 'r.WorkspaceViewer:show', enableSessionWatcher);
 
         // if session watcher is active, register dyamic completion provider
-        const liveTriggerCharacters = ['', '[', '(', ',', '$', '@', '"', '\'' ];
+        const liveTriggerCharacters = ['', '[', '(', ',', '$', '@', '"', '\''];
         vscode.languages.registerCompletionItemProvider('r', new completions.LiveCompletionItemProvider(), ...liveTriggerCharacters);
     }
 
     return rExtension;
 }
-

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -7,7 +7,7 @@ import { runChunksInTerm } from './rTerminal';
 import { config } from './util';
 
 function isRDocument(document: TextDocument) {
-  return (languages.match('r', document) > 0);
+  return (document.languageId === 'r');
 }
 
 function isRChunkLine(text: string) {

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -1,7 +1,7 @@
 import {
   CancellationToken, CodeLens, CodeLensProvider,
   CompletionItem, CompletionItemProvider,
-  Event, EventEmitter, Position, Range, TextDocument, TextEditorDecorationType, window, Selection, languages
+  Event, EventEmitter, Position, Range, TextDocument, TextEditorDecorationType, window, Selection
 } from 'vscode';
 import { runChunksInTerm } from './rTerminal';
 import { config } from './util';

--- a/src/rmarkdown.ts
+++ b/src/rmarkdown.ts
@@ -1,23 +1,33 @@
 import {
   CancellationToken, CodeLens, CodeLensProvider,
   CompletionItem, CompletionItemProvider,
-  Event, EventEmitter, Position, Range, TextDocument, TextEditorDecorationType, window, Selection
+  Event, EventEmitter, Position, Range, TextDocument, TextEditorDecorationType, window, Selection, languages
 } from 'vscode';
 import { runChunksInTerm } from './rTerminal';
 import { config } from './util';
 
-function isChunkStartLine(text: string) {
-  if (text.match(/^\s*```+\s*\{\w+\s*.*$/g)) {
-    return true;
-  }
-  return false;
+function isRDocument(document: TextDocument) {
+  return (languages.match('r', document) > 0);
 }
 
-function isChunkEndLine(text: string) {
-  if (text.match(/^\s*```+\s*$/g)) {
-    return true;
+function isRChunkLine(text: string) {
+  return (!!text.match(/^#+\s*%%/g));
+}
+
+function isChunkStartLine(text: string, isRDoc: boolean) {
+  if (isRDoc) {
+    return (isRChunkLine(text));
+  } else {
+    return (!!text.match(/^\s*```+\s*\{\w+\s*.*$/g));
   }
-  return false;
+}
+
+function isChunkEndLine(text: string, isRDoc: boolean) {
+  if (isRDoc) {
+    return (isRChunkLine(text));
+  } else {
+    return (!!text.match(/^\s*```+\s*$/g));
+  }
 }
 
 function getChunkLanguage(text: string) {
@@ -55,14 +65,14 @@ export class RMarkdownCodeLensProvider implements CodeLensProvider {
     const rmdCodeLensCommands: string[] = config().get('rmarkdown.codeLensCommands');
 
     // Iterate through all code chunks for getting chunk information for both CodeLens and chunk background color (set by `editor.setDecorations`)
-    for (let i = 1 ; i <= chunks.length ; i++) {
+    for (let i = 1; i <= chunks.length; i++) {
       const chunk = chunks.filter(e => e.id === i)[0];
       const chunkRange = chunk.chunkRange;
       const line = chunk.startLine;
       chunkRanges.push(chunkRange);
 
       // Enable/disable only CodeLens, without affecting chunk background color.
-      if (config().get<boolean>('rmarkdown.enableCodeLens') && chunk.language === 'r') {
+      if (config().get<boolean>('rmarkdown.enableCodeLens') && (chunk.language === 'r') || isRDocument(document)) {
         if (token.isCancellationRequested) {
           break;
         }
@@ -141,9 +151,9 @@ export class RMarkdownCodeLensProvider implements CodeLensProvider {
     // For user-specified options, both options and sort order are based on options specified in settings UI or settings.json.
     return this.codeLenses.
       filter(e => rmdCodeLensCommands.includes(e.command.command)).
-      sort(function(a, b) {
+      sort(function (a, b) {
         const sorted = rmdCodeLensCommands.indexOf(a.command.command) -
-                       rmdCodeLensCommands.indexOf(b.command.command);
+          rmdCodeLensCommands.indexOf(b.command.command);
         return sorted;
       });
   }
@@ -176,10 +186,11 @@ function getChunks(document: TextDocument): RMarkdownChunk[] {
   let chunkLanguage: string = undefined;
   let chunkOptions: string = undefined;
   let chunkEval: boolean = undefined;
+  const isRDoc = isRDocument(document);
 
   while (line < lines.length) {
     if (chunkStartLine === undefined) {
-      if (isChunkStartLine(lines[line])) {
+      if (isChunkStartLine(lines[line], isRDoc)) {
         chunkId++;
         chunkStartLine = line;
         chunkLanguage = getChunkLanguage(lines[line]);
@@ -187,7 +198,7 @@ function getChunks(document: TextDocument): RMarkdownChunk[] {
         chunkEval = getChunkEval(chunkOptions);
       }
     } else {
-      if (isChunkEndLine(lines[line])) {
+      if (isChunkEndLine(lines[line], isRDoc)) {
         chunkEndLine = line;
 
         const chunkRange = new Range(
@@ -211,10 +222,10 @@ function getChunks(document: TextDocument): RMarkdownChunk[] {
         });
 
         chunkStartLine = undefined;
-        }
       }
-      line++;
     }
+    line++;
+  }
   return chunks;
 }
 
@@ -225,11 +236,13 @@ function getCurrentChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk
   // `- 1` to cover edge case when cursor is at 'chunk end line'
   let chunkEndLineAbove = line - 1;
 
-  while (chunkStartLineAtOrAbove >= 0 && !isChunkStartLine(lines[chunkStartLineAtOrAbove])) {
+  const isRDoc = isRDocument(window.activeTextEditor.document);
+
+  while (chunkStartLineAtOrAbove >= 0 && !isChunkStartLine(lines[chunkStartLineAtOrAbove], isRDoc)) {
     chunkStartLineAtOrAbove--;
   }
 
-  while (chunkEndLineAbove >= 0 && !isChunkEndLine(lines[chunkEndLineAbove])) {
+  while (chunkEndLineAbove >= 0 && !isChunkEndLine(lines[chunkEndLineAbove], isRDoc)) {
     chunkEndLineAbove--;
   }
 
@@ -237,9 +250,9 @@ function getCurrentChunk(chunks: RMarkdownChunk[], line: number): RMarkdownChunk
   if (chunkEndLineAbove < chunkStartLineAtOrAbove) {
     line = chunkStartLineAtOrAbove;
   } else {
-  // Cases: Cursor is above the first chunk, at the first chunk or outside of chunk. Find the 'chunk start line' of the next chunk below the cursor.
+    // Cases: Cursor is above the first chunk, at the first chunk or outside of chunk. Find the 'chunk start line' of the next chunk below the cursor.
     let chunkStartLineBelow = line + 1;
-    while (!isChunkStartLine(lines[chunkStartLineBelow])) {
+    while (!isChunkStartLine(lines[chunkStartLineBelow], isRDoc)) {
       chunkStartLineBelow++;
     }
     line = chunkStartLineBelow;
@@ -287,32 +300,32 @@ function _getStartLine() {
 }
 
 export async function runCurrentChunk(chunks: RMarkdownChunk[] = _getChunks(),
-                                      line: number = _getStartLine()): Promise<void> {
+  line: number = _getStartLine()): Promise<void> {
   const currentChunk = getCurrentChunk(chunks, line);
   await runChunksInTerm([currentChunk.codeRange]);
 }
 
 export async function runPreviousChunk(chunks: RMarkdownChunk[] = _getChunks(),
-                                       line: number = _getStartLine()): Promise<void> {
+  line: number = _getStartLine()): Promise<void> {
   const previousChunk = getPreviousChunk(chunks, line);
   await runChunksInTerm([previousChunk.codeRange]);
 }
 
 export async function runNextChunk(chunks: RMarkdownChunk[] = _getChunks(),
-                                   line: number = _getStartLine()): Promise<void> {
+  line: number = _getStartLine()): Promise<void> {
   const nextChunk = getNextChunk(chunks, line);
   await runChunksInTerm([nextChunk.codeRange]);
 }
 
 export async function runAboveChunks(chunks: RMarkdownChunk[] = _getChunks(),
-                                     line: number = _getStartLine()): Promise<void> {
+  line: number = _getStartLine()): Promise<void> {
   const previousChunk = getPreviousChunk(chunks, line);
   const firstChunkId = 1;
   const previousChunkId = previousChunk.id;
 
   const codeRanges: Range[] = [];
 
-  for (let i = firstChunkId ; i <= previousChunkId ; i++) {
+  for (let i = firstChunkId; i <= previousChunkId; i++) {
     const chunk = chunks.filter(e => e.id === i)[0];
     if (chunk.eval) {
       codeRanges.push(chunk.codeRange);
@@ -322,7 +335,7 @@ export async function runAboveChunks(chunks: RMarkdownChunk[] = _getChunks(),
 }
 
 export async function runBelowChunks(chunks: RMarkdownChunk[] = _getChunks(),
-                                     line: number = _getStartLine()): Promise<void> {
+  line: number = _getStartLine()): Promise<void> {
 
   const nextChunk = getNextChunk(chunks, line);
   const nextChunkId = nextChunk.id;
@@ -330,7 +343,7 @@ export async function runBelowChunks(chunks: RMarkdownChunk[] = _getChunks(),
 
   const codeRanges: Range[] = [];
 
-  for (let i = nextChunkId ; i <= lastChunkId ; i++) {
+  for (let i = nextChunkId; i <= lastChunkId; i++) {
     const chunk = chunks.filter(e => e.id === i)[0];
     if (chunk.eval) {
       codeRanges.push(chunk.codeRange);
@@ -340,14 +353,14 @@ export async function runBelowChunks(chunks: RMarkdownChunk[] = _getChunks(),
 }
 
 export async function runCurrentAndBelowChunks(chunks: RMarkdownChunk[] = _getChunks(),
-                                               line: number = _getStartLine()): Promise<void> {
+  line: number = _getStartLine()): Promise<void> {
   const currentChunk = getCurrentChunk(chunks, line);
   const currentChunkId = currentChunk.id;
   const lastChunkId = chunks.length;
 
   const codeRanges: Range[] = [];
 
-  for (let i = currentChunkId ; i <= lastChunkId ; i++) {
+  for (let i = currentChunkId; i <= lastChunkId; i++) {
     const chunk = chunks.filter(e => e.id === i)[0];
     codeRanges.push(chunk.codeRange);
   }
@@ -361,7 +374,7 @@ export async function runAllChunks(chunks: RMarkdownChunk[] = _getChunks()): Pro
 
   const codeRanges: Range[] = [];
 
-  for (let i = firstChunkId ; i <= lastChunkId ; i++) {
+  for (let i = firstChunkId; i <= lastChunkId; i++) {
     const chunk = chunks.filter(e => e.id === i)[0];
     if (chunk.eval) {
       codeRanges.push(chunk.codeRange);
@@ -377,19 +390,19 @@ function goToChunk(chunk: RMarkdownChunk) {
 }
 
 export function goToPreviousChunk(chunks: RMarkdownChunk[] = _getChunks(),
-                                        line: number = _getStartLine()): void {
+  line: number = _getStartLine()): void {
   const previousChunk = getPreviousChunk(chunks, line);
   goToChunk(previousChunk);
 }
 
 export function goToNextChunk(chunks: RMarkdownChunk[] = _getChunks(),
-                                    line: number = _getStartLine()): void {
+  line: number = _getStartLine()): void {
   const nextChunk = getNextChunk(chunks, line);
   goToChunk(nextChunk);
 }
 
 export function selectCurrentChunk(chunks: RMarkdownChunk[] = _getChunks(),
-                                         line: number = _getStartLine()): void {
+  line: number = _getStartLine()): void {
   const editor = window.activeTextEditor;
   const currentChunk = getCurrentChunk__CursorWithinChunk(chunks, line);
   const lines = editor.document.getText().split(/\r?\n/);
@@ -426,7 +439,7 @@ export class RMarkdownCompletionItemProvider implements CompletionItemProvider {
 
   public provideCompletionItems(document: TextDocument, position: Position): CompletionItem[] {
     const line = document.lineAt(position).text;
-    if (isChunkStartLine(line) && getChunkLanguage(line) === 'r') {
+    if (isChunkStartLine(line, false) && getChunkLanguage(line) === 'r') {
       return this.chunkOptionCompletionItems;
     }
 


### PR DESCRIPTION
Implements jupyter code block style decorators for .R files, piggybacking on the previous rmarkdown code lens implementation.

# What problem did you solve?
Closes #191 

## Screenshot

![120947678-be001980-c72f-11eb-91c3-4dae45e42c6b](https://user-images.githubusercontent.com/60372411/120961714-dbdc7700-c74d-11eb-84ae-e3dc42ae43df.gif)


## (If you do not have screenshot) How can I check this pull request?
Open .R file, and make a code block like so:

```r
# %% I am a chunk
mtcars
# %%

# %% So am I
2 * 2
# %%

```

Markdown code fences should *not* work in .R files, and the new decorator should *not* work in rmd files

