### PR TITLE
Enable r.sessionWatcher by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -57,8 +57,8 @@ Yes / No
 // Use bracketed paste mode
 "r.bracketedPaste": false,
 
-// Enable R session watcher (experimental)
-"r.sessionWatcher": false,
+// Enable R session watcher
+"r.sessionWatcher": true,
 
 // Delay in milliseconds before sending each line to rterm (only applies if r.bracketedPaste is false)
 "r.rtermSendDelay": 8,

--- a/R/vsc.R
+++ b/R/vsc.R
@@ -34,11 +34,11 @@ request <- function(command, ...) {
   cat(get_timestamp(), file = request_lock_file)
 }
 
-capture_str <- function(object) {
+capture_str <- function(object, max.level = getOption("vsc.str.max.level", 0)) {
   paste0(
     utils::capture.output(
       utils::str(object,
-        max.level = getOption("vsc.str.max.level", 0),
+        max.level = max.level,
         give.attr = FALSE,
         vec.len = 1
       )
@@ -361,7 +361,7 @@ if (show_view) {
             type = typeof(obj),
             length = length(obj),
             size = as.integer(object.size(obj)),
-            value = trimws(capture_str(obj)),
+            value = trimws(capture_str(obj, 0)),
             stringsAsFactors = FALSE,
             check.names = FALSE
           )

--- a/package.json
+++ b/package.json
@@ -1167,8 +1167,8 @@
         },
         "r.sessionWatcher": {
           "type": "boolean",
-          "default": false,
-          "description": "Enable R session watcher (experimental). Required for workspace viewer. Restart required to take effect."
+          "default": true,
+          "description": "Enable R session watcher. Required for workspace viewer and most features to work with an R session. Restart required to take effect."
         },
         "r.rtermSendDelay": {
           "type": "integer",


### PR DESCRIPTION
# What problem did you solve?

Since a file-based session watcher was introduced in #150 one and a half years ago, a lot of features has been implemented around it, and they work well in a wide range of scenarios. This PR changes the status of the session watcher from *experimental* to *normal* by enabling `r.sessionWatcher` by default in the setting as I suggested at <https://github.com/Ikuyadeu/vscode-R/issues/668#issuecomment-860214074>.

## (If you do not have screenshot) How can I check this pull request?

The setting of `r.sessionWatcher` is enabled by default.