### PR TITLE
Catch LiveShare API errors

### DIFF
--- a/src/liveshare/shareSession.ts
+++ b/src/liveshare/shareSession.ts
@@ -18,8 +18,6 @@ export let guestResDir: string;
 // Browser Vars
 // Used to keep track of shared browsers
 export const browserDisposables: { Disposable: vscode.Disposable, url: string, name: string }[] = [];
-// for guest purposes
-export const sharedBrowsers: { url: string, name: string }[] = [];
 
 interface IRequest {
     command: string;
@@ -148,9 +146,9 @@ export function updateGuestGlobalenv(hostEnv: string): void {
 let panel: vscode.WebviewPanel = undefined;
 export async function updateGuestPlot(file: string): Promise<void> {
     const plotContent = await readContent(file, 'base64');
-    if (plotContent !== undefined) {
+    if (plotContent) {
         if (panel) {
-            panel.webview.html = getGuestImageHtml(panel.webview, plotContent);
+            panel.webview.html = getGuestImageHtml(plotContent);
             panel.reveal(vscode.ViewColumn[guestPlotView], true);
         } else {
             panel = vscode.window.createWebviewPanel('dataview', 'R Guest Plot',
@@ -165,7 +163,7 @@ export async function updateGuestPlot(file: string): Promise<void> {
                     retainContextWhenHidden: true,
                     localResourceRoots: [vscode.Uri.file(guestResDir)],
                 });
-            const content = getGuestImageHtml(panel.webview, plotContent);
+            const content = getGuestImageHtml(plotContent);
             panel.webview.html = content;
             panel.onDidDispose(
                 () => {
@@ -181,7 +179,7 @@ export async function updateGuestPlot(file: string): Promise<void> {
 
 // Purely used in order to decode a base64 string into
 // an image format, bypassing saving a file onto the guest's system
-function getGuestImageHtml(webview: vscode.Webview, content: string) {
+function getGuestImageHtml(content: string) {
     return `
 <!doctype HTML>
 <html>

--- a/src/liveshare/virtualDocs.ts
+++ b/src/liveshare/virtualDocs.ts
@@ -8,9 +8,9 @@ export const docProvider = new class implements vscode.TextDocumentContentProvid
     }
 };
 
-export async function openVirtualDoc(str: string, preserveFocus: boolean, preview: boolean, viewColumn: number): Promise<void> {
-    if (str) {
-        const uri = vscode.Uri.parse(`${docScheme}:dataview.r?${str}`);
+export async function openVirtualDoc(file: string, content: string, preserveFocus: boolean, preview: boolean, viewColumn: number): Promise<void> {
+    if (content) {
+        const uri = vscode.Uri.parse(`${docScheme}:${file}?${content}`);
         const doc = await vscode.workspace.openTextDocument(uri);
         await vscode.window.showTextDocument(doc, {
             preserveFocus: preserveFocus,

--- a/src/session.ts
+++ b/src/session.ts
@@ -340,7 +340,7 @@ export async function showDataView(source: string, type: string, title: string, 
     } else {
         if (isGuestSession) {
             const fileContent = await rGuestService.requestFileContent(file, 'utf8');
-            await openVirtualDoc(fileContent, true, true, ViewColumn[viewer]);
+            await openVirtualDoc(file, fileContent, true, true, ViewColumn[viewer]);
         } else {
             await commands.executeCommand('vscode.open', Uri.file(file), {
                 preserveFocus: true,


### PR DESCRIPTION
Primary change:
- Adds try/catch to the accessing of the vsls API, so as to hopefully avoid situations such as #671

Minor changes:
- Remove some superflous/dead code from previous iterations of the LiveShare PR
- Change the guest dataview file to have the same path as the host

Tested on Arch Linux