### PR TITLE
Small Plot Viewer adjustments

### DIFF
--- a/html/httpgd/index.js
+++ b/html/httpgd/index.js
@@ -45,7 +45,6 @@ function postLogMessage(content) {
 }
 window.addEventListener('message', (ev) => {
     const msg = ev.data;
-    console.info(msg);
     if (msg.message === 'updatePlot') {
         updatePlot({
             id: String(msg.plotId),
@@ -53,7 +52,6 @@ window.addEventListener('message', (ev) => {
         });
     }
     else if (msg.message === 'focusPlot') {
-        console.log('focussing plot');
         focusPlot(String(msg.plotId));
     }
     else if (msg.message === 'toggleStyle') {

--- a/html/httpgd/index.ts
+++ b/html/httpgd/index.ts
@@ -71,14 +71,12 @@ function postLogMessage(content: any){
 
 window.addEventListener('message', (ev: MessageEvent<InMessage>) => {
   const msg = ev.data;
-  console.info(msg);
   if(msg.message === 'updatePlot'){
     updatePlot({
       id: String(msg.plotId),
       svg: msg.svg
     });
   } else if(msg.message === 'focusPlot'){
-    console.log('focussing plot');
     focusPlot(String(msg.plotId));
   } else if(msg.message === 'toggleStyle'){
     toggleStyle(msg.useOverwrites);

--- a/html/httpgd/styleOverwrites.css
+++ b/html/httpgd/styleOverwrites.css
@@ -7,7 +7,7 @@
 
 svg text {
     font-family: var(--vscode-editor-font-family) !important;
-    stroke: var(--vscode-foreground) !important;
+    fill: var(--vscode-foreground) !important;
 }
 
 .httpgd line, .httpgd polyline, .httpgd polygon, .httpgd path, .httpgd circle, .httpgd rect:not(:first-of-type) {

--- a/package.json
+++ b/package.json
@@ -1212,8 +1212,8 @@
             "vscode",
             "original"
           ],
-          "enumDescriptions": [
-            "Match background and primary stroke color to the current color theme",
+          "markdownEnumDescriptions": [
+            "Match background and primary stroke color to the current color theme (Or apply custom CSS overwrites, if specified in `#r.plot.customStyleOverwrites#`)",
             "Use original colors"
           ],
           "markdownDescription": "Which color theme to use when launching the plot viewer."
@@ -1246,7 +1246,7 @@
         "r.plot.customStyleOverwrites": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Path to a custom CSS file to be used for `r.plot.toggleStyle`. WARNING: replaces default CSS overwrites!"
+          "markdownDescription": "Path to a custom CSS file to be used when `#r.plot.defaults.colorTheme#` is `vscode`. Replaces the default CSS overwrites!"
         }
       }
     },

--- a/src/plotViewer/httpgdTypes.d.ts
+++ b/src/plotViewer/httpgdTypes.d.ts
@@ -98,7 +98,7 @@ export class IHttpgdViewer {
     webviewPanel?: vscode.WebviewPanel;
 
     // Api that provides plot contents etc.
-    api: IHttpgdViewerApi;
+    api?: IHttpgdViewerApi;
 
     // active plots
     plots: HttpgdPlot[];

--- a/src/plotViewer/index.ts
+++ b/src/plotViewer/index.ts
@@ -560,8 +560,9 @@ export class HttpgdViewer implements IHttpgdViewer {
             void this.resizePlot();
         } else if(!this.resizeTimeout){
             this.resizeTimeout = setTimeout(() => {
-                void this.resizePlot();
-                this.resizeTimeout = undefined;
+                void this.resizePlot().then(() =>
+                    this.resizeTimeout = undefined
+                );
             }, this.resizeTimeoutLength);
         }
     }

--- a/src/plotViewer/index.ts
+++ b/src/plotViewer/index.ts
@@ -250,7 +250,7 @@ export class HttpgdViewer implements IHttpgdViewer {
     webviewPanel?: vscode.WebviewPanel;
 
     // Api that provides plot contents etc.
-    readonly api: Httpgd;
+    api?: Httpgd;
 
     // active plots
     plots: HttpgdPlot[] = [];
@@ -329,8 +329,13 @@ export class HttpgdViewer implements IHttpgdViewer {
         this.api.onPlotsChange(() => {
             this.checkStateDelayed();
         });
-        this.api.onConnectionChange(() => {
-            this.checkStateDelayed();
+        this.api.onConnectionChange((disconnected: boolean) => {
+            if(disconnected){
+                this.api?.dispose();
+                this.api = undefined;
+            } else{
+                this.checkStateDelayed();
+            }
         });
         this.customOverwriteCssPath = config().get('plot.customStyleOverwrites', '');
         const localResourceRoots = (
@@ -451,7 +456,7 @@ export class HttpgdViewer implements IHttpgdViewer {
         id ??= this.activePlot;
         if(id){
             this.hidePlot(id);
-            await this.api.closePlot(id);
+            await this.api?.closePlot(id);
         }
     }
 
@@ -531,6 +536,9 @@ export class HttpgdViewer implements IHttpgdViewer {
         }
     }
     protected async checkState(): Promise<void> {
+        if(!this.api){
+            return;
+        }
         const oldUpid = this.state?.upid;
         this.state = await this.api.getState();
         if(this.state.upid !== oldUpid){
@@ -573,12 +581,17 @@ export class HttpgdViewer implements IHttpgdViewer {
         const height = this.scaledViewHeight;
         const width = this.scaledViewWidth;
         const plt = await this.getPlotContent(id, height, width);
-        this.plotWidth = plt.width;
-        this.plotHeight = plt.height;
-        this.updatePlot(plt);
+        if(plt){
+            this.plotWidth = plt.width;
+            this.plotHeight = plt.height;
+            this.updatePlot(plt);
+        }
     }
 
     protected async refreshPlots(redraw: boolean = false, force: boolean = false): Promise<void> {
+        if(!this.api){
+            return;
+        }
         const nPlots = this.plots.length;
         const oldPlotIds = this.plots.map(plt => plt.id);
         let plotIds = await this.api.getPlotIds();
@@ -630,7 +643,10 @@ export class HttpgdViewer implements IHttpgdViewer {
         void this.setContextValues();
     }
 
-    protected async getPlotContent(id: PlotId, height?: number, width?: number): Promise<HttpgdPlot> {
+    protected async getPlotContent(id: PlotId, height?: number, width?: number): Promise<HttpgdPlot | undefined> {
+        if(!this.api){
+            return undefined;
+        }
         height ||= this.scaledViewHeight;
         width ||= this.scaledViewWidth;
         const plt = await this.api.getPlotContent(id, height, width);
@@ -778,7 +794,7 @@ export class HttpgdViewer implements IHttpgdViewer {
     // Dispose-function to clean up when vscode closes
     // E.g. to close connections etc., notify R, ...
     public dispose(): void {
-        this.api.dispose();
+        this.api?.dispose();
     }
 }
 


### PR DESCRIPTION
Addresses some issues that came up in the conversation of #678:
* Fixes the CSS used to change font colors
* Clarifies the description of two config entries

Also:
* Removes some unnecessary logging output
* Makes resizing the plot more "snappy" by not requesting an updated plot, while the previous request is still being handled