### PR TITLE
Add customization options to plot viewer

### DIFF
--- a/html/httpgd/index.ejs
+++ b/html/httpgd/index.ejs
@@ -3,7 +3,7 @@
 
 <head>
     <link href="<%= asWebViewPath('style.css') %> " rel="stylesheet">
-    <link href="<%= asWebViewPath('styleOverwrites.css') %> " rel="stylesheet" class="overwrites" <%- overwriteStyles ? '' : 'disabled' %>>
+    <link href="<%= overwriteCSS %> " rel="stylesheet" class="overwrites" <%- overwriteStyles ? '' : 'disabled' %>>
 </head>
 
 <body>

--- a/html/httpgd/index.ejs
+++ b/html/httpgd/index.ejs
@@ -3,7 +3,7 @@
 
 <head>
     <link href="<%= asWebViewPath('style.css') %> " rel="stylesheet">
-    <link href="<%= overwriteCSS %> " rel="stylesheet" class="overwrites" <%- overwriteStyles ? '' : 'disabled' %>>
+    <link href="<%= overwriteCssPath %> " rel="stylesheet" class="overwrites" <%- overwriteStyles ? '' : 'disabled' %>>
 </head>
 
 <body>

--- a/html/httpgd/index.ejs
+++ b/html/httpgd/index.ejs
@@ -11,7 +11,7 @@
         <%- largePlot?.svg %>
     </div>
     <div id="handler"> </div>
