### PR TITLE
Integer syntax supports e.g. 1e2L

### DIFF
--- a/syntax/r.json
+++ b/syntax/r.json
@@ -118,7 +118,7 @@
                     "name": "constant.numeric.integer.hexadecimal.r"
                 },
                 {
-                    "match": "\\b(?:[0-9]+\\.?[0-9]*)L\\b",
+                    "match": "\\b(?:[0-9]+\\.?[0-9]*)(?:(e|E)(\\+|-)?[0-9]+)?L\\b",
                     "name": "constant.numeric.integer.decimal.r"
                 },
                 {


### PR DESCRIPTION
# What problem did you solve?

Closes #144 

## (If you do not have screenshot) How can I check this pull request?

```r
1e2L
1e+2L
2e0L
3e-0L
1.2e5L
```