### PR TITLE
Minor workspace-related changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1180,6 +1180,11 @@
           "default": false,
           "description": "Remove hidden items when clearing workspace."
         },
+        "r.workspaceViewer.clearPrompt": {
+          "type": "boolean",
+          "default": true,
+          "description": "Prompt the user for confirmation when clearing the workspace."
+        },
         "r.liveShare.timeout": {
           "type": "integer",
           "default": 10000,

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -35,7 +35,10 @@ export class HoverProvider implements vscode.HoverProvider {
         }
         const wordRange = document.getWordRangeAtPosition(position);
         const text = document.getText(wordRange);
-        if (!session.globalenv[text]?.str) {
+        // use juggling check here for both
+        // null and undefined
+        // eslint-disable-next-line eqeqeq
+        if (session.globalenv[text]?.str == null) {
             return null;
         }
         return new vscode.Hover(`\`\`\`\n${session.globalenv[text]?.str}\n\`\`\``);

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -35,6 +35,9 @@ export class HoverProvider implements vscode.HoverProvider {
         }
         const wordRange = document.getWordRangeAtPosition(position);
         const text = document.getText(wordRange);
+        if (!session.globalenv[text]?.str) {
+            return null;
+        }
         return new vscode.Hover(`\`\`\`\n${session.globalenv[text]?.str}\n\`\`\``);
     }
 }

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -35,7 +35,7 @@ export class HoverProvider implements vscode.HoverProvider {
         }
         const wordRange = document.getWordRangeAtPosition(position);
         const text = document.getText(wordRange);
-        return new vscode.Hover(`\`\`\`\n${session.globalenv[text].str}\n\`\`\``);
+        return new vscode.Hover(`\`\`\`\n${session.globalenv[text]?.str}\n\`\`\``);
     }
 }
 
@@ -58,7 +58,7 @@ export class HelpLinkHoverProvider implements vscode.HoverProvider {
         });
         const md = new vscode.MarkdownString(mds.join('  \n'));
         md.isTrusted = true;
-        return new vscode.Hover(md, wordRange);        
+        return new vscode.Hover(md, wordRange);
     }
 }
 
@@ -200,7 +200,7 @@ function getPipelineCompletionItems(document: vscode.TextDocument, position: vsc
         if (line.isEmptyOrWhitespace) {
             continue;
         }
-        
+
         const cleanedLine = cleanLine(line.text);
         if (cleanedLine.length === 0) {
             continue;
@@ -220,7 +220,7 @@ function getPipelineCompletionItems(document: vscode.TextDocument, position: vsc
 
         break;
     }
-    
+
     if (!token.isCancellationRequested && symbol !== undefined) {
         const obj = session.globalenv[symbol];
         if (obj !== undefined && obj.names !== undefined) {


### PR DESCRIPTION
# What problem did you solve?
1. Prevent the str hover provider from shooting debug console errors when an object is not yet defined in the workspace

> At present, when hovering over a symbol that is undefined in the workspace, vscode shoots the error: `Cannot read property 'str' of undefined: TypeError: Cannot read property 'str' of undefined`. This prevents the error from occurring in the console.

2. **Allow environments with appropriate str to have their contents displayed in the workspace viewer**

> Presently, only list-type objects have their str output displayed in the workspace viewer. However, it is possible for environments to have relevant str outputs that mimic list-type objects. This change brings the workspace viewer in line with the current behaviour of the str hover provider.

![image](https://user-images.githubusercontent.com/60372411/122343224-0213cb00-cf35-11eb-986f-120f4ce0c660.png)

3. Contribute setting to toggle "clear workspace" prompt (default is to show prompt)

> The prompt for clearing the workspace is helpful for users, but may be unwanted. This provides a setting to toggle whether a confirmation prompt is shown. (prompt enabled by default). Closes #648 

## (If you do not have screenshot) How can I check this pull request?
1. Check the console for an error when hovering over an undefined object in the workspace
2. Check if environments with str are displayed in the workspace viewer

```r
str.environment <- function(object, ...) {
    object <- as.list(object)
    invisible(
        NextMethod(
            "str", ...,
            no.list = FALSE,
            nest.lev = 0L
        )
    )
}

a <- new.env()
a$b <- 5
```

3. Check the workspaceViewer.clearPrompt setting is functioning appropriately