-    <div id="smallPlots" class="<%- useMultirow ? 'multirow' : '' %>">
+    <div id="smallPlots" class="<%- previewPlotLayout%>">
         <% plots.forEach((plot)=> { %>
             <div class="wrapper">
             <%- include(asLocalPath('./smallPlot.ejs'), {plot: plot}) %>

--- a/html/httpgd/index.js
+++ b/html/httpgd/index.js
@@ -65,8 +65,8 @@ window.addEventListener('message', (ev) => {
     else if (msg.message === 'addPlot') {
         addPlot(msg.html);
     }
-    else if (msg.message === 'toggleMultirow') {
-        toggleMultirow(msg.useMultirow);
+    else if (msg.message === 'togglePreviewPlotLayout') {
+        togglePreviewPlotLayout(msg.style);
     }
 });
 function addPlot(html) {
@@ -122,13 +122,9 @@ function findIndex(plotId, smallPlots) {
 function toggleStyle(useOverwrites) {
     cssLink.disabled = !useOverwrites;
 }
-function toggleMultirow(useMultirow) {
-    if (useMultirow) {
-        smallPlotDiv.classList.add('multirow');
-    }
-    else {
-        smallPlotDiv.classList.remove('multirow');
-    }
+function togglePreviewPlotLayout(newStyle) {
+    smallPlotDiv.classList.remove('multirow', 'scroll', 'hidden');
+    smallPlotDiv.classList.add(newStyle);
 }
 ////
 // On window load

--- a/html/httpgd/index.ts
+++ b/html/httpgd/index.ts
@@ -86,8 +86,8 @@ window.addEventListener('message', (ev: MessageEvent<InMessage>) => {
     hidePlot(msg.plotId);
   } else if(msg.message === 'addPlot'){
     addPlot(msg.html);
-  } else if(msg.message === 'toggleMultirow'){
-    toggleMultirow(msg.useMultirow);
+  } else if(msg.message === 'togglePreviewPlotLayout'){
+    togglePreviewPlotLayout(msg.style);
   }
 });
 
@@ -162,12 +162,9 @@ function toggleStyle(useOverwrites: boolean): void {
   cssLink.disabled = !useOverwrites;
 }
 
-function toggleMultirow(useMultirow: boolean): void {
-  if(useMultirow){
-    smallPlotDiv.classList.add('multirow');
-  } else{
-    smallPlotDiv.classList.remove('multirow');
-  }
+function togglePreviewPlotLayout(newStyle: PreviewPlotLayout): void {
+  smallPlotDiv.classList.remove('multirow', 'scroll', 'hidden');
+  smallPlotDiv.classList.add(newStyle);
 }
 
 

--- a/html/httpgd/style.css
+++ b/html/httpgd/style.css
@@ -64,6 +64,10 @@ svg {
     flex-wrap: wrap;
 }
 
+#smallPlots.hidden {
+    display: none;
+}
+
 /* Each small plot: */
 
 #smallPlots .wrapper {

--- a/html/httpgd/webviewMessages.d.ts
+++ b/html/httpgd/webviewMessages.d.ts
@@ -40,9 +40,11 @@ interface ToggleStyleMessage extends IMessage {
   message: 'toggleStyle',
   useOverwrites: boolean
 }
-interface ToggleMultirowMessage extends IMessage {
-  message: 'toggleMultirow',
-  useMultirow: boolean
+
+type PreviewPlotLayout = 'multirow' | 'scroll' | 'hidden';
+interface PreviewPlotLayoutMessage extends IMessage {
+  message: 'togglePreviewPlotLayout',
+  style: PreviewPlotLayout
 }
 
 interface HidePlotMessage extends IMessage {
@@ -55,5 +57,5 @@ interface AddPlotMessage extends IMessage {
   html: string
 }
 
-type InMessage = UpdatePlotMessage | FocusPlotMessage | ToggleStyleMessage | HidePlotMessage | AddPlotMessage | ToggleMultirowMessage;
+type InMessage = UpdatePlotMessage | FocusPlotMessage | ToggleStyleMessage | HidePlotMessage | AddPlotMessage | PreviewPlotLayoutMessage;
 

--- a/package.json
+++ b/package.json
@@ -649,9 +649,9 @@
         "icon": "$(symbol-color)"
       },
       {
-        "title": "Toggle Multirow",
+        "title": "Toggle Preview Plot Layout",
         "category": "R Plot",
-        "command": "r.plot.toggleMultirow",
+        "command": "r.plot.togglePreviewPlots",
         "icon": "$(list-flat)"
       },
       {
@@ -855,7 +855,7 @@
         {
           "group": "httpgd",
           "when": "resourceScheme =~ /webview/ && r.plot.active",
-          "command": "r.plot.toggleMultirow"
+          "command": "r.plot.togglePreviewPlots"
         },
         {
           "group": "httpgd",
@@ -1223,11 +1223,13 @@
           "default": "multirow",
           "enum": [
             "multirow",
-            "scroll"
+            "scroll",
+            "hidden"
           ],
           "enumDescriptions": [
             "Show in multiple rows",
-            "Show scrollbar"
+            "Show scrollbar",
+            "Don't show preview plots"
           ],
           "markdownDescription": "How to display plot previews if more than one row required."
         },

--- a/package.json
+++ b/package.json
@@ -1242,6 +1242,11 @@
           "type": "number",
           "default": 10,
           "markdownDescription": "Interval in ms to wait between plot refreshs."
+        },
+        "r.plot.customStyleOverwrites": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Path to a custom CSS file to be used for `r.plot.toggleStyle`. WARNING: replaces default CSS overwrites!"
         }
       }
     },

--- a/src/plotViewer/httpgdTypes.d.ts
+++ b/src/plotViewer/httpgdTypes.d.ts
@@ -2,6 +2,7 @@
 
 import * as vscode from 'vscode';
 import { HttpgdManager } from '.';
+import { PreviewPlotLayout } from './webviewMessages';
 
 export type MaybePromise<T> = T | Promise<T>;
 
@@ -85,7 +86,7 @@ export interface HttpgdViewerOptions {
     viewColumn?: vscode.ViewColumn;
     htmlRoot: string;
     stripStyles?: boolean;
-    useMultirow?: boolean;
+    previewPlotLayout?: PreviewPlotLayout,
     resizeTimeoutLength?: number;
     refreshTimeoutLength?: number;
 }

--- a/src/plotViewer/webviewMessages.d.ts
+++ b/src/plotViewer/webviewMessages.d.ts
@@ -46,9 +46,10 @@ export interface ToggleStyleMessage extends IMessage {
   useOverwrites: boolean
 }
 
-export interface ToggleMultirowMessage extends IMessage {
-  message: 'toggleMultirow',
-  useMultirow: boolean
+export type PreviewPlotLayout = 'multirow' | 'scroll' | 'hidden';
+export interface PreviewPlotLayoutMessage extends IMessage {
+  message: 'togglePreviewPlotLayout',
+  style: PreviewPlotLayout
 }
 
 export interface HidePlotMessage extends IMessage {
@@ -61,4 +62,4 @@ export interface AddPlotMessage extends IMessage {
   html: string
 }
 
-export type InMessage = UpdatePlotMessage | FocusPlotMessage | ToggleStyleMessage | HidePlotMessage | AddPlotMessage | ToggleMultirowMessage;
+export type InMessage = UpdatePlotMessage | FocusPlotMessage | ToggleStyleMessage | HidePlotMessage | AddPlotMessage | PreviewPlotLayoutMessage;


### PR DESCRIPTION
Addresses the suggestions made by @psobolewskiPhD in https://github.com/Ikuyadeu/vscode-R/pull/620#issuecomment-846284374.

re 1.: It is now possible to set `r.plot.customStyleOverwrites` to a CSS file containing custom style overwrites. If specified, this file replaces [html/httpgd/styleOverwrites.css](https://github.com/Ikuyadeu/vscode-R/blob/master/html/httpgd/styleOverwrites.css). To check this, save e.g. the following css to a file and set `r.plot.customStyleOverwrites` to its absolute path:
``` css
.httpgd rect {
    stroke: none !important;
    fill: blue !important;
}

svg text {
    font-family: var(--vscode-editor-font-family) !important;
    color: blue !important;
}

.httpgd line, .httpgd polyline, .httpgd polygon, .httpgd path, .httpgd circle, .httpgd rect:not(:first-of-type) {
    stroke: blue !important;
}
```

re 2.: The command `r.plot.togglePreviewPlots` now cycles through mutlirow/scroll/hidden layouts. The setting `r.plot.defaults.plotPreviewLayout` can also be set accordingly.

