### PR TITLE
Provide links to workspace files in terminal

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -146,6 +146,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
     vscode.languages.registerHoverProvider('r', new completions.HoverProvider());
     vscode.languages.registerHoverProvider('r', new completions.HelpLinkHoverProvider());
     vscode.languages.registerCompletionItemProvider('r', new completions.StaticCompletionItemProvider(), '@');
+    vscode.window.registerTerminalLinkProvider(new rTerminal.rTerminalLinkProvider);
 
     // deploy liveshare listener
     await rShare.initLiveShare(context);
@@ -206,7 +207,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
         const liveTriggerCharacters = ['', '[', '(', ',', '$', '@', '"', '\''];
         vscode.languages.registerCompletionItemProvider('r', new completions.LiveCompletionItemProvider(), ...liveTriggerCharacters);
     }
-
 
     return rExtension;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -146,7 +146,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<apiImp
     vscode.languages.registerHoverProvider('r', new completions.HoverProvider());
     vscode.languages.registerHoverProvider('r', new completions.HelpLinkHoverProvider());
     vscode.languages.registerCompletionItemProvider('r', new completions.StaticCompletionItemProvider(), '@');
-    vscode.window.registerTerminalLinkProvider(new rTerminal.rTerminalLinkProvider);
+    vscode.window.registerTerminalLinkProvider(new rTerminal.TerminalLinkProvider);
 
     // deploy liveshare listener
     await rShare.initLiveShare(context);

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -305,7 +305,7 @@ export async function sendRangeToRepl(rng: vscode.Range): Promise<void> {
     editor.selections = sel0;
 }
 
-export class rTerminalLinkProvider implements vscode.TerminalLinkProvider {
+export class TerminalLinkProvider implements vscode.TerminalLinkProvider {
     provideTerminalLinks(context: vscode.TerminalLinkContext, token: vscode.CancellationToken): vscode.ProviderResult<vscode.TerminalLink[]> {
         const matches: vscode.TerminalLink[] = [];
         const regex = /[-_a-zA-Z]+\.r(:[0-9]+)?(:[0-9]+)?/gi;

--- a/src/rTerminal.ts
+++ b/src/rTerminal.ts
@@ -331,11 +331,12 @@ export class rTerminalLinkProvider implements vscode.TerminalLinkProvider {
         return matches;
     }
     async handleTerminalLink(link: unknown): Promise<void> {
-        if (link['data']) {
-            const url = (link['data'] as string).replace(/:[0-9]+/g, '');
-            const range = (link['data'] as string).match(/(?<=:)[0-9]+/g);
+        const data: unknown = link['data'];
+        if (typeof data === 'string') {
+            const url = data.replace(/:[0-9]+/g, '');
             const loc = await vscode.workspace.findFiles(`**/${url}`, null, 1);
-            if (loc) {
+            if (loc?.length > 0) {
+                const range = (data.match(/(?<=:)[0-9]+/g))?.map(num => Number(num) - 1);
                 await vscode.commands.executeCommand(
                     'vscode.open',
                     vscode.Uri.file(loc[0].fsPath),
@@ -343,19 +344,18 @@ export class rTerminalLinkProvider implements vscode.TerminalLinkProvider {
                         preserveFocus: false,
                         preview: false,
                         selection: range ? new vscode.Selection(
-                            Number(range[0]) - 1,
-                            Number(range[1] ?? 1) - 1,
-                            Number(range[0]) - 1,
-                            Number(range[1] ?? 1) - 1
+                            range[0],
+                            range[1] ?? 1,
+                            range[0],
+                            range[1] ?? 1
                         ) : null
                     }
                 );
-
                 if (range) {
                     await vscode.commands.executeCommand(
                         'revealLine',
                         {
-                            lineNumber: Number(range[0]) - 1,
+                            lineNumber: range[0],
                             at: 'center'
                         }
                     );


### PR DESCRIPTION
# What problem did you solve?

Closes #512 

E.g., provides terminal links for the following:
- text.r
- text.r:5
- text.r:5:6

You can technically test this by typing the file name in the terminal, and alt+clicking the link.

## Screenshot

![image](https://user-images.githubusercontent.com/60372411/122151104-79226400-ce4e-11eb-9bf8-84af3906f3df.gif)

